### PR TITLE
Phase 5: add discovery, collaboration lists, and mandate API slice

### DIFF
--- a/docs/phase-5/README.md
+++ b/docs/phase-5/README.md
@@ -100,7 +100,7 @@ Gateway namespace:
 3. Mandates + recommendation ops (`script-manifest-n92.3`)
 4. Hardening, analytics validation, and user docs
 
-## Current Implementation (n92.1 Foundation)
+## Current Implementation (n92.1 + n92.2/n92.3 Slice)
 
 Implemented in `codex/phase-5-industry-portal-foundation`:
 
@@ -129,6 +129,28 @@ Initial gateway endpoints:
 - `PUT /api/v1/industry/entitlements/:writerUserId`
 - `GET /api/v1/industry/entitlements/:writerUserId/check`
 
+Additional internal endpoints delivered on `codex/phase-5-discovery-mandates`:
+
+- `GET /internal/talent-search`
+- `GET /internal/lists`
+- `POST /internal/lists`
+- `POST /internal/lists/:listId/items`
+- `POST /internal/lists/:listId/notes`
+- `GET /internal/mandates`
+- `POST /internal/mandates`
+- `POST /internal/mandates/:mandateId/submissions`
+
+Additional gateway endpoints delivered on `codex/phase-5-discovery-mandates`:
+
+- `GET /api/v1/industry/talent-search`
+- `GET /api/v1/industry/lists`
+- `POST /api/v1/industry/lists`
+- `POST /api/v1/industry/lists/:listId/items`
+- `POST /api/v1/industry/lists/:listId/notes`
+- `GET /api/v1/industry/mandates`
+- `POST /api/v1/industry/mandates`
+- `POST /api/v1/industry/mandates/:mandateId/submissions`
+
 ## Exit Criteria
 
 - Industry users can be manually vetted and segmented by account tier.
@@ -147,3 +169,4 @@ Initial gateway endpoints:
 Current draft:
 
 - `docs/phase-5/industry-vetting-and-access-user-manual.md`
+- `docs/phase-5/discovery-collaboration-mandates-user-manual.md`

--- a/docs/phase-5/discovery-collaboration-mandates-user-manual.md
+++ b/docs/phase-5/discovery-collaboration-mandates-user-manual.md
@@ -1,0 +1,118 @@
+# Discovery, Collaboration, and Mandates User Manual
+
+This manual covers the Phase 5 discovery and collaboration APIs:
+
+- talent search
+- industry lists
+- list notes
+- mandate browsing/creation
+- mandate submissions
+
+## Prerequisites
+
+- Industry user has an approved account (`verificationStatus=verified`) for discovery/list operations.
+- Admin reviewer is allowlisted for mandate creation.
+- Writer user owns the project they submit to a mandate.
+
+## Endpoints
+
+Industry discovery and workspace:
+
+- `GET /api/v1/industry/talent-search`
+- `GET /api/v1/industry/lists`
+- `POST /api/v1/industry/lists`
+- `POST /api/v1/industry/lists/:listId/items`
+- `POST /api/v1/industry/lists/:listId/notes`
+
+Mandates:
+
+- `GET /api/v1/industry/mandates`
+- `POST /api/v1/industry/mandates`
+- `POST /api/v1/industry/mandates/:mandateId/submissions`
+
+## Talent Search
+
+Filters:
+
+- `q` (free-text)
+- `genre`
+- `format`
+- `representationStatus` (`represented|unrepresented|seeking_rep`)
+- `limit` / `offset`
+
+Example:
+
+```bash
+curl "http://localhost:4000/api/v1/industry/talent-search?genre=Drama&format=feature&limit=20" \
+  -H "authorization: Bearer <session-token>"
+```
+
+## Lists and Notes
+
+Create a list:
+
+```bash
+curl -X POST "http://localhost:4000/api/v1/industry/lists" \
+  -H "authorization: Bearer <session-token>" \
+  -H "content-type: application/json" \
+  -d '{
+    "name": "Drama Prospects",
+    "description": "First pass",
+    "isShared": true
+  }'
+```
+
+Add list item:
+
+```bash
+curl -X POST "http://localhost:4000/api/v1/industry/lists/<list-id>/items" \
+  -H "authorization: Bearer <session-token>" \
+  -H "content-type: application/json" \
+  -d '{
+    "writerUserId": "writer_01",
+    "projectId": "project_01"
+  }'
+```
+
+Add note:
+
+```bash
+curl -X POST "http://localhost:4000/api/v1/industry/lists/<list-id>/notes" \
+  -H "authorization: Bearer <session-token>" \
+  -H "content-type: application/json" \
+  -d '{
+    "writerUserId": "writer_01",
+    "body": "Strong voice and clear stakes."
+  }'
+```
+
+## Mandates
+
+Create mandate (admin only):
+
+```bash
+curl -X POST "http://localhost:4000/api/v1/industry/mandates" \
+  -H "x-admin-user-id: admin_01" \
+  -H "content-type: application/json" \
+  -d '{
+    "type": "mandate",
+    "title": "Contained thrillers wanted",
+    "description": "Producer request",
+    "format": "feature",
+    "genre": "Thriller",
+    "opensAt": "2026-02-23T00:00:00.000Z",
+    "closesAt": "2026-03-23T00:00:00.000Z"
+  }'
+```
+
+Submit writer project to mandate:
+
+```bash
+curl -X POST "http://localhost:4000/api/v1/industry/mandates/<mandate-id>/submissions" \
+  -H "authorization: Bearer <writer-session-token>" \
+  -H "content-type: application/json" \
+  -d '{
+    "projectId": "project_01",
+    "fitExplanation": "Matches budget and tone."
+  }'
+```

--- a/docs/phase-6/README.md
+++ b/docs/phase-6/README.md
@@ -1,6 +1,6 @@
 # Phase 6: Programs and Events Platform
 
-Status: Planned (feature `script-manifest-n2h` open)
+Status: In Progress (feature `script-manifest-n2h`)
 External ref: `gh-117`
 
 ## Objective
@@ -99,6 +99,13 @@ Gateway namespace:
 3. Program analytics and outcomes (`script-manifest-n2h.3`)
 4. Runbook hardening and launch checklists by program type
 
+## Kickoff Slice (Current)
+
+- Lock contracts for program catalog + application submission.
+- Stand up `services/programs-service` with health and application intake primitives.
+- Add gateway proxy routes for writer-facing program discovery/applications.
+- Publish initial operations manual skeleton for reviewer and cohort workflow.
+
 ## Exit Criteria
 
 - Application intake and review are auditable and repeatable.
@@ -114,4 +121,3 @@ Gateway namespace:
 - Session scheduling and live-event runbook
 - Mentorship operations guide
 - Outcome tracking and KPI definitions
-

--- a/docs/phase-7/README.md
+++ b/docs/phase-7/README.md
@@ -1,6 +1,6 @@
 # Phase 7: Partner Dashboard for Competition Organizers
 
-Status: Planned (feature `script-manifest-nzi` open)
+Status: In Progress (feature `script-manifest-nzi`)
 External ref: `gh-127`
 
 ## Objective
@@ -103,6 +103,13 @@ Gateway namespace:
 3. Publication + integration + analytics (`script-manifest-nzi.3`)
 4. Operational readiness and partner onboarding playbook
 
+## Kickoff Slice (Current)
+
+- Lock contracts for organizer account + competition configuration payloads.
+- Stand up `services/partner-dashboard-service` health + organizer workspace primitives.
+- Add initial gateway proxy routes for organizer competition CRUD.
+- Define publication event contracts for ranking/profile sync integration tests.
+
 ## Exit Criteria
 
 - Organizers can run a full submission cycle end-to-end.
@@ -118,4 +125,3 @@ Gateway namespace:
 - Result publication and rollback runbook
 - FilmFreeway integration and reconciliation guide
 - Draft swap and fee handling policy
-

--- a/docs/phase-inventory.md
+++ b/docs/phase-inventory.md
@@ -1,6 +1,6 @@
 # Phase Documentation Inventory
 
-Last updated: 2026-02-20
+Last updated: 2026-02-23
 Source of truth for scope: `docs/plan.md`
 
 ## Feature Set to Phase Mapping
@@ -26,17 +26,17 @@ Source of truth for scope: `docs/plan.md`
 | 2 | Backfilled summary and implementation references | `docs/phase-2/README.md`, `docs/plans/2026-02-16-coverage-marketplace-design.md` |
 | 3 | Backfilled summary and implementation references | `docs/phase-3/README.md` |
 | 4 | Backfilled summary and implementation references | `docs/phase-4/README.md` |
-| 5 | Planning expanded and implementation-ready | `docs/phase-5/README.md` |
-| 6 | Planning expanded and implementation-ready | `docs/phase-6/README.md` |
-| 7 | Planning expanded and implementation-ready | `docs/phase-7/README.md` |
+| 5 | In progress (foundation + discovery/mandates slice) | `docs/phase-5/README.md`, `docs/phase-5/industry-vetting-and-access-user-manual.md`, `docs/phase-5/discovery-collaboration-mandates-user-manual.md` |
+| 6 | In progress kickoff planning | `docs/phase-6/README.md` |
+| 7 | In progress kickoff planning | `docs/phase-7/README.md` |
 
 ## Open Planning Features
 
 | Beads Feature | Title | Status |
 | --- | --- | --- |
-| `script-manifest-n92` | Phase 5: Industry portal and discovery dashboard | Open |
-| `script-manifest-n2h` | Phase 6: Programs and events platform | Open |
-| `script-manifest-nzi` | Phase 7: Partner dashboard for competition organizers | Open |
+| `script-manifest-n92` | Phase 5: Industry portal and discovery dashboard | In Progress |
+| `script-manifest-n2h` | Phase 6: Programs and events platform | In Progress |
+| `script-manifest-nzi` | Phase 7: Partner dashboard for competition organizers | In Progress |
 
 ## Remaining Documentation Gaps
 
@@ -44,4 +44,3 @@ Source of truth for scope: `docs/plan.md`
 - Phase 3 user manuals (rank methodology admin, appeals, fraud flags)
 - Phase 4 user manuals (token economy, listing/review disputes, strike handling)
 - API reference consolidation for phases 2-4 (currently split between code and gateway routes)
-

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -516,6 +516,183 @@ export type IndustryEntitlementCheckResponse = z.infer<
   typeof IndustryEntitlementCheckResponseSchema
 >;
 
+export const IndustryTalentSearchFiltersSchema = z.object({
+  q: z.string().trim().max(200).optional(),
+  genre: z.string().trim().min(1).max(120).optional(),
+  format: z.string().trim().min(1).max(120).optional(),
+  representationStatus: z
+    .enum(["represented", "unrepresented", "seeking_rep"])
+    .optional(),
+  limit: z.number().int().positive().max(100).default(20).optional(),
+  offset: z.number().int().nonnegative().default(0).optional()
+});
+
+export type IndustryTalentSearchFilters = z.infer<typeof IndustryTalentSearchFiltersSchema>;
+
+export const IndustryTalentSearchResultSchema = z.object({
+  writerId: z.string().min(1),
+  displayName: z.string().min(1),
+  representationStatus: z.enum(["represented", "unrepresented", "seeking_rep"]),
+  genres: z.array(z.string()).default([]),
+  demographics: z.array(z.string()).default([]),
+  projectId: z.string().min(1),
+  projectTitle: z.string().min(1),
+  projectFormat: z.string().min(1),
+  projectGenre: z.string().min(1),
+  logline: z.string().default(""),
+  synopsis: z.string().default("")
+});
+
+export type IndustryTalentSearchResult = z.infer<typeof IndustryTalentSearchResultSchema>;
+
+export const IndustryTalentSearchResponseSchema = z.object({
+  results: z.array(IndustryTalentSearchResultSchema),
+  total: z.number().int().nonnegative(),
+  limit: z.number().int().positive(),
+  offset: z.number().int().nonnegative()
+});
+
+export type IndustryTalentSearchResponse = z.infer<typeof IndustryTalentSearchResponseSchema>;
+
+export const IndustryListSchema = z.object({
+  id: z.string().min(1),
+  industryAccountId: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().default(""),
+  createdByUserId: z.string().min(1),
+  isShared: z.boolean(),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true })
+});
+
+export type IndustryList = z.infer<typeof IndustryListSchema>;
+
+export const IndustryListCreateRequestSchema = z.object({
+  name: z.string().min(1).max(180),
+  description: z.string().max(2000).default(""),
+  isShared: z.boolean().default(false)
+});
+
+export type IndustryListCreateRequest = z.infer<typeof IndustryListCreateRequestSchema>;
+
+export const IndustryListItemSchema = z.object({
+  id: z.string().min(1),
+  listId: z.string().min(1),
+  writerUserId: z.string().min(1),
+  projectId: z.string().nullable(),
+  addedByUserId: z.string().min(1),
+  createdAt: z.string().datetime({ offset: true })
+});
+
+export type IndustryListItem = z.infer<typeof IndustryListItemSchema>;
+
+export const IndustryListItemCreateRequestSchema = z.object({
+  writerUserId: z.string().min(1),
+  projectId: z.string().min(1).optional()
+});
+
+export type IndustryListItemCreateRequest = z.infer<typeof IndustryListItemCreateRequestSchema>;
+
+export const IndustryNoteSchema = z.object({
+  id: z.string().min(1),
+  listId: z.string().min(1),
+  writerUserId: z.string().nullable(),
+  projectId: z.string().nullable(),
+  body: z.string().min(1),
+  createdByUserId: z.string().min(1),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true })
+});
+
+export type IndustryNote = z.infer<typeof IndustryNoteSchema>;
+
+export const IndustryNoteCreateRequestSchema = z.object({
+  writerUserId: z.string().min(1).optional(),
+  projectId: z.string().min(1).optional(),
+  body: z.string().min(1).max(5000)
+});
+
+export type IndustryNoteCreateRequest = z.infer<typeof IndustryNoteCreateRequestSchema>;
+
+export const IndustryMandateStatusSchema = z.enum(["open", "closed", "expired"]);
+
+export type IndustryMandateStatus = z.infer<typeof IndustryMandateStatusSchema>;
+
+export const IndustryMandateTypeSchema = z.enum(["mandate", "owa"]);
+
+export type IndustryMandateType = z.infer<typeof IndustryMandateTypeSchema>;
+
+export const IndustryMandateSchema = z.object({
+  id: z.string().min(1),
+  type: IndustryMandateTypeSchema,
+  title: z.string().min(1),
+  description: z.string().default(""),
+  format: z.string().min(1),
+  genre: z.string().min(1),
+  status: IndustryMandateStatusSchema,
+  opensAt: z.string().datetime({ offset: true }),
+  closesAt: z.string().datetime({ offset: true }),
+  createdByUserId: z.string().min(1),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true })
+});
+
+export type IndustryMandate = z.infer<typeof IndustryMandateSchema>;
+
+export const IndustryMandateCreateRequestSchema = z.object({
+  type: IndustryMandateTypeSchema.default("mandate"),
+  title: z.string().min(1).max(240),
+  description: z.string().max(5000).default(""),
+  format: z.string().min(1).max(120),
+  genre: z.string().min(1).max(120),
+  opensAt: z.string().datetime({ offset: true }),
+  closesAt: z.string().datetime({ offset: true })
+});
+
+export type IndustryMandateCreateRequest = z.infer<typeof IndustryMandateCreateRequestSchema>;
+
+export const IndustryMandateFiltersSchema = z.object({
+  type: IndustryMandateTypeSchema.optional(),
+  status: IndustryMandateStatusSchema.optional(),
+  format: z.string().trim().min(1).optional(),
+  genre: z.string().trim().min(1).optional(),
+  limit: z.number().int().positive().max(100).default(20).optional(),
+  offset: z.number().int().nonnegative().default(0).optional()
+});
+
+export type IndustryMandateFilters = z.infer<typeof IndustryMandateFiltersSchema>;
+
+export const IndustryMandateSubmissionStatusSchema = z.enum([
+  "submitted",
+  "under_review",
+  "forwarded",
+  "rejected"
+]);
+
+export type IndustryMandateSubmissionStatus = z.infer<typeof IndustryMandateSubmissionStatusSchema>;
+
+export const IndustryMandateSubmissionSchema = z.object({
+  id: z.string().min(1),
+  mandateId: z.string().min(1),
+  writerUserId: z.string().min(1),
+  projectId: z.string().min(1),
+  fitExplanation: z.string().default(""),
+  status: IndustryMandateSubmissionStatusSchema,
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true })
+});
+
+export type IndustryMandateSubmission = z.infer<typeof IndustryMandateSubmissionSchema>;
+
+export const IndustryMandateSubmissionCreateRequestSchema = z.object({
+  projectId: z.string().min(1),
+  fitExplanation: z.string().max(3000).default("")
+});
+
+export type IndustryMandateSubmissionCreateRequest = z.infer<
+  typeof IndustryMandateSubmissionCreateRequestSchema
+>;
+
 export const SubmissionStatusSchema = z.enum([
   "pending",
   "quarterfinalist",

--- a/services/api-gateway/src/routes/industry.test.ts
+++ b/services/api-gateway/src/routes/industry.test.ts
@@ -127,3 +127,129 @@ test("industry entitlement check proxies query params", async (t) => {
     "http://industry-svc/internal/entitlements/writer_01/check?industryUserId=industry_01"
   );
 });
+
+test("industry talent search resolves auth and forwards query", async (t) => {
+  const urls: string[] = [];
+  const headers: Record<string, string>[] = [];
+  const server = buildServer({
+    logger: false,
+    requestFn: (async (url, options) => {
+      const urlStr = String(url);
+      if (urlStr.includes("/internal/auth/me")) {
+        return jsonResponse({
+          user: { id: "industry_01", email: "exec@example.com", displayName: "Industry User" },
+          expiresAt: "2026-12-31T00:00:00.000Z"
+        });
+      }
+      urls.push(urlStr);
+      headers.push((options?.headers as Record<string, string> | undefined) ?? {});
+      return jsonResponse({ results: [], total: 0, limit: 20, offset: 0 });
+    }) as typeof request,
+    identityServiceBase: "http://identity-svc",
+    industryPortalBase: "http://industry-svc"
+  });
+  t.after(async () => {
+    await server.close();
+  });
+
+  const response = await server.inject({
+    method: "GET",
+    url: "/api/v1/industry/talent-search?genre=Drama&format=Feature",
+    headers: { authorization: "Bearer sess_1" }
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(
+    urls[0],
+    "http://industry-svc/internal/talent-search?genre=Drama&format=Feature"
+  );
+  assert.equal(headers[0]?.["x-auth-user-id"], "industry_01");
+});
+
+test("industry list routes proxy writer auth context", async (t) => {
+  const urls: string[] = [];
+  const headers: Record<string, string>[] = [];
+  const server = buildServer({
+    logger: false,
+    requestFn: (async (url, options) => {
+      const urlStr = String(url);
+      if (urlStr.includes("/internal/auth/me")) {
+        return jsonResponse({
+          user: { id: "industry_01", email: "exec@example.com", displayName: "Industry User" },
+          expiresAt: "2026-12-31T00:00:00.000Z"
+        });
+      }
+      urls.push(urlStr);
+      headers.push((options?.headers as Record<string, string> | undefined) ?? {});
+      return jsonResponse({ list: { id: "industry_list_1" } }, 201);
+    }) as typeof request,
+    identityServiceBase: "http://identity-svc",
+    industryPortalBase: "http://industry-svc"
+  });
+  t.after(async () => {
+    await server.close();
+  });
+
+  const response = await server.inject({
+    method: "POST",
+    url: "/api/v1/industry/lists/industry_list_1/items",
+    headers: { authorization: "Bearer sess_1" },
+    payload: { writerUserId: "writer_01", projectId: "project_01" }
+  });
+
+  assert.equal(response.statusCode, 201);
+  assert.equal(urls[0], "http://industry-svc/internal/lists/industry_list_1/items");
+  assert.equal(headers[0]?.["x-auth-user-id"], "industry_01");
+});
+
+test("industry mandate create route requires allowlisted admin", async (t) => {
+  const urls: string[] = [];
+  const headers: Record<string, string>[] = [];
+  const server = buildServer({
+    logger: false,
+    industryAdminAllowlist: ["admin_writer"],
+    requestFn: (async (url, options) => {
+      urls.push(String(url));
+      headers.push((options?.headers as Record<string, string> | undefined) ?? {});
+      return jsonResponse({ mandate: { id: "mandate_1" } }, 201);
+    }) as typeof request,
+    industryPortalBase: "http://industry-svc"
+  });
+  t.after(async () => {
+    await server.close();
+  });
+
+  const forbidden = await server.inject({
+    method: "POST",
+    url: "/api/v1/industry/mandates",
+    payload: {
+      title: "Need contained thrillers",
+      type: "mandate",
+      description: "",
+      format: "feature",
+      genre: "thriller",
+      opensAt: "2026-02-23T00:00:00.000Z",
+      closesAt: "2026-03-23T00:00:00.000Z"
+    }
+  });
+  assert.equal(forbidden.statusCode, 403);
+  assert.equal(urls.length, 0);
+
+  const ok = await server.inject({
+    method: "POST",
+    url: "/api/v1/industry/mandates",
+    headers: { "x-admin-user-id": "admin_writer" },
+    payload: {
+      title: "Need contained thrillers",
+      type: "mandate",
+      description: "",
+      format: "feature",
+      genre: "thriller",
+      opensAt: "2026-02-23T00:00:00.000Z",
+      closesAt: "2026-03-23T00:00:00.000Z"
+    }
+  });
+  assert.equal(ok.statusCode, 201);
+  assert.equal(urls[0], "http://industry-svc/internal/mandates");
+  assert.equal(headers[0]?.["x-admin-user-id"], "admin_writer");
+});

--- a/services/api-gateway/src/routes/industry.ts
+++ b/services/api-gateway/src/routes/industry.ts
@@ -118,4 +118,175 @@ export function registerIndustryRoutes(server: FastifyInstance, ctx: GatewayCont
       );
     }
   });
+
+  server.get("/api/v1/industry/talent-search", {
+    config: { rateLimit: { max: 30, timeWindow: "1 minute" } },
+    handler: async (req, reply) => {
+      const userId = await getUserIdFromAuth(ctx.requestFn, ctx.identityServiceBase, req.headers.authorization);
+      if (!userId) {
+        return reply.status(401).send({ error: "unauthorized", detail: "Could not resolve user from auth token" });
+      }
+      const querySuffix = buildQuerySuffix(req.query);
+      return proxyJsonRequest(
+        reply,
+        ctx.requestFn,
+        `${ctx.industryPortalBase}/internal/talent-search${querySuffix}`,
+        {
+          method: "GET",
+          headers: addAuthUserIdHeader({}, userId)
+        }
+      );
+    }
+  });
+
+  server.get("/api/v1/industry/lists", {
+    config: { rateLimit: { max: 40, timeWindow: "1 minute" } },
+    handler: async (req, reply) => {
+      const userId = await getUserIdFromAuth(ctx.requestFn, ctx.identityServiceBase, req.headers.authorization);
+      if (!userId) {
+        return reply.status(401).send({ error: "unauthorized", detail: "Could not resolve user from auth token" });
+      }
+
+      return proxyJsonRequest(
+        reply,
+        ctx.requestFn,
+        `${ctx.industryPortalBase}/internal/lists`,
+        {
+          method: "GET",
+          headers: addAuthUserIdHeader({}, userId)
+        }
+      );
+    }
+  });
+
+  server.post("/api/v1/industry/lists", {
+    config: { rateLimit: { max: 20, timeWindow: "1 minute" } },
+    handler: async (req, reply) => {
+      const userId = await getUserIdFromAuth(ctx.requestFn, ctx.identityServiceBase, req.headers.authorization);
+      if (!userId) {
+        return reply.status(401).send({ error: "unauthorized", detail: "Could not resolve user from auth token" });
+      }
+
+      return proxyJsonRequest(
+        reply,
+        ctx.requestFn,
+        `${ctx.industryPortalBase}/internal/lists`,
+        {
+          method: "POST",
+          headers: addAuthUserIdHeader({ "content-type": "application/json" }, userId),
+          body: JSON.stringify(req.body ?? {})
+        }
+      );
+    }
+  });
+
+  server.post("/api/v1/industry/lists/:listId/items", {
+    config: { rateLimit: { max: 30, timeWindow: "1 minute" } },
+    handler: async (req, reply) => {
+      const { listId } = req.params as { listId: string };
+      const userId = await getUserIdFromAuth(ctx.requestFn, ctx.identityServiceBase, req.headers.authorization);
+      if (!userId) {
+        return reply.status(401).send({ error: "unauthorized", detail: "Could not resolve user from auth token" });
+      }
+
+      return proxyJsonRequest(
+        reply,
+        ctx.requestFn,
+        `${ctx.industryPortalBase}/internal/lists/${encodeURIComponent(listId)}/items`,
+        {
+          method: "POST",
+          headers: addAuthUserIdHeader({ "content-type": "application/json" }, userId),
+          body: JSON.stringify(req.body ?? {})
+        }
+      );
+    }
+  });
+
+  server.post("/api/v1/industry/lists/:listId/notes", {
+    config: { rateLimit: { max: 30, timeWindow: "1 minute" } },
+    handler: async (req, reply) => {
+      const { listId } = req.params as { listId: string };
+      const userId = await getUserIdFromAuth(ctx.requestFn, ctx.identityServiceBase, req.headers.authorization);
+      if (!userId) {
+        return reply.status(401).send({ error: "unauthorized", detail: "Could not resolve user from auth token" });
+      }
+
+      return proxyJsonRequest(
+        reply,
+        ctx.requestFn,
+        `${ctx.industryPortalBase}/internal/lists/${encodeURIComponent(listId)}/notes`,
+        {
+          method: "POST",
+          headers: addAuthUserIdHeader({ "content-type": "application/json" }, userId),
+          body: JSON.stringify(req.body ?? {})
+        }
+      );
+    }
+  });
+
+  server.get("/api/v1/industry/mandates", {
+    config: { rateLimit: { max: 30, timeWindow: "1 minute" } },
+    handler: async (req, reply) => {
+      const querySuffix = buildQuerySuffix(req.query);
+      return proxyJsonRequest(
+        reply,
+        ctx.requestFn,
+        `${ctx.industryPortalBase}/internal/mandates${querySuffix}`,
+        {
+          method: "GET"
+        }
+      );
+    }
+  });
+
+  server.post("/api/v1/industry/mandates", {
+    config: { rateLimit: { max: 10, timeWindow: "1 minute" } },
+    handler: async (req, reply) => {
+      const adminUserId = await resolveAdminUserId(
+        ctx.requestFn,
+        ctx.identityServiceBase,
+        req.headers as Record<string, unknown>,
+        ctx.industryAdminAllowlist
+      );
+      if (!adminUserId) {
+        return reply.status(403).send({ error: "forbidden" });
+      }
+
+      return proxyJsonRequest(
+        reply,
+        ctx.requestFn,
+        `${ctx.industryPortalBase}/internal/mandates`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-admin-user-id": adminUserId
+          },
+          body: JSON.stringify(req.body ?? {})
+        }
+      );
+    }
+  });
+
+  server.post("/api/v1/industry/mandates/:mandateId/submissions", {
+    config: { rateLimit: { max: 20, timeWindow: "1 minute" } },
+    handler: async (req, reply) => {
+      const { mandateId } = req.params as { mandateId: string };
+      const userId = await getUserIdFromAuth(ctx.requestFn, ctx.identityServiceBase, req.headers.authorization);
+      if (!userId) {
+        return reply.status(401).send({ error: "unauthorized", detail: "Could not resolve user from auth token" });
+      }
+
+      return proxyJsonRequest(
+        reply,
+        ctx.requestFn,
+        `${ctx.industryPortalBase}/internal/mandates/${encodeURIComponent(mandateId)}/submissions`,
+        {
+          method: "POST",
+          headers: addAuthUserIdHeader({ "content-type": "application/json" }, userId),
+          body: JSON.stringify(req.body ?? {})
+        }
+      );
+    }
+  });
 }

--- a/services/industry-portal-service/src/index.test.ts
+++ b/services/industry-portal-service/src/index.test.ts
@@ -5,18 +5,96 @@ import type {
   IndustryAccountCreateInternal,
   IndustryAccountVerificationRequest,
   IndustryEntitlement,
-  IndustryEntitlementUpsertRequest
+  IndustryEntitlementUpsertRequest,
+  IndustryList,
+  IndustryListCreateRequest,
+  IndustryListItem,
+  IndustryListItemCreateRequest,
+  IndustryMandate,
+  IndustryMandateCreateRequest,
+  IndustryMandateFilters,
+  IndustryMandateSubmission,
+  IndustryMandateSubmissionCreateRequest,
+  IndustryNote,
+  IndustryNoteCreateRequest,
+  IndustryTalentSearchFilters,
+  IndustryTalentSearchResult,
+  WriterProfile
 } from "@script-manifest/contracts";
 import { buildServer } from "./index.js";
 import type {
   IndustryAccountCreateResult,
-  IndustryPortalRepository
+  IndustryMandatesPage,
+  IndustryPortalRepository,
+  IndustryTalentSearchPage
 } from "./repository.js";
 
+type ProjectRecord = {
+  id: string;
+  ownerUserId: string;
+  title: string;
+  logline: string;
+  synopsis: string;
+  format: string;
+  genre: string;
+  isDiscoverable: boolean;
+};
+
 class MemoryRepository implements IndustryPortalRepository {
-  private users = new Set<string>(["writer_01", "industry_01", "admin_01"]);
+  private users = new Set<string>(["writer_01", "writer_02", "industry_01", "admin_01"]);
   private accounts = new Map<string, IndustryAccount>();
   private entitlements = new Map<string, IndustryEntitlement>();
+  private lists = new Map<string, IndustryList>();
+  private listItems = new Map<string, IndustryListItem>();
+  private notes = new Map<string, IndustryNote>();
+  private mandates = new Map<string, IndustryMandate>();
+  private mandateSubmissions = new Map<string, IndustryMandateSubmission>();
+  private profiles = new Map<string, WriterProfile>([
+    ["writer_01", {
+      id: "writer_01",
+      displayName: "Writer One",
+      bio: "Bio one",
+      genres: ["Drama", "Thriller"],
+      demographics: ["LGBTQ+"],
+      representationStatus: "seeking_rep",
+      headshotUrl: "",
+      customProfileUrl: "",
+      isSearchable: true
+    }],
+    ["writer_02", {
+      id: "writer_02",
+      displayName: "Writer Two",
+      bio: "Bio two",
+      genres: ["Comedy"],
+      demographics: ["Veteran"],
+      representationStatus: "represented",
+      headshotUrl: "",
+      customProfileUrl: "",
+      isSearchable: true
+    }]
+  ]);
+  private projects = new Map<string, ProjectRecord>([
+    ["project_01", {
+      id: "project_01",
+      ownerUserId: "writer_01",
+      title: "Contained Drama",
+      logline: "A family must reunite in one night.",
+      synopsis: "A contained drama set during one stormy evening.",
+      format: "feature",
+      genre: "Drama",
+      isDiscoverable: true
+    }],
+    ["project_02", {
+      id: "project_02",
+      ownerUserId: "writer_02",
+      title: "Workplace Comedy",
+      logline: "An office team survives a merger.",
+      synopsis: "Ensemble comedy pilot with heart.",
+      format: "pilot",
+      genre: "Comedy",
+      isDiscoverable: true
+    }]
+  ]);
 
   async init(): Promise<void> {}
 
@@ -123,6 +201,257 @@ class MemoryRepository implements IndustryPortalRepository {
   ): Promise<IndustryEntitlement | null> {
     return this.entitlements.get(`${writerUserId}:${industryAccountId}`) ?? null;
   }
+
+  async searchTalent(filters: IndustryTalentSearchFilters): Promise<IndustryTalentSearchPage> {
+    const q = (filters.q ?? "").toLowerCase();
+    const filtered = [...this.projects.values()].filter((project) => {
+      if (!project.isDiscoverable) {
+        return false;
+      }
+      const profile = this.profiles.get(project.ownerUserId);
+      if (!profile || !profile.isSearchable) {
+        return false;
+      }
+      if (filters.genre && project.genre !== filters.genre) {
+        return false;
+      }
+      if (filters.format && project.format !== filters.format) {
+        return false;
+      }
+      if (filters.representationStatus && profile.representationStatus !== filters.representationStatus) {
+        return false;
+      }
+      if (q.length > 0) {
+        const matches = profile.displayName.toLowerCase().includes(q)
+          || project.title.toLowerCase().includes(q)
+          || project.logline.toLowerCase().includes(q)
+          || project.synopsis.toLowerCase().includes(q);
+        if (!matches) {
+          return false;
+        }
+      }
+      return true;
+    });
+
+    const total = filtered.length;
+    const limit = filters.limit ?? 20;
+    const offset = filters.offset ?? 0;
+    const results: IndustryTalentSearchResult[] = filtered.slice(offset, offset + limit).map((project) => {
+      const profile = this.profiles.get(project.ownerUserId)!;
+      return {
+        writerId: profile.id,
+        displayName: profile.displayName,
+        representationStatus: profile.representationStatus,
+        genres: profile.genres,
+        demographics: profile.demographics,
+        projectId: project.id,
+        projectTitle: project.title,
+        projectFormat: project.format,
+        projectGenre: project.genre,
+        logline: project.logline,
+        synopsis: project.synopsis
+      };
+    });
+
+    return { results, total, limit, offset };
+  }
+
+  async listLists(industryAccountId: string): Promise<IndustryList[]> {
+    return [...this.lists.values()].filter((list) => list.industryAccountId === industryAccountId);
+  }
+
+  async createList(
+    industryAccountId: string,
+    createdByUserId: string,
+    input: IndustryListCreateRequest
+  ): Promise<IndustryList | null> {
+    if (!(await this.getAccountById(industryAccountId))) {
+      return null;
+    }
+    if (!(await this.userExists(createdByUserId))) {
+      return null;
+    }
+    const now = new Date().toISOString();
+    const list: IndustryList = {
+      id: `industry_list_${this.lists.size + 1}`,
+      industryAccountId,
+      name: input.name,
+      description: input.description,
+      createdByUserId,
+      isShared: input.isShared,
+      createdAt: now,
+      updatedAt: now
+    };
+    this.lists.set(list.id, list);
+    return list;
+  }
+
+  async addListItem(
+    listId: string,
+    industryAccountId: string,
+    addedByUserId: string,
+    input: IndustryListItemCreateRequest
+  ): Promise<IndustryListItem | null> {
+    const list = this.lists.get(listId);
+    if (!list || list.industryAccountId !== industryAccountId) {
+      return null;
+    }
+    if (!(await this.userExists(addedByUserId)) || !(await this.userExists(input.writerUserId))) {
+      return null;
+    }
+    if (input.projectId) {
+      const project = this.projects.get(input.projectId);
+      if (!project || project.ownerUserId !== input.writerUserId) {
+        return null;
+      }
+    }
+    const item: IndustryListItem = {
+      id: `industry_list_item_${this.listItems.size + 1}`,
+      listId,
+      writerUserId: input.writerUserId,
+      projectId: input.projectId ?? null,
+      addedByUserId,
+      createdAt: new Date().toISOString()
+    };
+    this.listItems.set(item.id, item);
+    return item;
+  }
+
+  async addListNote(
+    listId: string,
+    industryAccountId: string,
+    createdByUserId: string,
+    input: IndustryNoteCreateRequest
+  ): Promise<IndustryNote | null> {
+    const list = this.lists.get(listId);
+    if (!list || list.industryAccountId !== industryAccountId) {
+      return null;
+    }
+    if (!(await this.userExists(createdByUserId))) {
+      return null;
+    }
+    if (input.writerUserId && !(await this.userExists(input.writerUserId))) {
+      return null;
+    }
+    if (input.projectId && !this.projects.has(input.projectId)) {
+      return null;
+    }
+    const now = new Date().toISOString();
+    const note: IndustryNote = {
+      id: `industry_note_${this.notes.size + 1}`,
+      listId,
+      writerUserId: input.writerUserId ?? null,
+      projectId: input.projectId ?? null,
+      body: input.body,
+      createdByUserId,
+      createdAt: now,
+      updatedAt: now
+    };
+    this.notes.set(note.id, note);
+    return note;
+  }
+
+  async listMandates(filters: IndustryMandateFilters): Promise<IndustryMandatesPage> {
+    const filtered = [...this.mandates.values()].filter((mandate) => {
+      if (filters.type && mandate.type !== filters.type) {
+        return false;
+      }
+      if (filters.status && mandate.status !== filters.status) {
+        return false;
+      }
+      if (filters.format && mandate.format !== filters.format) {
+        return false;
+      }
+      if (filters.genre && mandate.genre !== filters.genre) {
+        return false;
+      }
+      return true;
+    });
+    const limit = filters.limit ?? 20;
+    const offset = filters.offset ?? 0;
+    return {
+      mandates: filtered.slice(offset, offset + limit),
+      total: filtered.length,
+      limit,
+      offset
+    };
+  }
+
+  async createMandate(
+    createdByUserId: string,
+    input: IndustryMandateCreateRequest
+  ): Promise<IndustryMandate | null> {
+    if (!(await this.userExists(createdByUserId))) {
+      return null;
+    }
+    const now = new Date().toISOString();
+    const mandate: IndustryMandate = {
+      id: `mandate_${this.mandates.size + 1}`,
+      type: input.type,
+      title: input.title,
+      description: input.description,
+      format: input.format,
+      genre: input.genre,
+      status: "open",
+      opensAt: input.opensAt,
+      closesAt: input.closesAt,
+      createdByUserId,
+      createdAt: now,
+      updatedAt: now
+    };
+    this.mandates.set(mandate.id, mandate);
+    return mandate;
+  }
+
+  async createMandateSubmission(
+    mandateId: string,
+    writerUserId: string,
+    input: IndustryMandateSubmissionCreateRequest
+  ): Promise<IndustryMandateSubmission | null> {
+    if (!(await this.userExists(writerUserId))) {
+      return null;
+    }
+    const project = this.projects.get(input.projectId);
+    if (!project || project.ownerUserId !== writerUserId) {
+      return null;
+    }
+    const mandate = this.mandates.get(mandateId);
+    if (!mandate || mandate.status !== "open") {
+      return null;
+    }
+    const now = new Date().toISOString();
+    const submission: IndustryMandateSubmission = {
+      id: `mandate_submission_${this.mandateSubmissions.size + 1}`,
+      mandateId,
+      writerUserId,
+      projectId: input.projectId,
+      fitExplanation: input.fitExplanation,
+      status: "submitted",
+      createdAt: now,
+      updatedAt: now
+    };
+    this.mandateSubmissions.set(submission.id, submission);
+    return submission;
+  }
+}
+
+async function createVerifiedIndustryAccount(repository: MemoryRepository): Promise<string> {
+  const createResult = await repository.createAccount({
+    userId: "industry_01",
+    companyName: "Studio One",
+    roleTitle: "Manager",
+    professionalEmail: "exec@studioone.com",
+    websiteUrl: "",
+    linkedinUrl: "",
+    imdbUrl: ""
+  });
+  assert.equal(createResult.status, "created");
+  const accountId = createResult.status === "created" ? createResult.account.id : "";
+  await repository.verifyAccount(accountId, "admin_01", {
+    status: "verified",
+    verificationNotes: "validated"
+  });
+  return accountId;
 }
 
 test("industry portal creates account for authenticated user", async (t) => {
@@ -179,17 +508,7 @@ test("industry portal verify route updates account status", async (t) => {
 
 test("industry entitlement upsert enforces writer ownership", async (t) => {
   const repository = new MemoryRepository();
-  const created = await repository.createAccount({
-    userId: "industry_01",
-    companyName: "Studio One",
-    roleTitle: "Manager",
-    professionalEmail: "exec@studioone.com",
-    websiteUrl: "",
-    linkedinUrl: "",
-    imdbUrl: ""
-  });
-  assert.equal(created.status, "created");
-  const accountId = created.status === "created" ? created.account.id : "";
+  const accountId = await createVerifiedIndustryAccount(repository);
 
   const server = buildServer({ logger: false, repository });
   t.after(async () => {
@@ -216,17 +535,7 @@ test("industry entitlement upsert enforces writer ownership", async (t) => {
 
 test("industry entitlement check resolves account from industry user id", async (t) => {
   const repository = new MemoryRepository();
-  const created = await repository.createAccount({
-    userId: "industry_01",
-    companyName: "Studio One",
-    roleTitle: "Manager",
-    professionalEmail: "exec@studioone.com",
-    websiteUrl: "",
-    linkedinUrl: "",
-    imdbUrl: ""
-  });
-  assert.equal(created.status, "created");
-  const accountId = created.status === "created" ? created.account.id : "";
+  const accountId = await createVerifiedIndustryAccount(repository);
 
   await repository.upsertEntitlement("writer_01", "writer_01", {
     industryAccountId: accountId,
@@ -246,4 +555,120 @@ test("industry entitlement check resolves account from industry user id", async 
   assert.equal(response.statusCode, 200);
   assert.equal(response.json().canView, true);
   assert.equal(response.json().canDownload, true);
+});
+
+test("industry talent search requires verified account and returns discoverable results", async (t) => {
+  const repository = new MemoryRepository();
+  const account = await repository.createAccount({
+    userId: "industry_01",
+    companyName: "Studio One",
+    roleTitle: "Manager",
+    professionalEmail: "exec@studioone.com",
+    websiteUrl: "",
+    linkedinUrl: "",
+    imdbUrl: ""
+  });
+  assert.equal(account.status, "created");
+  const accountId = account.status === "created" ? account.account.id : "";
+  const server = buildServer({ logger: false, repository });
+  t.after(async () => {
+    await server.close();
+  });
+
+  const forbidden = await server.inject({
+    method: "GET",
+    url: "/internal/talent-search?genre=Drama",
+    headers: { "x-auth-user-id": "industry_01" }
+  });
+  assert.equal(forbidden.statusCode, 403);
+
+  await repository.verifyAccount(accountId, "admin_01", {
+    status: "verified",
+    verificationNotes: "validated"
+  });
+  const ok = await server.inject({
+    method: "GET",
+    url: "/internal/talent-search?genre=Drama&format=feature",
+    headers: { "x-auth-user-id": "industry_01" }
+  });
+  assert.equal(ok.statusCode, 200);
+  assert.equal(ok.json().results.length, 1);
+  assert.equal(ok.json().results[0]?.writerId, "writer_01");
+});
+
+test("industry lists support create, item add, and note add", async (t) => {
+  const repository = new MemoryRepository();
+  await createVerifiedIndustryAccount(repository);
+  const server = buildServer({ logger: false, repository });
+  t.after(async () => {
+    await server.close();
+  });
+
+  const created = await server.inject({
+    method: "POST",
+    url: "/internal/lists",
+    headers: { "x-auth-user-id": "industry_01" },
+    payload: { name: "Drama Prospects", description: "Round one", isShared: true }
+  });
+  assert.equal(created.statusCode, 201);
+  const listId = created.json().list.id as string;
+
+  const item = await server.inject({
+    method: "POST",
+    url: `/internal/lists/${listId}/items`,
+    headers: { "x-auth-user-id": "industry_01" },
+    payload: { writerUserId: "writer_01", projectId: "project_01" }
+  });
+  assert.equal(item.statusCode, 201);
+  assert.equal(item.json().item.writerUserId, "writer_01");
+
+  const note = await server.inject({
+    method: "POST",
+    url: `/internal/lists/${listId}/notes`,
+    headers: { "x-auth-user-id": "industry_01" },
+    payload: { writerUserId: "writer_01", body: "Strong voice and clear stakes." }
+  });
+  assert.equal(note.statusCode, 201);
+  assert.equal(note.json().note.body, "Strong voice and clear stakes.");
+});
+
+test("industry mandates support create and writer submission", async (t) => {
+  const repository = new MemoryRepository();
+  const server = buildServer({ logger: false, repository });
+  t.after(async () => {
+    await server.close();
+  });
+
+  const created = await server.inject({
+    method: "POST",
+    url: "/internal/mandates",
+    headers: { "x-admin-user-id": "admin_01" },
+    payload: {
+      type: "mandate",
+      title: "Contained thrillers wanted",
+      description: "Producer request",
+      format: "feature",
+      genre: "Thriller",
+      opensAt: "2026-01-01T00:00:00.000Z",
+      closesAt: "2027-01-01T00:00:00.000Z"
+    }
+  });
+  assert.equal(created.statusCode, 201);
+  const mandateId = created.json().mandate.id as string;
+
+  const list = await server.inject({
+    method: "GET",
+    url: "/internal/mandates?status=open"
+  });
+  assert.equal(list.statusCode, 200);
+  assert.equal(list.json().mandates.length, 1);
+
+  const submission = await server.inject({
+    method: "POST",
+    url: `/internal/mandates/${mandateId}/submissions`,
+    headers: { "x-auth-user-id": "writer_01" },
+    payload: { projectId: "project_01", fitExplanation: "Matches budget and tone." }
+  });
+  assert.equal(submission.statusCode, 201);
+  assert.equal(submission.json().submission.status, "submitted");
 });

--- a/services/industry-portal-service/src/repository.ts
+++ b/services/industry-portal-service/src/repository.ts
@@ -7,7 +7,26 @@ import {
   IndustryAccountSchema,
   type IndustryEntitlement,
   type IndustryEntitlementUpsertRequest,
-  IndustryEntitlementSchema
+  IndustryEntitlementSchema,
+  type IndustryList,
+  type IndustryListCreateRequest,
+  type IndustryListItem,
+  type IndustryListItemCreateRequest,
+  IndustryListItemSchema,
+  IndustryListSchema,
+  type IndustryMandate,
+  type IndustryMandateCreateRequest,
+  type IndustryMandateFilters,
+  type IndustryMandateSubmission,
+  type IndustryMandateSubmissionCreateRequest,
+  IndustryMandateSchema,
+  IndustryMandateSubmissionSchema,
+  type IndustryNote,
+  type IndustryNoteCreateRequest,
+  IndustryNoteSchema,
+  type IndustryTalentSearchFilters,
+  type IndustryTalentSearchResult,
+  IndustryTalentSearchResultSchema
 } from "@script-manifest/contracts";
 import {
   ensureCoreTables,
@@ -19,6 +38,20 @@ export type IndustryAccountCreateResult =
   | { status: "created"; account: IndustryAccount }
   | { status: "user_not_found" }
   | { status: "already_exists"; account: IndustryAccount };
+
+export type IndustryTalentSearchPage = {
+  results: IndustryTalentSearchResult[];
+  total: number;
+  limit: number;
+  offset: number;
+};
+
+export type IndustryMandatesPage = {
+  mandates: IndustryMandate[];
+  total: number;
+  limit: number;
+  offset: number;
+};
 
 export interface IndustryPortalRepository {
   init(): Promise<void>;
@@ -41,6 +74,35 @@ export interface IndustryPortalRepository {
     writerUserId: string,
     industryAccountId: string
   ): Promise<IndustryEntitlement | null>;
+  searchTalent(filters: IndustryTalentSearchFilters): Promise<IndustryTalentSearchPage>;
+  listLists(industryAccountId: string): Promise<IndustryList[]>;
+  createList(
+    industryAccountId: string,
+    createdByUserId: string,
+    input: IndustryListCreateRequest
+  ): Promise<IndustryList | null>;
+  addListItem(
+    listId: string,
+    industryAccountId: string,
+    addedByUserId: string,
+    input: IndustryListItemCreateRequest
+  ): Promise<IndustryListItem | null>;
+  addListNote(
+    listId: string,
+    industryAccountId: string,
+    createdByUserId: string,
+    input: IndustryNoteCreateRequest
+  ): Promise<IndustryNote | null>;
+  listMandates(filters: IndustryMandateFilters): Promise<IndustryMandatesPage>;
+  createMandate(
+    createdByUserId: string,
+    input: IndustryMandateCreateRequest
+  ): Promise<IndustryMandate | null>;
+  createMandateSubmission(
+    mandateId: string,
+    writerUserId: string,
+    input: IndustryMandateSubmissionCreateRequest
+  ): Promise<IndustryMandateSubmission | null>;
 }
 
 function mapAccount(row: Record<string, unknown>): IndustryAccount {
@@ -68,6 +130,73 @@ function mapEntitlement(row: Record<string, unknown>): IndustryEntitlement {
     industryAccountId: row.industry_account_id,
     accessLevel: row.access_level,
     grantedByUserId: row.granted_by_user_id,
+    createdAt: new Date(String(row.created_at)).toISOString(),
+    updatedAt: new Date(String(row.updated_at)).toISOString()
+  });
+}
+
+function mapIndustryList(row: Record<string, unknown>): IndustryList {
+  return IndustryListSchema.parse({
+    id: row.id,
+    industryAccountId: row.industry_account_id,
+    name: row.name,
+    description: row.description ?? "",
+    createdByUserId: row.created_by_user_id,
+    isShared: row.is_shared,
+    createdAt: new Date(String(row.created_at)).toISOString(),
+    updatedAt: new Date(String(row.updated_at)).toISOString()
+  });
+}
+
+function mapListItem(row: Record<string, unknown>): IndustryListItem {
+  return IndustryListItemSchema.parse({
+    id: row.id,
+    listId: row.list_id,
+    writerUserId: row.writer_user_id,
+    projectId: typeof row.project_id === "string" ? row.project_id : null,
+    addedByUserId: row.added_by_user_id,
+    createdAt: new Date(String(row.created_at)).toISOString()
+  });
+}
+
+function mapNote(row: Record<string, unknown>): IndustryNote {
+  return IndustryNoteSchema.parse({
+    id: row.id,
+    listId: row.list_id,
+    writerUserId: typeof row.writer_user_id === "string" ? row.writer_user_id : null,
+    projectId: typeof row.project_id === "string" ? row.project_id : null,
+    body: row.body,
+    createdByUserId: row.created_by_user_id,
+    createdAt: new Date(String(row.created_at)).toISOString(),
+    updatedAt: new Date(String(row.updated_at)).toISOString()
+  });
+}
+
+function mapMandate(row: Record<string, unknown>): IndustryMandate {
+  return IndustryMandateSchema.parse({
+    id: row.id,
+    type: row.type,
+    title: row.title,
+    description: row.description ?? "",
+    format: row.format,
+    genre: row.genre,
+    status: row.status,
+    opensAt: new Date(String(row.opens_at)).toISOString(),
+    closesAt: new Date(String(row.closes_at)).toISOString(),
+    createdByUserId: row.created_by_user_id,
+    createdAt: new Date(String(row.created_at)).toISOString(),
+    updatedAt: new Date(String(row.updated_at)).toISOString()
+  });
+}
+
+function mapMandateSubmission(row: Record<string, unknown>): IndustryMandateSubmission {
+  return IndustryMandateSubmissionSchema.parse({
+    id: row.id,
+    mandateId: row.mandate_id,
+    writerUserId: row.writer_user_id,
+    projectId: row.project_id,
+    fitExplanation: row.fit_explanation ?? "",
+    status: row.status,
     createdAt: new Date(String(row.created_at)).toISOString(),
     updatedAt: new Date(String(row.updated_at)).toISOString()
   });
@@ -268,5 +397,422 @@ export class PgIndustryPortalRepository implements IndustryPortalRepository {
       return null;
     }
     return mapEntitlement(result.rows[0] as Record<string, unknown>);
+  }
+
+  async searchTalent(filters: IndustryTalentSearchFilters): Promise<IndustryTalentSearchPage> {
+    const db = getPool();
+    const limit = filters.limit ?? 20;
+    const offset = filters.offset ?? 0;
+    const where: string[] = [
+      "wp.is_searchable = TRUE",
+      "p.is_discoverable = TRUE"
+    ];
+    const params: unknown[] = [];
+
+    if (filters.genre) {
+      params.push(filters.genre);
+      where.push(`p.genre = $${params.length}`);
+    }
+    if (filters.format) {
+      params.push(filters.format);
+      where.push(`p.format = $${params.length}`);
+    }
+    if (filters.representationStatus) {
+      params.push(filters.representationStatus);
+      where.push(`wp.representation_status = $${params.length}`);
+    }
+    if (filters.q && filters.q.trim().length > 0) {
+      params.push(`%${filters.q.trim()}%`);
+      where.push(`(
+        wp.display_name ILIKE $${params.length}
+        OR p.title ILIKE $${params.length}
+        OR p.logline ILIKE $${params.length}
+        OR p.synopsis ILIKE $${params.length}
+      )`);
+    }
+
+    const whereSql = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
+    const countResult = await db.query<{ total: string }>(
+      `SELECT COUNT(*)::int AS total
+         FROM writer_profiles wp
+         JOIN projects p ON p.owner_user_id = wp.writer_id
+       ${whereSql}`,
+      params
+    );
+
+    const dataParams = [...params, limit, offset];
+    const rows = await db.query(
+      `SELECT
+         wp.writer_id,
+         wp.display_name,
+         wp.representation_status,
+         wp.genres,
+         wp.demographics,
+         p.id AS project_id,
+         p.title AS project_title,
+         p.format AS project_format,
+         p.genre AS project_genre,
+         p.logline,
+         p.synopsis
+       FROM writer_profiles wp
+       JOIN projects p ON p.owner_user_id = wp.writer_id
+       ${whereSql}
+       ORDER BY p.updated_at DESC
+       LIMIT $${params.length + 1}
+       OFFSET $${params.length + 2}`,
+      dataParams
+    );
+
+    const results = rows.rows.map((row) => IndustryTalentSearchResultSchema.parse({
+      writerId: row.writer_id,
+      displayName: row.display_name,
+      representationStatus: row.representation_status,
+      genres: Array.isArray(row.genres) ? row.genres : [],
+      demographics: Array.isArray(row.demographics) ? row.demographics : [],
+      projectId: row.project_id,
+      projectTitle: row.project_title,
+      projectFormat: row.project_format,
+      projectGenre: row.project_genre,
+      logline: row.logline ?? "",
+      synopsis: row.synopsis ?? ""
+    }));
+
+    return {
+      results,
+      total: Number(countResult.rows[0]?.total ?? 0),
+      limit,
+      offset
+    };
+  }
+
+  async listLists(industryAccountId: string): Promise<IndustryList[]> {
+    const db = getPool();
+    const result = await db.query(
+      `SELECT *
+         FROM industry_lists
+        WHERE industry_account_id = $1
+        ORDER BY updated_at DESC`,
+      [industryAccountId]
+    );
+    return result.rows.map((row) => mapIndustryList(row as Record<string, unknown>));
+  }
+
+  async createList(
+    industryAccountId: string,
+    createdByUserId: string,
+    input: IndustryListCreateRequest
+  ): Promise<IndustryList | null> {
+    const db = getPool();
+    const [account, creatorExists] = await Promise.all([
+      this.getAccountById(industryAccountId),
+      this.userExists(createdByUserId)
+    ]);
+    if (!account || !creatorExists) {
+      return null;
+    }
+
+    const now = new Date().toISOString();
+    const result = await db.query(
+      `INSERT INTO industry_lists (
+         id,
+         industry_account_id,
+         name,
+         description,
+         created_by_user_id,
+         is_shared,
+         created_at,
+         updated_at
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+       RETURNING *`,
+      [
+        `industry_list_${randomUUID()}`,
+        industryAccountId,
+        input.name,
+        input.description,
+        createdByUserId,
+        input.isShared,
+        now,
+        now
+      ]
+    );
+
+    return mapIndustryList(result.rows[0] as Record<string, unknown>);
+  }
+
+  private async listBelongsToAccount(listId: string, industryAccountId: string): Promise<boolean> {
+    const db = getPool();
+    const result = await db.query(
+      `SELECT 1
+         FROM industry_lists
+        WHERE id = $1
+          AND industry_account_id = $2
+        LIMIT 1`,
+      [listId, industryAccountId]
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async addListItem(
+    listId: string,
+    industryAccountId: string,
+    addedByUserId: string,
+    input: IndustryListItemCreateRequest
+  ): Promise<IndustryListItem | null> {
+    const db = getPool();
+    const [listOk, writerExists, addedByExists] = await Promise.all([
+      this.listBelongsToAccount(listId, industryAccountId),
+      this.userExists(input.writerUserId),
+      this.userExists(addedByUserId)
+    ]);
+    if (!listOk || !writerExists || !addedByExists) {
+      return null;
+    }
+
+    if (input.projectId) {
+      const ownedProject = await db.query(
+        `SELECT 1
+           FROM projects
+          WHERE id = $1
+            AND owner_user_id = $2
+          LIMIT 1`,
+        [input.projectId, input.writerUserId]
+      );
+      if ((ownedProject.rowCount ?? 0) < 1) {
+        return null;
+      }
+    }
+
+    const now = new Date().toISOString();
+    const result = await db.query(
+      `INSERT INTO industry_list_items (
+         id,
+         list_id,
+         writer_user_id,
+         project_id,
+         added_by_user_id,
+         created_at
+       ) VALUES ($1,$2,$3,$4,$5,$6)
+       ON CONFLICT (list_id, writer_user_id, project_id)
+       DO UPDATE SET added_by_user_id = EXCLUDED.added_by_user_id
+       RETURNING *`,
+      [
+        `industry_list_item_${randomUUID()}`,
+        listId,
+        input.writerUserId,
+        input.projectId ?? null,
+        addedByUserId,
+        now
+      ]
+    );
+
+    return mapListItem(result.rows[0] as Record<string, unknown>);
+  }
+
+  async addListNote(
+    listId: string,
+    industryAccountId: string,
+    createdByUserId: string,
+    input: IndustryNoteCreateRequest
+  ): Promise<IndustryNote | null> {
+    const db = getPool();
+    const [listOk, createdByExists] = await Promise.all([
+      this.listBelongsToAccount(listId, industryAccountId),
+      this.userExists(createdByUserId)
+    ]);
+    if (!listOk || !createdByExists) {
+      return null;
+    }
+    if (input.writerUserId && !(await this.userExists(input.writerUserId))) {
+      return null;
+    }
+    if (input.projectId) {
+      const projectExists = await db.query("SELECT 1 FROM projects WHERE id = $1 LIMIT 1", [input.projectId]);
+      if ((projectExists.rowCount ?? 0) < 1) {
+        return null;
+      }
+    }
+
+    const now = new Date().toISOString();
+    const result = await db.query(
+      `INSERT INTO industry_notes (
+         id,
+         list_id,
+         writer_user_id,
+         project_id,
+         body,
+         created_by_user_id,
+         created_at,
+         updated_at
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+       RETURNING *`,
+      [
+        `industry_note_${randomUUID()}`,
+        listId,
+        input.writerUserId ?? null,
+        input.projectId ?? null,
+        input.body,
+        createdByUserId,
+        now,
+        now
+      ]
+    );
+
+    return mapNote(result.rows[0] as Record<string, unknown>);
+  }
+
+  async listMandates(filters: IndustryMandateFilters): Promise<IndustryMandatesPage> {
+    const db = getPool();
+    const limit = filters.limit ?? 20;
+    const offset = filters.offset ?? 0;
+    const where: string[] = [];
+    const params: unknown[] = [];
+
+    if (filters.type) {
+      params.push(filters.type);
+      where.push(`type = $${params.length}`);
+    }
+    if (filters.status) {
+      params.push(filters.status);
+      where.push(`status = $${params.length}`);
+    }
+    if (filters.format) {
+      params.push(filters.format);
+      where.push(`format = $${params.length}`);
+    }
+    if (filters.genre) {
+      params.push(filters.genre);
+      where.push(`genre = $${params.length}`);
+    }
+
+    const whereSql = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
+
+    const countResult = await db.query<{ total: string }>(
+      `SELECT COUNT(*)::int AS total FROM mandates ${whereSql}`,
+      params
+    );
+
+    const dataParams = [...params, limit, offset];
+    const rows = await db.query(
+      `SELECT *
+         FROM mandates
+         ${whereSql}
+        ORDER BY closes_at ASC
+        LIMIT $${params.length + 1}
+       OFFSET $${params.length + 2}`,
+      dataParams
+    );
+
+    return {
+      mandates: rows.rows.map((row) => mapMandate(row as Record<string, unknown>)),
+      total: Number(countResult.rows[0]?.total ?? 0),
+      limit,
+      offset
+    };
+  }
+
+  async createMandate(
+    createdByUserId: string,
+    input: IndustryMandateCreateRequest
+  ): Promise<IndustryMandate | null> {
+    const db = getPool();
+    if (!(await this.userExists(createdByUserId))) {
+      return null;
+    }
+    const now = new Date().toISOString();
+    const result = await db.query(
+      `INSERT INTO mandates (
+         id,
+         type,
+         title,
+         description,
+         format,
+         genre,
+         status,
+         opens_at,
+         closes_at,
+         created_by_user_id,
+         created_at,
+         updated_at
+       ) VALUES ($1,$2,$3,$4,$5,$6,'open',$7,$8,$9,$10,$11)
+       RETURNING *`,
+      [
+        `mandate_${randomUUID()}`,
+        input.type,
+        input.title,
+        input.description,
+        input.format,
+        input.genre,
+        input.opensAt,
+        input.closesAt,
+        createdByUserId,
+        now,
+        now
+      ]
+    );
+
+    return mapMandate(result.rows[0] as Record<string, unknown>);
+  }
+
+  async createMandateSubmission(
+    mandateId: string,
+    writerUserId: string,
+    input: IndustryMandateSubmissionCreateRequest
+  ): Promise<IndustryMandateSubmission | null> {
+    const db = getPool();
+    const [writerExists, projectOwned, mandateResult] = await Promise.all([
+      this.userExists(writerUserId),
+      db.query(
+        `SELECT 1
+           FROM projects
+          WHERE id = $1
+            AND owner_user_id = $2
+          LIMIT 1`,
+        [input.projectId, writerUserId]
+      ),
+      db.query(
+        `SELECT *
+           FROM mandates
+          WHERE id = $1
+            AND status = 'open'
+            AND opens_at <= NOW()
+            AND closes_at >= NOW()
+          LIMIT 1`,
+        [mandateId]
+      )
+    ]);
+    if (!writerExists || (projectOwned.rowCount ?? 0) < 1 || (mandateResult.rowCount ?? 0) < 1) {
+      return null;
+    }
+
+    const now = new Date().toISOString();
+    const result = await db.query(
+      `INSERT INTO mandate_submissions (
+         id,
+         mandate_id,
+         writer_user_id,
+         project_id,
+         fit_explanation,
+         status,
+         created_at,
+         updated_at
+       ) VALUES ($1,$2,$3,$4,$5,'submitted',$6,$7)
+       ON CONFLICT (mandate_id, writer_user_id, project_id)
+       DO UPDATE SET
+         fit_explanation = EXCLUDED.fit_explanation,
+         status = 'submitted',
+         updated_at = EXCLUDED.updated_at
+       RETURNING *`,
+      [
+        `mandate_submission_${randomUUID()}`,
+        mandateId,
+        writerUserId,
+        input.projectId,
+        input.fitExplanation,
+        now,
+        now
+      ]
+    );
+
+    return mapMandateSubmission(result.rows[0] as Record<string, unknown>);
   }
 }


### PR DESCRIPTION
## Summary
- extend industry portal contracts and DB schema for talent search, lists/notes, and mandates/submissions
- implement new internal endpoints in industry-portal-service and proxy routes in api-gateway
- add unit tests for new gateway and service flows
- update Phase 5 docs/user manual and kickoff status in Phase 6/7 docs

## Tracker alignment
- Continues script-manifest-n92.2 (discovery + collaboration)
- Continues script-manifest-n92.3 (mandates)
- Kickoff updates for script-manifest-n2h and script-manifest-nzi

## Validation
- `pnpm run test:unit`
- `pnpm run typecheck`
- `pnpm run build`
