### PR TITLE
chore: add Claude Code automations

### DIFF
--- a/.claude/agents/service-reviewer.md
+++ b/.claude/agents/service-reviewer.md
@@ -1,0 +1,59 @@
+---
+name: service-reviewer
+description: Reviews Fastify service code for adherence to project patterns and conventions
+user-invocable: false
+---
+
+# Service Pattern Reviewer
+
+You review code changes in the script-manifest monorepo for adherence to established Fastify service patterns.
+
+## What to Check
+
+### Service Factory (`buildServer`)
+- Uses `buildServer(options)` factory pattern with typed options
+- Logger defaults to `{ level: process.env.LOG_LEVEL ?? "info" }`
+- Includes `genReqId` with `x-request-id` header fallback to `randomUUID()`
+- Sets `requestIdHeader: "x-request-id"`
+
+### Health Endpoints
+- Exposes `GET /health` (deep check), `GET /health/live` (always 200), `GET /health/ready` (deep check)
+- DB-backed services ping PostgreSQL in deep checks
+
+### Repository Pattern
+- DB-backed services define a repository interface
+- Production uses `PgXRepository` with `@script-manifest/db`
+- Tests use `MemoryXRepository` (in-memory implementation)
+- Repository injected via `buildServer(options)` — never import DB directly in routes
+
+### API Gateway Routes
+- Route modules follow `registerXRoutes(server: FastifyInstance, ctx: GatewayContext)` pattern
+- Use `proxyJsonRequest()` for upstream calls — never raw `fetch`/`undici` in routes
+- Auth: call `getUserIdFromAuth()` then `addAuthUserIdHeader()` for authenticated routes
+- Rate limiting applied via `@fastify/rate-limit` decorators (10/min auth, 100/min general, 5/min export)
+
+### Contracts
+- Request/response shapes defined in `packages/contracts/` as Zod schemas
+- Services import from `@script-manifest/contracts` — never define duplicate schemas locally
+- Public schemas exclude identity fields (no `ownerUserId` in client-facing types)
+
+### Testing
+- Services use `node:test` + `node:assert/strict` (NOT Jest, NOT Vitest)
+- Frontend uses Vitest + React Testing Library
+- Test files co-located as `*.test.ts`
+- Tests create server via `buildServer({ logger: false, repository: new MemoryRepo() })`
+- Use `server.inject()` for HTTP testing — never start a real server in tests
+
+### Auth Propagation
+- Gateway resolves identity and injects `x-auth-user-id` header
+- Backend services trust `x-auth-user-id` — never validate tokens themselves
+- Client-supplied `ownerUserId`/`writerId` in request bodies is forbidden — read from header
+
+## Output Format
+
+Report issues by priority:
+1. **Critical**: Pattern violations that will cause bugs or security issues
+2. **Warning**: Convention deviations that hurt maintainability
+3. **Suggestion**: Minor improvements
+
+Include file paths and line numbers. Be concise.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'BRANCH=$(git -C /Users/chris/projects/script-manifest branch --show-current 2>/dev/null); if [ \"$BRANCH\" = \"main\" ] && echo \"$TOOL_INPUT\" | grep -qE \"git (commit|push)\"; then echo \"BLOCK: Cannot commit/push on main branch. Create a feature branch first: git checkout -b codex/phase-<n>-<slug>\" >&2; exit 2; fi'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/new-service/SKILL.md
+++ b/.claude/skills/new-service/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: new-service
+description: Scaffold a new Fastify microservice following project conventions
+disable-model-invocation: true
+---
+
+# New Service Scaffolding
+
+Scaffold a new Fastify microservice in the script-manifest monorepo.
+
+## Arguments
+
+The user provides:
+- **name**: Service name (e.g., `analytics`) — becomes `{name}-service` directory
+- **port**: Port number (check existing services to avoid conflicts)
+- **storage**: `none` | `postgres` | `opensearch` | `minio`
+
+## What to Create
+
+Create `services/{name}-service/` with:
+
+### package.json
+```json
+{
+  "name": "@script-manifest/{name}-service",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "build": "tsc",
+    "test": "node --import tsx --test src/index.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@script-manifest/contracts": "workspace:*",
+    "fastify": "^5.2.0",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.8.1",
+    "tsx": "^4.19.2",
+    "typescript": "^5.9.3"
+  }
+}
+```
+
+If `storage: postgres`, add `"@script-manifest/db": "workspace:*"` to dependencies.
+
+### tsconfig.json
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src"]
+}
+```
+
+### src/index.ts
+Use `buildServer()` factory pattern with:
+- Typed options interface with `logger` and optional repository (if DB-backed)
+- `genReqId` with `x-request-id` header fallback
+- Health endpoints: `/health`, `/health/live`, `/health/ready`
+- Start server on configured port
+
+### src/index.test.ts
+- Use `node:test` and `node:assert/strict`
+- Create server with `buildServer({ logger: false })`
+- Test health endpoints
+- If DB-backed, test with `MemoryRepo`
+
+### Dockerfile
+Standard multi-stage Node.js Dockerfile matching other services.
+
+## After Scaffolding
+
+1. Add service to `pnpm-workspace.yaml` if not auto-detected
+2. Add to `compose.yml` if infrastructure is needed
+3. Add upstream URL to gateway's `GatewayContext` if it needs gateway routing
+4. Run `pnpm install` to link workspace dependencies
+5. Run `pnpm --filter @script-manifest/{name}-service test` to verify

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 .vscode/
 .idea/
 
+# Claude Code local settings (personal permissions, not shared)
+.claude/settings.local.json
+
 # Node/Python build artifacts
 node_modules/
 dist/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/context7-mcp@latest"]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+# Script Manifest
+
+Writer-first platform for profiles, scripts, competitions, submissions, peer feedback, and paid coverage.
+
+## Stack
+
+- **Monorepo**: pnpm 9.12, Turborepo 2.x, TypeScript 5.9 strict
+- **Backend**: 11 Fastify microservices behind an API gateway
+- **Frontend**: Next.js 16 (App Router), React 19.2, Tailwind CSS 3.4
+- **Storage**: PostgreSQL 16, OpenSearch 2.17, MinIO, Redpanda (Kafka)
+- **Payments**: Stripe Connect (coverage-marketplace-service)
+
+## Commands
+
+```bash
+pnpm test                                      # All tests
+pnpm typecheck                                 # All typechecks
+pnpm dev                                       # Start all services
+pnpm --filter @script-manifest/<name> test      # Single package test
+pnpm --filter @script-manifest/<name> typecheck # Single package typecheck
+```
+
+## Service Map
+
+| Service | Port | Package | Storage |
+|---------|------|---------|---------|
+| api-gateway | 4000 | @script-manifest/api-gateway | — |
+| profile-project | 4001 | @script-manifest/profile-project-service | PostgreSQL |
+| competition-directory | 4002 | @script-manifest/competition-directory-service | In-memory |
+| search-indexer | 4003 | @script-manifest/search-indexer-service | OpenSearch |
+| submission-tracking | 4004 | @script-manifest/submission-tracking-service | In-memory |
+| identity | 4005 | @script-manifest/identity-service | PostgreSQL |
+| feedback-exchange | 4006 | @script-manifest/feedback-exchange-service | PostgreSQL |
+| ranking | 4007 | @script-manifest/ranking-service | PostgreSQL |
+| coverage-marketplace | 4008 | @script-manifest/coverage-marketplace-service | PostgreSQL+Stripe |
+| notification | 4010 | @script-manifest/notification-service | In-memory |
+| script-storage | 4011 | @script-manifest/script-storage-service | MinIO |
+| writer-web | 3000 | @script-manifest/writer-web | — |
+
+## Architecture Patterns
+
+### Service Factory
+
+Every Fastify service uses `buildServer(options)` with dependency injection:
+
+```typescript
+export function buildServer(options: XServiceOptions = {}): FastifyInstance
+```
+
+Tests: `buildServer({ logger: false, repository: new MemoryRepo() })` + `server.inject()`.
+
+### Repository Pattern
+
+DB-backed services (identity, profile-project, feedback-exchange, ranking, coverage-marketplace) define a repository interface with:
+- `PgXRepository` for production (PostgreSQL via `@script-manifest/db`)
+- `MemoryXRepository` for tests (in-memory implementations within test files)
+
+### API Gateway
+
+- Route modules in `services/api-gateway/src/routes/` — one per domain
+- `GatewayContext` type passed to all route registrars
+- `registerXRoutes(server, ctx)` pattern for each route module
+- `proxyJsonRequest()` for upstream proxying with error wrapping
+- `getUserIdFromAuth()` resolves Bearer token → userId via identity service
+- `addAuthUserIdHeader()` injects `x-auth-user-id` on downstream requests
+
+### Health Endpoints
+
+All services expose: `GET /health` (deep), `GET /health/live` (liveness), `GET /health/ready` (readiness).
+
+### Auth Flow
+
+Frontend stores session in localStorage (`script_manifest_session`). Requests include `Authorization: Bearer <token>`. Gateway validates via identity service and propagates `x-auth-user-id`.
+
+### Contracts
+
+Shared Zod schemas + TypeScript types in `packages/contracts/`. All API request/response shapes defined here. Services import from `@script-manifest/contracts`.
+
+## Testing
+
+- **Services**: `node:test` + `node:assert/strict` (Node.js built-in test runner)
+- **Frontend**: Vitest + React Testing Library + jsdom
+- **Pattern**: Tests co-located as `*.test.ts` files alongside source
+
+## Git Workflow
+
+- **NEVER commit or push directly to `main`.** All changes go through feature branches + PRs.
+- Branch format: `codex/phase-<n>-<short-feature-slug>`
+- Create from latest: `git fetch origin && git checkout main && git pull --ff-only`
+- Task tracking: Beads (`bd`) as local source of truth, mirrored to GitHub Issues on `full-chaos` Project #2
+
+## Known Gotchas
+
+- **Fastify empty JSON bodies**: `content-type: application/json` with no body causes `FST_ERR_CTP_EMPTY_JSON_BODY`. Don't set content-type on bodyless POST requests.
+- **pg TIMESTAMPTZ**: PostgreSQL `pg` driver returns `TIMESTAMPTZ` as JS `Date` objects, not strings. Zod `z.string().datetime()` will fail — use `instanceof Date` check + `.toISOString()`.


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — project conventions, service map, architecture patterns, known gotchas for all Claude Code sessions
- **.mcp.json** — shared context7 MCP server so all collaborators get live documentation lookup
- **PreToolUse hook** — blocks `git commit`/`git push` on `main` branch (enforces branching rule)
- **service-reviewer agent** — custom subagent that reviews Fastify services for pattern adherence (buildServer factory, repository pattern, auth propagation, health endpoints, contracts, testing conventions)
- **/new-service skill** — scaffolds a new Fastify microservice following all project conventions
- **.gitignore** — excludes `.claude/settings.local.json` (personal permissions)

## Test plan

- [ ] Start a new Claude Code session in the repo — verify CLAUDE.md is loaded
- [ ] Attempt `git commit` while on `main` — verify hook blocks it
- [ ] Run `/new-service` — verify skill is discoverable
- [ ] Verify `.mcp.json` context7 server connects on session start