### PR TITLE
fix(signin): reorder OAuth above email form

### DIFF
--- a/apps/writer-web/app/signin/page.tsx
+++ b/apps/writer-web/app/signin/page.tsx
@@ -235,6 +235,21 @@ export default function SignInPage() {
               </button>
             </div>
 
+            <button
+              type="button"
+              className="btn btn-primary w-full justify-center"
+              onClick={() => void signInWithGoogle()}
+              disabled={oauthSubmitting}
+            >
+              {oauthSubmitting ? "Connecting..." : "Continue with Google"}
+            </button>
+
+            <div className="flex items-center gap-3">
+              <div className="h-px flex-1 bg-ink-500/15" />
+              <span className="text-xs text-ink-500">or continue with email</span>
+              <div className="h-px flex-1 bg-ink-500/15" />
+            </div>
+
             {mode === "register" ? (
               <label className="stack-tight">
                 <span>Display name</span>
@@ -270,22 +285,7 @@ export default function SignInPage() {
               />
             </label>
 
-            <button
-              type="button"
-              className="btn btn-secondary w-full justify-center"
-              onClick={() => void signInWithGoogle()}
-              disabled={oauthSubmitting}
-            >
-              {oauthSubmitting ? "Connecting..." : "Continue with Google"}
-            </button>
-
-            <div className="flex items-center gap-3">
-              <div className="h-px flex-1 bg-ink-500/15" />
-              <span className="text-xs text-ink-500">or continue with email</span>
-              <div className="h-px flex-1 bg-ink-500/15" />
-            </div>
-
-            <button type="submit" className="btn btn-primary w-full justify-center" disabled={submitting}>
+            <button type="submit" className="btn btn-secondary w-full justify-center" disabled={submitting}>
               {submitting ? "Submitting..." : modeLabel}
             </button>
           </form>


### PR DESCRIPTION
## Summary
- Move "Continue with Google" to top of sign-in form with `btn-primary` styling
- Email/password fields now appear below an "or continue with email" divider
- Email submit button demoted to `btn-secondary` since OAuth is the primary path

This was the only remaining gap in Tier 1 design polish (bw3). All 5 subtasks now complete and beads closed.

## Test plan
- [x] Visit `/signin` — Google button should be the first prominent action
- [x] Toggle between Sign in / Create account — form fields update correctly
- [x] Submit via email still works
- [x] OAuth flow still works