### PR TITLE
fix(feedback): remove content-type from bodyless POST requests

### DIFF
--- a/apps/writer-web/app/feedback/page.tsx
+++ b/apps/writer-web/app/feedback/page.tsx
@@ -170,7 +170,7 @@ export default function FeedbackPage() {
     try {
       await fetch("/api/v1/feedback/tokens/grant-signup", {
         method: "POST",
-        headers: { "content-type": "application/json", ...getAuthHeaders() }
+        headers: getAuthHeaders()
       });
       await loadBalance();
     } catch {
@@ -430,7 +430,7 @@ export default function FeedbackPage() {
     try {
       const response = await fetch(`/api/v1/feedback/listings/${encodeURIComponent(listingId)}/claim`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...getAuthHeaders() }
+        headers: getAuthHeaders()
       });
       const body = (await response.json()) as { error?: string };
       if (!response.ok) {
@@ -448,7 +448,7 @@ export default function FeedbackPage() {
     try {
       const response = await fetch(`/api/v1/feedback/listings/${encodeURIComponent(listingId)}/cancel`, {
         method: "POST",
-        headers: { "content-type": "application/json", ...getAuthHeaders() }
+        headers: getAuthHeaders()
       });
       const body = (await response.json()) as { error?: string };
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- Fixes 400 error (`FST_ERR_CTP_EMPTY_JSON_BODY`) on the feedback page when granting signup tokens, claiming listings, and cancelling listings
- Root cause: `content-type: application/json` was set on POST requests that had no body, which Fastify rejects
- Removed the unnecessary `content-type` header from three bodyless `fetch()` calls in `apps/writer-web/app/feedback/page.tsx`

## Test plan
- [x] `curl` verified: `POST /api/v1/feedback/tokens/grant-signup` returns 201 without content-type header
- [x] Typecheck passes
- [x] All 16 feedback-exchange-service tests pass