### PR TITLE
fix(tsconfig): remove paths overrides, add rootDir to all services

### DIFF
--- a/services/competition-directory-service/tsconfig.json
+++ b/services/competition-directory-service/tsconfig.json
@@ -1,11 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist",
-    "paths": {
-      "@script-manifest/contracts": ["../../packages/contracts/src/index.ts"]
-    }
+    "rootDir": "src"
   },
   "include": ["src/**/*.ts"]
 }

--- a/services/identity-service/tsconfig.json
+++ b/services/identity-service/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist",
-    "paths": {
-      "@script-manifest/contracts": ["../../packages/contracts/src/index.ts"],
-      "@script-manifest/db": ["../../packages/db/src/index.ts"]
-    }
+    "rootDir": "src"
   },
   "include": ["src/**/*.ts"]
 }

--- a/services/notification-service/tsconfig.json
+++ b/services/notification-service/tsconfig.json
@@ -1,11 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist",
-    "paths": {
-      "@script-manifest/contracts": ["../../packages/contracts/src/index.ts"]
-    }
+    "rootDir": "src"
   },
   "include": ["src/**/*.ts"]
 }

--- a/services/profile-project-service/tsconfig.json
+++ b/services/profile-project-service/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist",
-    "paths": {
-      "@script-manifest/contracts": ["../../packages/contracts/src/index.ts"],
-      "@script-manifest/db": ["../../packages/db/src/index.ts"]
-    }
+    "rootDir": "src"
   },
   "include": ["src/**/*.ts"]
 }

--- a/services/script-storage-service/tsconfig.json
+++ b/services/script-storage-service/tsconfig.json
@@ -1,11 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist",
-    "paths": {
-      "@script-manifest/contracts": ["../../packages/contracts/src/index.ts"]
-    }
+    "rootDir": "src"
   },
   "include": ["src/**/*.ts"]
 }

--- a/services/search-indexer-service/tsconfig.json
+++ b/services/search-indexer-service/tsconfig.json
@@ -1,11 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist",
-    "paths": {
-      "@script-manifest/contracts": ["../../packages/contracts/src/index.ts"]
-    }
+    "rootDir": "src"
   },
   "include": ["src/**/*.ts"]
 }

--- a/services/submission-tracking-service/tsconfig.json
+++ b/services/submission-tracking-service/tsconfig.json
@@ -1,11 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist",
-    "paths": {
-      "@script-manifest/contracts": ["../../packages/contracts/src/index.ts"]
-    }
+    "rootDir": "src"
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

- Removes `baseUrl` + `paths` overrides from 7 service tsconfigs that pointed directly at raw `.ts` source in shared packages
- Adds `rootDir: "src"` to anchor tsc output so `dist/index.js` lands at the expected flat path

**Root cause:** The `paths` overrides told tsc to resolve `@script-manifest/contracts` to `../../packages/contracts/src/index.ts`. This pulled external `.ts` files into the compilation, and without `rootDir`, tsc computed the common ancestor as rootDir — nesting output at `dist/services/<name>/src/index.js` instead of `dist/index.js`. Docker images then crashed with `Cannot find module`.

Now that shared packages export from `dist/` (PR #153), these path overrides are unnecessary — tsc resolves via `package.json` exports to the `.d.ts` declarations.

**Services fixed:** competition-directory, identity, notification, profile-project, script-storage, search-indexer, submission-tracking

## Test plan

- [x] `pnpm build` — all 13 packages build, 7 rebuilt with correct flat `dist/index.js`
- [x] `pnpm test` — all 102 tests pass
- [x] Verified `dist/index.js` exists at flat path for all 7 fixed services