### PR TITLE
docs: inventory phase coverage and expand phase 5-7 execution plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,13 @@ Revisiting the writer ecosystem: portfolio hosting, competition tracking, rankin
 ## Current Status
 
 - Phase 0 complete: product/legal foundation and architecture decisions.
-- Phase 1 in progress on branch `codex/phase-1-writer-hub`.
+- Phases 1-4 implemented and documented.
+- Phases 5-7 are planned and open in tracking (`script-manifest-n92`, `script-manifest-n2h`, `script-manifest-nzi`).
 - Local development stack: Docker Compose with PostgreSQL, Redis, OpenSearch, MinIO, Redpanda, and Mailpit.
+
+Planning and phase documentation index:
+- `docs/README.md`
+- `docs/phase-inventory.md`
 
 ## Phase 0 Deliverables
 
@@ -18,7 +23,7 @@ See:
 ## Local Infrastructure
 
 ```bash
-docker compose -f infra/docker-compose.yml up -d
+docker compose -f compose.yml up -d
 ```
 
 OpenSearch: `http://localhost:9200`
@@ -43,8 +48,8 @@ pnpm --filter @script-manifest/api-gateway dev
 pnpm --filter @script-manifest/writer-web dev
 ```
 
-Or use compose profile:
+Or run the local compose stack:
 
 ```bash
-docker compose -f infra/docker-compose.yml up -d
+docker compose -f compose.yml up -d
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+# Documentation Index
+
+## Core Planning
+
+- Master rebuild plan: `docs/plan.md`
+- Phase inventory and status matrix: `docs/phase-inventory.md`
+
+## Phase Docs
+
+- Phase 0: `docs/phase-0/README.md`
+- Phase 1: `docs/phase-1/README.md`
+- Phase 2: `docs/phase-2/README.md`
+- Phase 3: `docs/phase-3/README.md`
+- Phase 4: `docs/phase-4/README.md`
+- Phase 5: `docs/phase-5/README.md`
+- Phase 6: `docs/phase-6/README.md`
+- Phase 7: `docs/phase-7/README.md`
+
+## Deep Design Docs
+
+- Coverage marketplace implementation plan: `docs/plans/2026-02-16-coverage-marketplace.md`
+- Coverage marketplace design: `docs/plans/2026-02-16-coverage-marketplace-design.md`
+

--- a/docs/phase-2/README.md
+++ b/docs/phase-2/README.md
@@ -1,0 +1,35 @@
+# Phase 2: Paid Coverage Marketplace
+
+Status: Implemented (feature `script-manifest-612` closed)
+
+## Goal
+
+Launch paid professional coverage with provider onboarding, service listings, escrow-like payment holds, delivery, ratings, and dispute handling.
+
+## Current Implementation
+
+- Service: `services/coverage-marketplace-service`
+- Gateway routes: `services/api-gateway/src/routes/coverage.ts`
+- Writer web surface: `apps/writer-web/app/coverage`
+- Contracts: `packages/contracts/src/index.ts` (coverage schemas)
+
+## Key Capabilities Present
+
+- Provider lifecycle: create, update, stripe onboarding link
+- Service catalog: create/list/update coverage services
+- Order lifecycle: create, claim, deliver, complete, cancel
+- Delivery and review handling
+- Dispute opening and admin resolution
+- Stripe webhook ingestion route
+
+## Primary Design References
+
+- `docs/plans/2026-02-16-coverage-marketplace.md`
+- `docs/plans/2026-02-16-coverage-marketplace-design.md`
+
+## Documentation Gaps Remaining
+
+- Provider onboarding user manual
+- Coverage order state-machine user manual
+- Admin dispute runbook
+

--- a/docs/phase-3/README.md
+++ b/docs/phase-3/README.md
@@ -1,0 +1,31 @@
+# Phase 3: Full Ranking Algorithm and Leaderboard
+
+Status: Implemented (feature `script-manifest-94s` closed)
+
+## Goal
+
+Replace lightweight ranking with a production scoring engine that supports weighted placements, decay, badges, leaderboards, appeals, and moderation flags.
+
+## Current Implementation
+
+- Service: `services/ranking-service`
+- Gateway routes: `services/api-gateway/src/routes/ranking.ts`
+- Writer web surfaces: `apps/writer-web/app/leaderboard`, `apps/writer-web/app/rankings`, `apps/writer-web/app/admin/rankings`
+
+## Key Capabilities Present
+
+- Leaderboard API with filters
+- Writer score and badges endpoints
+- Published methodology endpoint
+- Prestige weight management endpoints (admin)
+- Full recompute + incremental recompute entrypoints
+- Appeals queue and resolution endpoints
+- Flagging queue and resolution endpoints
+- Maintenance snapshot endpoint
+
+## Documentation Gaps Remaining
+
+- Scoring methodology admin operations manual
+- Appeal and flag triage runbook
+- Incremental recompute and maintenance job SOP
+

--- a/docs/phase-4/README.md
+++ b/docs/phase-4/README.md
@@ -1,0 +1,31 @@
+# Phase 4: Peer-to-Peer Feedback Exchange
+
+Status: Implemented (features `script-manifest-g0b` and `script-manifest-3s5` closed)
+
+## Goal
+
+Deliver token-based peer review exchange with listing bids, claim windows, structured feedback submission, ratings, disputes, and anti-abuse controls.
+
+## Current Implementation
+
+- Service: `services/feedback-exchange-service`
+- Gateway routes: `services/api-gateway/src/routes/feedback.ts`
+- Writer web surface: `apps/writer-web/app/feedback`
+
+## Key Capabilities Present
+
+- Token balance and transaction history
+- Signup token grants
+- Listing create/browse/view/claim/cancel
+- Review retrieval and structured review submit
+- Reviewer rating and rating retrieval
+- Reputation endpoint
+- Dispute open/list/detail/resolve
+- Maintenance endpoints (listing expiry, review expiry, strike decay)
+
+## Documentation Gaps Remaining
+
+- Token economy rules manual
+- Listing/review lifecycle and SLA guide
+- Dispute and strike operations runbook
+

--- a/docs/phase-5/README.md
+++ b/docs/phase-5/README.md
@@ -1,0 +1,117 @@
+# Phase 5: Industry Portal and Discovery Dashboard
+
+Status: Planned (feature `script-manifest-n92` open)
+External ref: `gh-107`
+
+## Objective
+
+Build the B2B industry portal that lets vetted industry users discover writers/projects, download scripts with auditability, collaborate in shared workspaces, and run mandate/OWA pipelines.
+
+## Scope
+
+In scope:
+- Industry account registration and manual credential vetting
+- Writer discovery search with rich filters
+- Script download with writer-controlled permissions and download notifications
+- Industry team lists and shared notes
+- Writer and industry analytics
+- Mandate and OWA board with editorial review/forwarding workflow
+- Weekly recommendation digest (manual first, algorithm-assisted later)
+
+Out of scope for this phase:
+- Fully autonomous recommendation engine
+- Fully automated vetting (manual verification remains required)
+
+## Beads Breakdown
+
+- `script-manifest-n92.1`: Industry account verification and access control
+- `script-manifest-n92.2`: Discovery search and team collaboration workspace
+- `script-manifest-n92.3`: Mandate workflows and recommendation operations
+
+## Architecture and Technology Choices
+
+### Deployables
+
+| Deployable | Location | Responsibility |
+| --- | --- | --- |
+| Industry web app (new) | `apps/industry-web` | Industry-facing UI for search, lists, notes, mandates |
+| Writer app integration (existing) | `apps/writer-web` | Writer controls for access grants and analytics visibility |
+| Industry portal service (new) | `services/industry-portal-service` | Vetting, search, lists, notes, mandates, analytics read model |
+| API gateway routes (new) | `services/api-gateway/src/routes/industry.ts` | Auth + proxy layer for industry APIs |
+| Search indexer extension (existing) | `services/search-indexer-service` | Talent index writes/updates for filterable discovery |
+| Notification service extension (existing) | `services/notification-service` | Download alerts and digest delivery |
+| Contracts extension | `packages/contracts/src/index.ts` | Industry schemas, payloads, filters |
+| DB migrations | `packages/db/src/migrations` | Industry accounts, entitlements, lists/notes, mandates, analytics snapshots |
+
+### Core Infrastructure Choices
+
+- PostgreSQL remains system of record for industry accounts, permissions, mandates, and collaboration artifacts.
+- OpenSearch remains the search engine for talent discovery and filter-heavy ranking queries.
+- Event-driven audit events continue over existing platform event flows for downloads and access decisions.
+- Notification pipeline remains centralized in notification-service for writer alerts and digest delivery.
+
+## Planned Data Model Additions
+
+- `industry_accounts`
+- `industry_vetting_reviews`
+- `industry_entitlements`
+- `industry_download_audit`
+- `industry_lists`
+- `industry_list_items`
+- `industry_notes`
+- `industry_teams`
+- `industry_team_members`
+- `mandates`
+- `mandate_submissions`
+- `owa_submissions`
+- `industry_digest_runs`
+
+## Planned API Surface
+
+Gateway namespace:
+- `POST /api/v1/industry/accounts`
+- `POST /api/v1/industry/accounts/:accountId/verify`
+- `GET /api/v1/industry/talent-search`
+- `POST /api/v1/industry/scripts/:scriptId/download`
+- `GET /api/v1/industry/lists`
+- `POST /api/v1/industry/lists`
+- `POST /api/v1/industry/lists/:listId/items`
+- `POST /api/v1/industry/lists/:listId/notes`
+- `GET /api/v1/industry/mandates`
+- `POST /api/v1/industry/mandates`
+- `POST /api/v1/industry/mandates/:mandateId/submissions`
+- `GET /api/v1/industry/analytics`
+
+## Job and Event Plan
+
+- Digest builder job (weekly)
+- Download audit aggregation job (hourly)
+- Mandate expiry and reminder job (daily)
+- Entitlement integrity checker (daily)
+- Events:
+  - `industry_script_downloaded`
+  - `industry_account_verified`
+  - `mandate_submission_forwarded`
+
+## Milestones
+
+1. Access and vetting foundation (`script-manifest-n92.1`)
+2. Search + collaboration workspace (`script-manifest-n92.2`)
+3. Mandates + recommendation ops (`script-manifest-n92.3`)
+4. Hardening, analytics validation, and user docs
+
+## Exit Criteria
+
+- Industry users can be manually vetted and segmented by account tier.
+- Search supports role-critical filters with acceptable latency.
+- Every script download is permission-checked and writer-notified.
+- Mandate/OWA flows support submission, editorial review, and forwarding.
+- Core operations have runbooks and user-facing documentation.
+
+## Documentation Deliverables for Completion
+
+- Industry onboarding and vetting manual
+- Writer access-control manual (industry visibility)
+- Mandate and OWA operations runbook
+- Weekly digest curation SOP
+

--- a/docs/phase-6/README.md
+++ b/docs/phase-6/README.md
@@ -1,0 +1,117 @@
+# Phase 6: Programs and Events Platform
+
+Status: Planned (feature `script-manifest-n2h` open)
+External ref: `gh-117`
+
+## Objective
+
+Launch operational programs (fee waivers, Career Lab, mentorship, live reads, Pitch Week, expanded mandates) as repeatable platform workflows, not one-off manual processes.
+
+## Scope
+
+In scope:
+- Program catalog and applications workflow
+- Review and selection workflows for cohorts
+- Event scheduling and attendance tracking
+- Live session integration (Zoom or equivalent)
+- Mentorship matching and progress tracking
+- Program KPI dashboards and outcome tracking
+- CRM synchronization hooks for editorial and industry follow-up
+
+Out of scope for this phase:
+- Fully automated mentor matching decisions without human override
+- Replacing CRM; only synchronization and workflow integration
+
+## Beads Breakdown
+
+- `script-manifest-n2h.1`: Applications and cohort operations
+- `script-manifest-n2h.2`: Scheduling and live session infrastructure
+- `script-manifest-n2h.3`: Program analytics and outcome tracking
+
+## Architecture and Technology Choices
+
+### Deployables
+
+| Deployable | Location | Responsibility |
+| --- | --- | --- |
+| Programs admin web app (new) | `apps/programs-admin-web` | Internal operations for applications, cohorts, reviews, scheduling |
+| Writer app extension (existing) | `apps/writer-web` | Program discovery, application submission, status tracking |
+| Programs service (new) | `services/programs-service` | Program definitions, applications, cohorts, outcomes |
+| Scheduling service (new) | `services/scheduling-service` | Availability windows, slotting, calendar and conferencing orchestration |
+| API gateway routes (new) | `services/api-gateway/src/routes/programs.ts` | Auth + proxy for program workflows |
+| Notification service extension (existing) | `services/notification-service` | Application status, event reminders, follow-up messages |
+| Contracts extension | `packages/contracts/src/index.ts` | Program/application/session schemas |
+| DB migrations | `packages/db/src/migrations` | Program entities, applications, cohorts, attendance, outcomes |
+
+### Core Infrastructure Choices
+
+- PostgreSQL as source of truth for programs, applications, and outcomes.
+- Background jobs for reminders, cohort transitions, and follow-ups.
+- External calendar/video integration through scheduling-service abstraction.
+- Analytics snapshots stored in Postgres read models; OpenSearch optional for discoverability-only indexing.
+
+## Planned Data Model Additions
+
+- `programs`
+- `program_tracks`
+- `program_applications`
+- `program_application_reviews`
+- `program_cohorts`
+- `program_cohort_members`
+- `mentor_profiles`
+- `mentor_assignments`
+- `events`
+- `event_registrations`
+- `session_attendance`
+- `program_outcomes`
+- `crm_sync_queue`
+
+## Planned API Surface
+
+Gateway namespace:
+- `GET /api/v1/programs`
+- `POST /api/v1/programs/:programId/applications`
+- `GET /api/v1/programs/:programId/applications/me`
+- `POST /api/v1/admin/programs/:programId/reviews`
+- `POST /api/v1/admin/programs/:programId/cohorts`
+- `POST /api/v1/admin/programs/:programId/sessions`
+- `POST /api/v1/admin/programs/:programId/sessions/:sessionId/attendance`
+- `POST /api/v1/admin/programs/:programId/mentorship/matches`
+- `GET /api/v1/admin/programs/:programId/analytics`
+
+## Job and Event Plan
+
+- Application SLA reminder job (daily)
+- Session reminder job (hourly)
+- Cohort transition job (daily)
+- Outcome and KPI aggregation job (daily)
+- CRM sync dispatcher (continuous/batched)
+- Events:
+  - `program_application_submitted`
+  - `program_application_decided`
+  - `program_session_scheduled`
+  - `program_session_attended`
+
+## Milestones
+
+1. Application and cohort operations (`script-manifest-n2h.1`)
+2. Scheduling/live session infrastructure (`script-manifest-n2h.2`)
+3. Program analytics and outcomes (`script-manifest-n2h.3`)
+4. Runbook hardening and launch checklists by program type
+
+## Exit Criteria
+
+- Application intake and review are auditable and repeatable.
+- Events can be scheduled with reminder delivery and attendance capture.
+- Mentorship pairing and lifecycle tracking are operational.
+- KPI views support leadership and partner reporting.
+- Program operations have complete internal runbooks.
+
+## Documentation Deliverables for Completion
+
+- Program operations handbook
+- Application reviewer rubric and triage guide
+- Session scheduling and live-event runbook
+- Mentorship operations guide
+- Outcome tracking and KPI definitions
+

--- a/docs/phase-7/README.md
+++ b/docs/phase-7/README.md
@@ -1,0 +1,121 @@
+# Phase 7: Partner Dashboard for Competition Organizers
+
+Status: Planned (feature `script-manifest-nzi` open)
+External ref: `gh-127`
+
+## Objective
+
+Provide a competition organizer backend for submission intake, judge workflows, normalized scoring, and result publication directly into writer profiles and rankings.
+
+## Scope
+
+In scope:
+- Organizer accounts and competition-level RBAC
+- Submission intake and management
+- Judge assignment and workload balancing
+- Evaluation forms and score normalization
+- Results publication and sync to writer profile/ranking systems
+- Entrant communications and organizer analytics
+- FilmFreeway bridge for submission synchronization
+- Draft swap workflow (including optional fee handling)
+
+Out of scope for this phase:
+- Full replacement of all third-party festival tooling on day one
+- Fully self-serve partner API monetization (deferred to post-launch hardening)
+
+## Beads Breakdown
+
+- `script-manifest-nzi.1`: Organizer workspace and submission operations
+- `script-manifest-nzi.2`: Judging workflow and scoring normalization
+- `script-manifest-nzi.3`: Results publishing, integrations, and organizer analytics
+
+## Architecture and Technology Choices
+
+### Deployables
+
+| Deployable | Location | Responsibility |
+| --- | --- | --- |
+| Partner dashboard web app (new) | `apps/partner-dashboard-web` | Organizer and judge interfaces |
+| Partner service (new) | `services/partner-dashboard-service` | Competition setup, submissions, judge workflows |
+| Scoring service extension (existing) | `services/ranking-service` | Score normalization and prestige alignment hooks |
+| Submission service extension (existing) | `services/submission-tracking-service` | Bidirectional sync for entrant records and placements |
+| API gateway routes (new) | `services/api-gateway/src/routes/partners.ts` | Auth + proxy for partner endpoints |
+| FilmFreeway sync worker (new) | `services/filmfreeway-sync-service` | Import/export bridge, retries, reconciliation |
+| Notification service extension (existing) | `services/notification-service` | Entrant and organizer communications |
+| Contracts extension | `packages/contracts/src/index.ts` | Organizer, judge, scoring, and publication schemas |
+| DB migrations | `packages/db/src/migrations` | Competitions, submissions, judges, evaluations, publication artifacts |
+
+### Core Infrastructure Choices
+
+- PostgreSQL remains authoritative for organizer configuration and scoring artifacts.
+- OpenSearch optional only for organizer reporting filters; not required for core correctness.
+- Event-driven publication: result events feed profile and ranking recalculation pipelines.
+- Integration reliability via dedicated sync worker with idempotent import keys.
+
+## Planned Data Model Additions
+
+- `organizer_accounts`
+- `organizer_memberships`
+- `partner_competitions`
+- `partner_submission_windows`
+- `partner_submissions`
+- `partner_submission_assets`
+- `judge_profiles`
+- `judge_assignments`
+- `evaluation_forms`
+- `evaluation_scores`
+- `score_normalization_runs`
+- `published_results`
+- `entrant_messages`
+- `filmfreeway_sync_jobs`
+- `draft_swap_requests`
+
+## Planned API Surface
+
+Gateway namespace:
+- `POST /api/v1/partners/competitions`
+- `GET /api/v1/partners/competitions/:competitionId/submissions`
+- `POST /api/v1/partners/competitions/:competitionId/judges/assign`
+- `POST /api/v1/partners/competitions/:competitionId/evaluations`
+- `POST /api/v1/partners/competitions/:competitionId/normalize`
+- `POST /api/v1/partners/competitions/:competitionId/publish-results`
+- `POST /api/v1/partners/competitions/:competitionId/draft-swaps`
+- `GET /api/v1/partners/competitions/:competitionId/analytics`
+- `POST /api/v1/partners/integrations/filmfreeway/sync`
+
+## Job and Event Plan
+
+- Judge assignment balancing job (hourly/demand-based)
+- Normalization recompute job (nightly and pre-publication)
+- Results publication sync job (event-driven)
+- FilmFreeway reconciliation job (scheduled)
+- Entrant reminder job (daily during active windows)
+- Events:
+  - `partner_submission_received`
+  - `partner_score_normalized`
+  - `partner_results_published`
+  - `partner_draft_swap_processed`
+
+## Milestones
+
+1. Organizer workspace and submission ops (`script-manifest-nzi.1`)
+2. Judge workflow and normalization (`script-manifest-nzi.2`)
+3. Publication + integration + analytics (`script-manifest-nzi.3`)
+4. Operational readiness and partner onboarding playbook
+
+## Exit Criteria
+
+- Organizers can run a full submission cycle end-to-end.
+- Judge assignment and evaluation processing are auditable and fair.
+- Published results sync into writer profiles and ranking calculations.
+- FilmFreeway bridge supports import reconciliation without duplication.
+- Partner operations have clear support and incident runbooks.
+
+## Documentation Deliverables for Completion
+
+- Organizer onboarding and RBAC guide
+- Judge assignment and scoring operations manual
+- Result publication and rollback runbook
+- FilmFreeway integration and reconciliation guide
+- Draft swap and fee handling policy
+

--- a/docs/phase-inventory.md
+++ b/docs/phase-inventory.md
@@ -1,0 +1,47 @@
+# Phase Documentation Inventory
+
+Last updated: 2026-02-20
+Source of truth for scope: `docs/plan.md`
+
+## Feature Set to Phase Mapping
+
+| Original Feature Set | Primary Phase(s) | Notes |
+| --- | --- | --- |
+| 1. Writer profile and portfolio | 1 | Foundation for all downstream phases |
+| 2. Competition and submission hub | 1 | Expanded again in 7 for organizer backend |
+| 3. Ranking and discovery system | 3 | Consumes data from phases 1, 2, 4, 7 |
+| 4. Paid coverage marketplace | 2 | Revenue and scoring input |
+| 5. Peer-to-peer feedback exchange | 4 | Token economy and community loop |
+| 6. Industry dashboard | 5 | B2B discovery and writer outcomes |
+| 7. Writer development programs | 6 | Operationally heavy programs layer |
+| 8. Partner dashboard for competitions | 7 | Optional moat phase; organizer backend |
+| 9. Community and content | 1, 6 | Initial content in 1, program/event amplification in 6 |
+
+## Documentation Coverage by Phase
+
+| Phase | Status | Primary Docs |
+| --- | --- | --- |
+| 0 | Documented and complete | `docs/phase-0/README.md` + policy docs |
+| 1 | Documented and implemented | `docs/phase-1/README.md` + user manuals |
+| 2 | Backfilled summary and implementation references | `docs/phase-2/README.md`, `docs/plans/2026-02-16-coverage-marketplace-design.md` |
+| 3 | Backfilled summary and implementation references | `docs/phase-3/README.md` |
+| 4 | Backfilled summary and implementation references | `docs/phase-4/README.md` |
+| 5 | Planning expanded and implementation-ready | `docs/phase-5/README.md` |
+| 6 | Planning expanded and implementation-ready | `docs/phase-6/README.md` |
+| 7 | Planning expanded and implementation-ready | `docs/phase-7/README.md` |
+
+## Open Planning Features
+
+| Beads Feature | Title | Status |
+| --- | --- | --- |
+| `script-manifest-n92` | Phase 5: Industry portal and discovery dashboard | Open |
+| `script-manifest-n2h` | Phase 6: Programs and events platform | Open |
+| `script-manifest-nzi` | Phase 7: Partner dashboard for competition organizers | Open |
+
+## Remaining Documentation Gaps
+
+- Phase 2 user manuals (provider onboarding, order lifecycle, disputes)
+- Phase 3 user manuals (rank methodology admin, appeals, fraud flags)
+- Phase 4 user manuals (token economy, listing/review disputes, strike handling)
+- API reference consolidation for phases 2-4 (currently split between code and gateway routes)
+

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -93,6 +93,17 @@ Coverfly shut down on August 1, 2025, following a chain of corporate acquisition
 
 ## Phased Rebuild Plan
 
+Execution docs index:
+- `docs/phase-inventory.md`
+- `docs/phase-0/README.md`
+- `docs/phase-1/README.md`
+- `docs/phase-2/README.md`
+- `docs/phase-3/README.md`
+- `docs/phase-4/README.md`
+- `docs/phase-5/README.md`
+- `docs/phase-6/README.md`
+- `docs/phase-7/README.md`
+
 ### Phase 0: Product & Legal Foundation (Weeks 1–3)
 
 **Goal**: Get the non-code decisions right before writing a line of code.
@@ -230,6 +241,8 @@ Coverfly shut down on August 1, 2025, following a chain of corporate acquisition
 
 ### Phase 5: Industry Portal & Discovery Dashboard (Weeks 37–46)
 
+Detailed implementation plan: `docs/phase-5/README.md`
+
 **Goal**: Build the B2B side that makes the platform career-changing for writers and valuable for agents, managers, and producers.
 
 **Core Features**:
@@ -262,6 +275,8 @@ Coverfly shut down on August 1, 2025, following a chain of corporate acquisition
 
 ### Phase 6: Programs & Events (Weeks 47–60+)
 
+Detailed implementation plan: `docs/phase-6/README.md`
+
 **Goal**: Launch the high-touch programs that differentiate from a database. Each program is a separate rollout.
 
 **Program Rollouts** (roughly in order of operational complexity):
@@ -290,6 +305,8 @@ Coverfly shut down on August 1, 2025, following a chain of corporate acquisition
 ---
 
 ### Phase 7: Partner Dashboard for Competition Organizers (Optional / Weeks 60+)
+
+Detailed implementation plan: `docs/phase-7/README.md`
 
 **Goal**: Become the backend platform that competitions run on, not just a directory that lists them.
 


### PR DESCRIPTION
## Summary
- add docs inventory and phase coverage matrix (`docs/phase-inventory.md`)
- add docs index and backfilled phase READMEs for phases 2-4
- add detailed implementation planning docs for open phases 5, 6, and 7
- link master phase plan (`docs/plan.md`) to per-phase execution docs
- refresh root README status + doc index links
- update open Beads phase features/tasks with planning baselines and acceptance criteria

## Notes
- no runtime code changes; documentation and planning updates only

## Tracking
- Phase 5: `script-manifest-n92`
- Phase 6: `script-manifest-n2h`
- Phase 7: `script-manifest-nzi`
