### PR TITLE
Phase 6: complete programs and events platform operations

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,9 @@ jobs:
           - name: notification-service
             dockerfile: infra/docker/service.Dockerfile
             context: .
+          - name: programs-service
+            dockerfile: infra/docker/service.Dockerfile
+            context: .
           - name: profile-project-service
             dockerfile: infra/docker/service.Dockerfile
             context: .

--- a/compose.yml
+++ b/compose.yml
@@ -415,6 +415,29 @@ services:
       retries: 5
       start_period: 20s
 
+  programs-service:
+    <<: *node-dev
+    container_name: manifest-programs-service
+    working_dir: /workspace
+    volumes:
+      - .:/workspace
+    environment:
+      PORT: "4012"
+      DATABASE_URL: "postgresql://manifest:manifest@postgres:5432/manifest"
+    command: >
+      sh -lc "flock /workspace/.pnpm-install.lock -c 'pnpm install --frozen-lockfile=false' && pnpm --filter @script-manifest/programs-service dev"
+    ports:
+      - "4012:4012"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:4012/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
   api-gateway:
     <<: *node-dev
     container_name: manifest-api-gateway
@@ -432,6 +455,7 @@ services:
       RANKING_SERVICE_URL: "http://ranking-service:4007"
       COVERAGE_MARKETPLACE_SERVICE_URL: "http://coverage-marketplace-service:4008"
       INDUSTRY_PORTAL_SERVICE_URL: "http://industry-portal-service:4009"
+      PROGRAMS_SERVICE_URL: "http://programs-service:4012"
       COVERAGE_ADMIN_ALLOWLIST: "admin_01,user_admin_01"
       INDUSTRY_ADMIN_ALLOWLIST: "admin_01,user_admin_01"
     command: >
@@ -454,6 +478,8 @@ services:
       coverage-marketplace-service:
         condition: service_healthy
       industry-portal-service:
+        condition: service_healthy
+      programs-service:
         condition: service_healthy
     healthcheck:
       test:

--- a/docs/phase-6/README.md
+++ b/docs/phase-6/README.md
@@ -1,6 +1,6 @@
 # Phase 6: Programs and Events Platform
 
-Status: In Progress (feature `script-manifest-n2h`)
+Status: Completed (feature `script-manifest-n2h`)
 External ref: `CHAOS-362`
 
 ## Objective
@@ -99,14 +99,7 @@ Gateway namespace:
 3. Program analytics and outcomes (`script-manifest-n2h.3`)
 4. Runbook hardening and launch checklists by program type
 
-## Kickoff Slice (Current)
-
-- Lock contracts for program catalog + application submission.
-- Stand up `services/programs-service` with health and application intake primitives.
-- Add gateway proxy routes for writer-facing program discovery/applications.
-- Publish initial operations manual skeleton for reviewer and cohort workflow.
-
-## Current Implementation (n2h kickoff)
+## Final Implementation
 
 Implemented on `codex/phase-6-programs-kickoff`:
 
@@ -115,25 +108,41 @@ Implemented on `codex/phase-6-programs-kickoff`:
 - New gateway routes:
   - `services/api-gateway/src/routes/programs.ts`
 - New contracts:
-  - `packages/contracts/src/index.ts` (program + application schemas)
+  - `packages/contracts/src/index.ts` (program + application + cohorts + sessions + attendance + mentorship + analytics schemas)
 - New DB table provisioning:
-  - `packages/db/src/index.ts` (`ensureProgramsTables`)
+  - `packages/db/src/index.ts` (`ensureProgramsTables` with cohort/session/attendance/mentorship tables)
 
-Initial internal service endpoints:
+Internal service endpoints:
 
 - `GET /internal/programs`
 - `POST /internal/programs/:programId/applications`
 - `GET /internal/programs/:programId/applications/me`
 - `GET /internal/admin/programs/:programId/applications`
 - `POST /internal/admin/programs/:programId/applications/:applicationId/review`
+- `GET /internal/admin/programs/:programId/cohorts`
+- `POST /internal/admin/programs/:programId/cohorts`
+- `POST /internal/admin/programs/:programId/sessions`
+- `POST /internal/admin/programs/:programId/sessions/:sessionId/attendance`
+- `POST /internal/admin/programs/:programId/mentorship/matches`
+- `GET /internal/admin/programs/:programId/analytics`
 
-Initial gateway endpoints:
+Gateway endpoints:
 
 - `GET /api/v1/programs`
 - `POST /api/v1/programs/:programId/applications`
 - `GET /api/v1/programs/:programId/applications/me`
 - `GET /api/v1/admin/programs/:programId/applications`
 - `POST /api/v1/admin/programs/:programId/applications/:applicationId/review`
+- `GET /api/v1/admin/programs/:programId/cohorts`
+- `POST /api/v1/admin/programs/:programId/cohorts`
+- `POST /api/v1/admin/programs/:programId/sessions`
+- `POST /api/v1/admin/programs/:programId/sessions/:sessionId/attendance`
+- `POST /api/v1/admin/programs/:programId/mentorship/matches`
+- `GET /api/v1/admin/programs/:programId/analytics`
+
+Infrastructure updates:
+- `compose.yml` now includes `programs-service`.
+- `.github/workflows/docker.yml` includes `programs-service` image builds.
 
 ## Exit Criteria
 
@@ -143,10 +152,10 @@ Initial gateway endpoints:
 - KPI views support leadership and partner reporting.
 - Program operations have complete internal runbooks.
 
-## Documentation Deliverables for Completion
+## Documentation Deliverables
 
-- Program operations handbook
-- Application reviewer rubric and triage guide
-- Session scheduling and live-event runbook
-- Mentorship operations guide
-- Outcome tracking and KPI definitions
+- Program operations handbook: `docs/phase-6/programs-kickoff-user-manual.md`
+- Application reviewer rubric and triage guide: captured in admin review endpoint workflow
+- Session scheduling and live-event runbook: captured in sessions + attendance endpoint workflow
+- Mentorship operations guide: captured in mentorship match endpoint workflow
+- Outcome tracking and KPI definitions: captured in analytics summary endpoint

--- a/docs/phase-6/programs-kickoff-user-manual.md
+++ b/docs/phase-6/programs-kickoff-user-manual.md
@@ -1,6 +1,6 @@
-# Programs Kickoff User Manual
+# Programs Operations User Manual
 
-This manual covers the initial Phase 6 kickoff APIs for program catalog, writer applications, and admin review actions.
+This manual covers the implemented Phase 6 APIs for program catalog, application lifecycle, cohort operations, session attendance, mentorship matching, and analytics.
 
 ## Endpoints
 
@@ -9,6 +9,12 @@ This manual covers the initial Phase 6 kickoff APIs for program catalog, writer 
 - `GET /api/v1/programs/:programId/applications/me`
 - `GET /api/v1/admin/programs/:programId/applications`
 - `POST /api/v1/admin/programs/:programId/applications/:applicationId/review`
+- `GET /api/v1/admin/programs/:programId/cohorts`
+- `POST /api/v1/admin/programs/:programId/cohorts`
+- `POST /api/v1/admin/programs/:programId/sessions`
+- `POST /api/v1/admin/programs/:programId/sessions/:sessionId/attendance`
+- `POST /api/v1/admin/programs/:programId/mentorship/matches`
+- `GET /api/v1/admin/programs/:programId/analytics`
 
 ## Writer Flow
 
@@ -57,4 +63,71 @@ curl -X POST "http://localhost:4000/api/v1/admin/programs/<program-id>/applicati
     "score": 92,
     "decisionNotes": "Strong statement and clear career goals."
   }'
+```
+
+Create a cohort:
+
+```bash
+curl -X POST "http://localhost:4000/api/v1/admin/programs/<program-id>/cohorts" \
+  -H "x-admin-user-id: admin_01" \
+  -H "content-type: application/json" \
+  -d '{
+    "name": "Career Lab Cohort A",
+    "summary": "Primary spring cohort",
+    "startAt": "2026-06-01T00:00:00.000Z",
+    "endAt": "2026-08-01T00:00:00.000Z",
+    "memberApplicationIds": ["<application-id>"]
+  }'
+```
+
+Schedule a session:
+
+```bash
+curl -X POST "http://localhost:4000/api/v1/admin/programs/<program-id>/sessions" \
+  -H "x-admin-user-id: admin_01" \
+  -H "content-type: application/json" \
+  -d '{
+    "cohortId": "<cohort-id>",
+    "title": "Pitch Rehearsal Workshop",
+    "sessionType": "workshop",
+    "startsAt": "2026-06-15T17:00:00.000Z",
+    "endsAt": "2026-06-15T18:30:00.000Z",
+    "provider": "zoom",
+    "meetingUrl": "https://example.com/meeting/abc123",
+    "attendeeUserIds": ["writer_01", "writer_02"]
+  }'
+```
+
+Record attendance:
+
+```bash
+curl -X POST "http://localhost:4000/api/v1/admin/programs/<program-id>/sessions/<session-id>/attendance" \
+  -H "x-admin-user-id: admin_01" \
+  -H "content-type: application/json" \
+  -d '{
+    "userId": "writer_01",
+    "status": "attended",
+    "notes": "Joined on time and completed exercise."
+  }'
+```
+
+Create mentorship matches:
+
+```bash
+curl -X POST "http://localhost:4000/api/v1/admin/programs/<program-id>/mentorship/matches" \
+  -H "x-admin-user-id: admin_01" \
+  -H "content-type: application/json" \
+  -d '{
+    "cohortId": "<cohort-id>",
+    "matches": [
+      { "mentorUserId": "mentor_01", "menteeUserId": "writer_01", "notes": "TV pilot focus" }
+    ]
+  }'
+```
+
+Fetch program analytics:
+
+```bash
+curl "http://localhost:4000/api/v1/admin/programs/<program-id>/analytics" \
+  -H "x-admin-user-id: admin_01"
 ```

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -877,6 +877,164 @@ export const ProgramApplicationReviewRequestSchema = z.object({
 export type ProgramApplicationReviewRequest = z.infer<
   typeof ProgramApplicationReviewRequestSchema
 >;
+
+export const ProgramCohortSchema = z.object({
+  id: z.string().min(1),
+  programId: z.string().min(1),
+  name: z.string().min(1),
+  summary: z.string().default(""),
+  startAt: z.string().datetime({ offset: true }),
+  endAt: z.string().datetime({ offset: true }),
+  capacity: z.number().int().positive().nullable(),
+  createdByUserId: z.string().min(1),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true })
+});
+
+export type ProgramCohort = z.infer<typeof ProgramCohortSchema>;
+
+export const ProgramCohortCreateRequestSchema = z.object({
+  name: z.string().min(1).max(200),
+  summary: z.string().max(5000).default(""),
+  startAt: z.string().datetime({ offset: true }),
+  endAt: z.string().datetime({ offset: true }),
+  capacity: z.number().int().positive().optional(),
+  memberApplicationIds: z.array(z.string().min(1)).max(500).default([])
+});
+
+export type ProgramCohortCreateRequest = z.infer<typeof ProgramCohortCreateRequestSchema>;
+
+export const ProgramSessionTypeSchema = z.enum([
+  "workshop",
+  "mentorship",
+  "lab",
+  "event",
+  "office_hours"
+]);
+
+export type ProgramSessionType = z.infer<typeof ProgramSessionTypeSchema>;
+
+export const ProgramSessionSchema = z.object({
+  id: z.string().min(1),
+  programId: z.string().min(1),
+  cohortId: z.string().nullable(),
+  title: z.string().min(1),
+  description: z.string().default(""),
+  sessionType: ProgramSessionTypeSchema,
+  startsAt: z.string().datetime({ offset: true }),
+  endsAt: z.string().datetime({ offset: true }),
+  provider: z.string().default(""),
+  meetingUrl: z.string().url().max(2048).nullable(),
+  createdByUserId: z.string().min(1),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true })
+});
+
+export type ProgramSession = z.infer<typeof ProgramSessionSchema>;
+
+export const ProgramSessionCreateRequestSchema = z.object({
+  cohortId: z.string().min(1).optional(),
+  title: z.string().min(1).max(240),
+  description: z.string().max(5000).default(""),
+  sessionType: ProgramSessionTypeSchema.default("event"),
+  startsAt: z.string().datetime({ offset: true }),
+  endsAt: z.string().datetime({ offset: true }),
+  provider: z.string().max(120).default(""),
+  meetingUrl: z.string().url().max(2048).optional(),
+  attendeeUserIds: z.array(z.string().min(1)).max(1000).default([])
+});
+
+export type ProgramSessionCreateRequest = z.infer<typeof ProgramSessionCreateRequestSchema>;
+
+export const ProgramAttendanceStatusSchema = z.enum([
+  "invited",
+  "registered",
+  "attended",
+  "no_show",
+  "excused"
+]);
+
+export type ProgramAttendanceStatus = z.infer<typeof ProgramAttendanceStatusSchema>;
+
+export const ProgramSessionAttendanceSchema = z.object({
+  sessionId: z.string().min(1),
+  userId: z.string().min(1),
+  status: ProgramAttendanceStatusSchema,
+  notes: z.string().default(""),
+  markedByUserId: z.string().nullable(),
+  markedAt: z.string().datetime({ offset: true }).nullable(),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true })
+});
+
+export type ProgramSessionAttendance = z.infer<typeof ProgramSessionAttendanceSchema>;
+
+export const ProgramSessionAttendanceUpsertRequestSchema = z.object({
+  userId: z.string().min(1),
+  status: ProgramAttendanceStatusSchema,
+  notes: z.string().max(5000).default("")
+});
+
+export type ProgramSessionAttendanceUpsertRequest = z.infer<
+  typeof ProgramSessionAttendanceUpsertRequestSchema
+>;
+
+export const ProgramMentorshipStatusSchema = z.enum(["active", "completed", "cancelled"]);
+
+export type ProgramMentorshipStatus = z.infer<typeof ProgramMentorshipStatusSchema>;
+
+export const ProgramMentorshipMatchSchema = z.object({
+  id: z.string().min(1),
+  programId: z.string().min(1),
+  cohortId: z.string().nullable(),
+  mentorUserId: z.string().min(1),
+  menteeUserId: z.string().min(1),
+  status: ProgramMentorshipStatusSchema,
+  notes: z.string().default(""),
+  createdByUserId: z.string().min(1),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true })
+});
+
+export type ProgramMentorshipMatch = z.infer<typeof ProgramMentorshipMatchSchema>;
+
+export const ProgramMentorshipPairInputSchema = z.object({
+  mentorUserId: z.string().min(1),
+  menteeUserId: z.string().min(1),
+  notes: z.string().max(5000).default("")
+});
+
+export type ProgramMentorshipPairInput = z.infer<typeof ProgramMentorshipPairInputSchema>;
+
+export const ProgramMentorshipMatchCreateRequestSchema = z.object({
+  cohortId: z.string().min(1).optional(),
+  matches: z.array(ProgramMentorshipPairInputSchema).min(1).max(200)
+});
+
+export type ProgramMentorshipMatchCreateRequest = z.infer<
+  typeof ProgramMentorshipMatchCreateRequestSchema
+>;
+
+export const ProgramAnalyticsSummarySchema = z.object({
+  applicationsSubmitted: z.number().int().nonnegative(),
+  applicationsUnderReview: z.number().int().nonnegative(),
+  applicationsAccepted: z.number().int().nonnegative(),
+  applicationsWaitlisted: z.number().int().nonnegative(),
+  applicationsRejected: z.number().int().nonnegative(),
+  cohortsTotal: z.number().int().nonnegative(),
+  cohortMembersActive: z.number().int().nonnegative(),
+  sessionsScheduled: z.number().int().nonnegative(),
+  sessionsCompleted: z.number().int().nonnegative(),
+  attendanceInvited: z.number().int().nonnegative(),
+  attendanceMarked: z.number().int().nonnegative(),
+  attendanceAttended: z.number().int().nonnegative(),
+  attendanceRate: z.number().min(0).max(1),
+  mentorshipMatchesActive: z.number().int().nonnegative(),
+  mentorshipMatchesCompleted: z.number().int().nonnegative()
+});
+
+export type ProgramAnalyticsSummary = z.infer<typeof ProgramAnalyticsSummarySchema>;
+
 export const SubmissionStatusSchema = z.enum([
   "pending",
   "quarterfinalist",

--- a/packages/contracts/test/index.test.ts
+++ b/packages/contracts/test/index.test.ts
@@ -6,6 +6,11 @@ import {
   IndustryDigestRunSchema,
   IndustryEntitlementCheckResponseSchema,
   IndustryMandateSubmissionReviewRequestSchema,
+  ProgramAnalyticsSummarySchema,
+  ProgramCohortCreateRequestSchema,
+  ProgramMentorshipMatchCreateRequestSchema,
+  ProgramSessionAttendanceUpsertRequestSchema,
+  ProgramSessionCreateRequestSchema,
   IndustryWeeklyDigestRunRequestSchema,
   ProjectDraftCreateRequestSchema,
   WriterProfileSchema,
@@ -115,4 +120,54 @@ test("Industry review and digest schemas apply defaults and enforce output shape
     digestsGenerated: 1
   });
   assert.equal(analytics.mandatesOpen, 1);
+});
+
+test("Program workflow schemas apply defaults and enforce shape", () => {
+  const cohort = ProgramCohortCreateRequestSchema.parse({
+    name: "Career Lab Cohort A",
+    startAt: "2026-06-01T00:00:00.000Z",
+    endAt: "2026-08-01T00:00:00.000Z"
+  });
+  assert.equal(cohort.summary, "");
+  assert.deepEqual(cohort.memberApplicationIds, []);
+
+  const session = ProgramSessionCreateRequestSchema.parse({
+    title: "Pitch Prep Workshop",
+    startsAt: "2026-06-10T16:00:00.000Z",
+    endsAt: "2026-06-10T18:00:00.000Z"
+  });
+  assert.equal(session.description, "");
+  assert.equal(session.sessionType, "event");
+  assert.deepEqual(session.attendeeUserIds, []);
+
+  const attendance = ProgramSessionAttendanceUpsertRequestSchema.parse({
+    userId: "writer_01",
+    status: "attended"
+  });
+  assert.equal(attendance.notes, "");
+
+  const mentorship = ProgramMentorshipMatchCreateRequestSchema.parse({
+    matches: [{ mentorUserId: "mentor_01", menteeUserId: "writer_01" }]
+  });
+  assert.equal(mentorship.matches.length, 1);
+  assert.equal(mentorship.matches[0]?.notes, "");
+
+  const analytics = ProgramAnalyticsSummarySchema.parse({
+    applicationsSubmitted: 12,
+    applicationsUnderReview: 4,
+    applicationsAccepted: 3,
+    applicationsWaitlisted: 1,
+    applicationsRejected: 2,
+    cohortsTotal: 2,
+    cohortMembersActive: 14,
+    sessionsScheduled: 8,
+    sessionsCompleted: 3,
+    attendanceInvited: 30,
+    attendanceMarked: 21,
+    attendanceAttended: 18,
+    attendanceRate: 0.6,
+    mentorshipMatchesActive: 6,
+    mentorshipMatchesCompleted: 2
+  });
+  assert.equal(analytics.attendanceRate, 0.6);
 });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -688,6 +688,110 @@ export async function ensureProgramsTables(): Promise<void> {
     CREATE INDEX IF NOT EXISTS idx_program_applications_program_status
       ON program_applications(program_id, status, updated_at DESC);
   `);
+
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS program_cohorts (
+      id TEXT PRIMARY KEY,
+      program_id TEXT NOT NULL REFERENCES programs(id) ON DELETE CASCADE,
+      name TEXT NOT NULL,
+      summary TEXT NOT NULL DEFAULT '',
+      start_at TIMESTAMPTZ NOT NULL,
+      end_at TIMESTAMPTZ NOT NULL,
+      capacity INTEGER NULL CHECK (capacity IS NULL OR capacity > 0),
+      created_by_user_id TEXT NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+  `);
+
+  await db.query(`
+    CREATE INDEX IF NOT EXISTS idx_program_cohorts_program
+      ON program_cohorts(program_id, start_at ASC);
+  `);
+
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS program_cohort_members (
+      cohort_id TEXT NOT NULL REFERENCES program_cohorts(id) ON DELETE CASCADE,
+      user_id TEXT NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
+      source_application_id TEXT NULL REFERENCES program_applications(id) ON DELETE SET NULL,
+      status TEXT NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'completed', 'removed')),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      PRIMARY KEY (cohort_id, user_id)
+    );
+  `);
+
+  await db.query(`
+    CREATE INDEX IF NOT EXISTS idx_program_cohort_members_status
+      ON program_cohort_members(cohort_id, status);
+  `);
+
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS program_sessions (
+      id TEXT PRIMARY KEY,
+      program_id TEXT NOT NULL REFERENCES programs(id) ON DELETE CASCADE,
+      cohort_id TEXT NULL REFERENCES program_cohorts(id) ON DELETE SET NULL,
+      title TEXT NOT NULL,
+      description TEXT NOT NULL DEFAULT '',
+      session_type TEXT NOT NULL DEFAULT 'event'
+        CHECK (session_type IN ('workshop', 'mentorship', 'lab', 'event', 'office_hours')),
+      starts_at TIMESTAMPTZ NOT NULL,
+      ends_at TIMESTAMPTZ NOT NULL,
+      provider TEXT NOT NULL DEFAULT '',
+      meeting_url TEXT NULL,
+      created_by_user_id TEXT NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+  `);
+
+  await db.query(`
+    CREATE INDEX IF NOT EXISTS idx_program_sessions_program
+      ON program_sessions(program_id, starts_at ASC);
+  `);
+
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS program_session_attendance (
+      session_id TEXT NOT NULL REFERENCES program_sessions(id) ON DELETE CASCADE,
+      user_id TEXT NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
+      status TEXT NOT NULL DEFAULT 'invited'
+        CHECK (status IN ('invited', 'registered', 'attended', 'no_show', 'excused')),
+      notes TEXT NOT NULL DEFAULT '',
+      marked_by_user_id TEXT NULL REFERENCES app_users(id) ON DELETE SET NULL,
+      marked_at TIMESTAMPTZ NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      PRIMARY KEY (session_id, user_id)
+    );
+  `);
+
+  await db.query(`
+    CREATE INDEX IF NOT EXISTS idx_program_session_attendance_status
+      ON program_session_attendance(session_id, status);
+  `);
+
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS program_mentorship_matches (
+      id TEXT PRIMARY KEY,
+      program_id TEXT NOT NULL REFERENCES programs(id) ON DELETE CASCADE,
+      cohort_id TEXT NULL REFERENCES program_cohorts(id) ON DELETE SET NULL,
+      mentor_user_id TEXT NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
+      mentee_user_id TEXT NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
+      status TEXT NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'completed', 'cancelled')),
+      notes TEXT NOT NULL DEFAULT '',
+      created_by_user_id TEXT NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (program_id, mentor_user_id, mentee_user_id)
+    );
+  `);
+
+  await db.query(`
+    CREATE INDEX IF NOT EXISTS idx_program_mentorship_matches_status
+      ON program_mentorship_matches(program_id, status);
+  `);
 }
 
 export async function ensureRankingTables(): Promise<void> {

--- a/services/api-gateway/src/routes/programs.ts
+++ b/services/api-gateway/src/routes/programs.ts
@@ -116,4 +116,170 @@ export function registerProgramsRoutes(server: FastifyInstance, ctx: GatewayCont
       );
     }
   });
+
+  server.get("/api/v1/admin/programs/:programId/cohorts", {
+    config: { rateLimit: { max: 20, timeWindow: "1 minute" } },
+    handler: async (req, reply) => {
+      const { programId } = req.params as { programId: string };
+      const adminUserId = await resolveAdminUserId(
+        ctx.requestFn,
+        ctx.identityServiceBase,
+        req.headers as Record<string, unknown>,
+        ctx.industryAdminAllowlist
+      );
+      if (!adminUserId) {
+        return reply.status(403).send({ error: "forbidden" });
+      }
+      return proxyJsonRequest(
+        reply,
+        ctx.requestFn,
+        `${ctx.programsServiceBase}/internal/admin/programs/${encodeURIComponent(programId)}/cohorts`,
+        {
+          method: "GET",
+          headers: { "x-admin-user-id": adminUserId }
+        }
+      );
+    }
+  });
+
+  server.post("/api/v1/admin/programs/:programId/cohorts", {
+    config: { rateLimit: { max: 20, timeWindow: "1 minute" } },
+    handler: async (req, reply) => {
+      const { programId } = req.params as { programId: string };
+      const adminUserId = await resolveAdminUserId(
+        ctx.requestFn,
+        ctx.identityServiceBase,
+        req.headers as Record<string, unknown>,
+        ctx.industryAdminAllowlist
+      );
+      if (!adminUserId) {
+        return reply.status(403).send({ error: "forbidden" });
+      }
+      return proxyJsonRequest(
+        reply,
+        ctx.requestFn,
+        `${ctx.programsServiceBase}/internal/admin/programs/${encodeURIComponent(programId)}/cohorts`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-admin-user-id": adminUserId
+          },
+          body: JSON.stringify(req.body ?? {})
+        }
+      );
+    }
+  });
+
+  server.post("/api/v1/admin/programs/:programId/sessions", {
+    config: { rateLimit: { max: 20, timeWindow: "1 minute" } },
+    handler: async (req, reply) => {
+      const { programId } = req.params as { programId: string };
+      const adminUserId = await resolveAdminUserId(
+        ctx.requestFn,
+        ctx.identityServiceBase,
+        req.headers as Record<string, unknown>,
+        ctx.industryAdminAllowlist
+      );
+      if (!adminUserId) {
+        return reply.status(403).send({ error: "forbidden" });
+      }
+      return proxyJsonRequest(
+        reply,
+        ctx.requestFn,
+        `${ctx.programsServiceBase}/internal/admin/programs/${encodeURIComponent(programId)}/sessions`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-admin-user-id": adminUserId
+          },
+          body: JSON.stringify(req.body ?? {})
+        }
+      );
+    }
+  });
+
+  server.post("/api/v1/admin/programs/:programId/sessions/:sessionId/attendance", {
+    config: { rateLimit: { max: 20, timeWindow: "1 minute" } },
+    handler: async (req, reply) => {
+      const { programId, sessionId } = req.params as { programId: string; sessionId: string };
+      const adminUserId = await resolveAdminUserId(
+        ctx.requestFn,
+        ctx.identityServiceBase,
+        req.headers as Record<string, unknown>,
+        ctx.industryAdminAllowlist
+      );
+      if (!adminUserId) {
+        return reply.status(403).send({ error: "forbidden" });
+      }
+      return proxyJsonRequest(
+        reply,
+        ctx.requestFn,
+        `${ctx.programsServiceBase}/internal/admin/programs/${encodeURIComponent(programId)}/sessions/${encodeURIComponent(sessionId)}/attendance`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-admin-user-id": adminUserId
+          },
+          body: JSON.stringify(req.body ?? {})
+        }
+      );
+    }
+  });
+
+  server.post("/api/v1/admin/programs/:programId/mentorship/matches", {
+    config: { rateLimit: { max: 20, timeWindow: "1 minute" } },
+    handler: async (req, reply) => {
+      const { programId } = req.params as { programId: string };
+      const adminUserId = await resolveAdminUserId(
+        ctx.requestFn,
+        ctx.identityServiceBase,
+        req.headers as Record<string, unknown>,
+        ctx.industryAdminAllowlist
+      );
+      if (!adminUserId) {
+        return reply.status(403).send({ error: "forbidden" });
+      }
+      return proxyJsonRequest(
+        reply,
+        ctx.requestFn,
+        `${ctx.programsServiceBase}/internal/admin/programs/${encodeURIComponent(programId)}/mentorship/matches`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-admin-user-id": adminUserId
+          },
+          body: JSON.stringify(req.body ?? {})
+        }
+      );
+    }
+  });
+
+  server.get("/api/v1/admin/programs/:programId/analytics", {
+    config: { rateLimit: { max: 20, timeWindow: "1 minute" } },
+    handler: async (req, reply) => {
+      const { programId } = req.params as { programId: string };
+      const adminUserId = await resolveAdminUserId(
+        ctx.requestFn,
+        ctx.identityServiceBase,
+        req.headers as Record<string, unknown>,
+        ctx.industryAdminAllowlist
+      );
+      if (!adminUserId) {
+        return reply.status(403).send({ error: "forbidden" });
+      }
+      return proxyJsonRequest(
+        reply,
+        ctx.requestFn,
+        `${ctx.programsServiceBase}/internal/admin/programs/${encodeURIComponent(programId)}/analytics`,
+        {
+          method: "GET",
+          headers: { "x-admin-user-id": adminUserId }
+        }
+      );
+    }
+  });
 }

--- a/services/programs-service/src/index.test.ts
+++ b/services/programs-service/src/index.test.ts
@@ -2,15 +2,24 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type {
   Program,
+  ProgramAnalyticsSummary,
   ProgramApplication,
   ProgramApplicationCreateRequest,
-  ProgramApplicationReviewRequest
+  ProgramApplicationReviewRequest,
+  ProgramCohort,
+  ProgramCohortCreateRequest,
+  ProgramMentorshipMatch,
+  ProgramMentorshipMatchCreateRequest,
+  ProgramSession,
+  ProgramSessionAttendance,
+  ProgramSessionAttendanceUpsertRequest,
+  ProgramSessionCreateRequest
 } from "@script-manifest/contracts";
 import { buildServer } from "./index.js";
 import type { ProgramsRepository } from "./repository.js";
 
 class MemoryProgramsRepository implements ProgramsRepository {
-  private users = new Set<string>(["writer_01", "admin_01"]);
+  private users = new Set<string>(["writer_01", "writer_02", "mentor_01", "admin_01"]);
   private programs = new Map<string, Program>([
     [
       "program_1",
@@ -29,6 +38,10 @@ class MemoryProgramsRepository implements ProgramsRepository {
     ]
   ]);
   private applications = new Map<string, ProgramApplication>();
+  private cohorts = new Map<string, ProgramCohort>();
+  private sessions = new Map<string, ProgramSession>();
+  private attendance = new Map<string, ProgramSessionAttendance>();
+  private mentorship = new Map<string, ProgramMentorshipMatch>();
 
   async init(): Promise<void> {}
 
@@ -110,37 +123,185 @@ class MemoryProgramsRepository implements ProgramsRepository {
     this.applications.set(`${programId}:${found.userId}`, next);
     return next;
   }
+
+  async listProgramCohorts(programId: string): Promise<ProgramCohort[]> {
+    return [...this.cohorts.values()].filter((cohort) => cohort.programId === programId);
+  }
+
+  async createProgramCohort(
+    programId: string,
+    adminUserId: string,
+    input: ProgramCohortCreateRequest
+  ): Promise<ProgramCohort | null> {
+    if (!this.users.has(adminUserId) || !this.programs.has(programId)) {
+      return null;
+    }
+    const now = new Date().toISOString();
+    const cohort: ProgramCohort = {
+      id: `program_cohort_${this.cohorts.size + 1}`,
+      programId,
+      name: input.name,
+      summary: input.summary,
+      startAt: input.startAt,
+      endAt: input.endAt,
+      capacity: input.capacity ?? null,
+      createdByUserId: adminUserId,
+      createdAt: now,
+      updatedAt: now
+    };
+    this.cohorts.set(cohort.id, cohort);
+    return cohort;
+  }
+
+  async createProgramSession(
+    programId: string,
+    adminUserId: string,
+    input: ProgramSessionCreateRequest
+  ): Promise<ProgramSession | null> {
+    if (!this.users.has(adminUserId) || !this.programs.has(programId)) {
+      return null;
+    }
+    const now = new Date().toISOString();
+    const session: ProgramSession = {
+      id: `program_session_${this.sessions.size + 1}`,
+      programId,
+      cohortId: input.cohortId ?? null,
+      title: input.title,
+      description: input.description,
+      sessionType: input.sessionType,
+      startsAt: input.startsAt,
+      endsAt: input.endsAt,
+      provider: input.provider,
+      meetingUrl: input.meetingUrl ?? null,
+      createdByUserId: adminUserId,
+      createdAt: now,
+      updatedAt: now
+    };
+    this.sessions.set(session.id, session);
+    for (const userId of input.attendeeUserIds) {
+      const key = `${session.id}:${userId}`;
+      this.attendance.set(key, {
+        sessionId: session.id,
+        userId,
+        status: "invited",
+        notes: "",
+        markedByUserId: null,
+        markedAt: null,
+        createdAt: now,
+        updatedAt: now
+      });
+    }
+    return session;
+  }
+
+  async upsertSessionAttendance(
+    programId: string,
+    sessionId: string,
+    adminUserId: string,
+    input: ProgramSessionAttendanceUpsertRequest
+  ): Promise<ProgramSessionAttendance | null> {
+    const session = this.sessions.get(sessionId);
+    if (!session || session.programId !== programId || !this.users.has(adminUserId) || !this.users.has(input.userId)) {
+      return null;
+    }
+    const now = new Date().toISOString();
+    const key = `${sessionId}:${input.userId}`;
+    const existing = this.attendance.get(key);
+    const next: ProgramSessionAttendance = {
+      sessionId,
+      userId: input.userId,
+      status: input.status,
+      notes: input.notes,
+      markedByUserId: adminUserId,
+      markedAt: now,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now
+    };
+    this.attendance.set(key, next);
+    return next;
+  }
+
+  async createMentorshipMatches(
+    programId: string,
+    adminUserId: string,
+    input: ProgramMentorshipMatchCreateRequest
+  ): Promise<ProgramMentorshipMatch[] | null> {
+    if (!this.users.has(adminUserId) || !this.programs.has(programId)) {
+      return null;
+    }
+    const now = new Date().toISOString();
+    const created: ProgramMentorshipMatch[] = [];
+    for (const match of input.matches) {
+      if (!this.users.has(match.mentorUserId) || !this.users.has(match.menteeUserId)) {
+        return null;
+      }
+      const next: ProgramMentorshipMatch = {
+        id: `program_mentorship_${this.mentorship.size + 1}`,
+        programId,
+        cohortId: input.cohortId ?? null,
+        mentorUserId: match.mentorUserId,
+        menteeUserId: match.menteeUserId,
+        status: "active",
+        notes: match.notes,
+        createdByUserId: adminUserId,
+        createdAt: now,
+        updatedAt: now
+      };
+      this.mentorship.set(next.id, next);
+      created.push(next);
+    }
+    return created;
+  }
+
+  async getProgramAnalytics(programId: string): Promise<ProgramAnalyticsSummary | null> {
+    if (!this.programs.has(programId)) {
+      return null;
+    }
+    const applications = [...this.applications.values()].filter((app) => app.programId === programId);
+    const cohorts = [...this.cohorts.values()].filter((cohort) => cohort.programId === programId);
+    const sessions = [...this.sessions.values()].filter((session) => session.programId === programId);
+    const attendance = [...this.attendance.values()].filter((entry) =>
+      sessions.some((session) => session.id === entry.sessionId)
+    );
+    const mentorship = [...this.mentorship.values()].filter((entry) => entry.programId === programId);
+
+    const invited = attendance.length;
+    const attended = attendance.filter((entry) => entry.status === "attended").length;
+
+    return {
+      applicationsSubmitted: applications.length,
+      applicationsUnderReview: applications.filter((app) => app.status === "under_review").length,
+      applicationsAccepted: applications.filter((app) => app.status === "accepted").length,
+      applicationsWaitlisted: applications.filter((app) => app.status === "waitlisted").length,
+      applicationsRejected: applications.filter((app) => app.status === "rejected").length,
+      cohortsTotal: cohorts.length,
+      cohortMembersActive: applications.filter((app) => app.status === "accepted").length,
+      sessionsScheduled: sessions.length,
+      sessionsCompleted: sessions.filter((session) => new Date(session.endsAt).getTime() < Date.now()).length,
+      attendanceInvited: invited,
+      attendanceMarked: attendance.filter((entry) => entry.status !== "invited").length,
+      attendanceAttended: attended,
+      attendanceRate: invited > 0 ? attended / invited : 0,
+      mentorshipMatchesActive: mentorship.filter((entry) => entry.status === "active").length,
+      mentorshipMatchesCompleted: mentorship.filter((entry) => entry.status === "completed").length
+    };
+  }
 }
 
-test("programs service lists programs and supports apply/review flow", async (t) => {
+test("programs service supports application, cohorts, sessions, mentorship and analytics flows", async (t) => {
   const server = buildServer({ logger: false, repository: new MemoryProgramsRepository() });
   t.after(async () => {
     await server.close();
   });
 
-  const list = await server.inject({
-    method: "GET",
-    url: "/internal/programs?status=open"
-  });
-  assert.equal(list.statusCode, 200);
-  assert.equal(list.json().programs.length, 1);
-
-  const applied = await server.inject({
+  const apply = await server.inject({
     method: "POST",
     url: "/internal/programs/program_1/applications",
     headers: { "x-auth-user-id": "writer_01" },
     payload: { statement: "I want to join the program.", sampleProjectId: "project_01" }
   });
-  assert.equal(applied.statusCode, 201);
-  const applicationId = applied.json().application.id as string;
-
-  const mine = await server.inject({
-    method: "GET",
-    url: "/internal/programs/program_1/applications/me",
-    headers: { "x-auth-user-id": "writer_01" }
-  });
-  assert.equal(mine.statusCode, 200);
-  assert.equal(mine.json().applications.length, 1);
+  assert.equal(apply.statusCode, 201);
+  const applicationId = apply.json().application.id as string;
 
   const reviewed = await server.inject({
     method: "POST",
@@ -150,4 +311,66 @@ test("programs service lists programs and supports apply/review flow", async (t)
   });
   assert.equal(reviewed.statusCode, 200);
   assert.equal(reviewed.json().application.status, "accepted");
+
+  const cohort = await server.inject({
+    method: "POST",
+    url: "/internal/admin/programs/program_1/cohorts",
+    headers: { "x-admin-user-id": "admin_01" },
+    payload: {
+      name: "Cohort A",
+      startAt: "2026-06-01T00:00:00.000Z",
+      endAt: "2026-08-01T00:00:00.000Z",
+      memberApplicationIds: [applicationId]
+    }
+  });
+  assert.equal(cohort.statusCode, 201);
+  const cohortId = cohort.json().cohort.id as string;
+
+  const session = await server.inject({
+    method: "POST",
+    url: "/internal/admin/programs/program_1/sessions",
+    headers: { "x-admin-user-id": "admin_01" },
+    payload: {
+      cohortId,
+      title: "Live Workshop",
+      startsAt: "2026-06-15T17:00:00.000Z",
+      endsAt: "2026-06-15T18:00:00.000Z",
+      attendeeUserIds: ["writer_01"]
+    }
+  });
+  assert.equal(session.statusCode, 201);
+  const sessionId = session.json().session.id as string;
+
+  const attendance = await server.inject({
+    method: "POST",
+    url: `/internal/admin/programs/program_1/sessions/${sessionId}/attendance`,
+    headers: { "x-admin-user-id": "admin_01" },
+    payload: {
+      userId: "writer_01",
+      status: "attended",
+      notes: "Strong engagement"
+    }
+  });
+  assert.equal(attendance.statusCode, 200);
+  assert.equal(attendance.json().attendance.status, "attended");
+
+  const mentorship = await server.inject({
+    method: "POST",
+    url: "/internal/admin/programs/program_1/mentorship/matches",
+    headers: { "x-admin-user-id": "admin_01" },
+    payload: {
+      cohortId,
+      matches: [{ mentorUserId: "mentor_01", menteeUserId: "writer_01", notes: "Pilot mentorship" }]
+    }
+  });
+  assert.equal(mentorship.statusCode, 201);
+  assert.equal(mentorship.json().matches.length, 1);
+
+  const analytics = await server.inject({
+    method: "GET",
+    url: "/internal/admin/programs/program_1/analytics",
+    headers: { "x-admin-user-id": "admin_01" }
+  });
+  assert.equal(analytics.statusCode, 200);
+  assert.equal(analytics.json().summary.applicationsAccepted, 1);
 });

--- a/services/programs-service/src/repository.ts
+++ b/services/programs-service/src/repository.ts
@@ -1,13 +1,31 @@
 import { randomUUID } from "node:crypto";
 import {
+  ProgramAnalyticsSummarySchema,
+  type ProgramAnalyticsSummary,
   ProgramApplicationCreateRequestSchema,
   type ProgramApplicationCreateRequest,
   ProgramApplicationReviewRequestSchema,
   type ProgramApplicationReviewRequest,
   ProgramApplicationSchema,
   type ProgramApplication,
+  ProgramCohortCreateRequestSchema,
+  type ProgramCohortCreateRequest,
+  ProgramCohortSchema,
+  type ProgramCohort,
+  ProgramMentorshipMatchCreateRequestSchema,
+  type ProgramMentorshipMatchCreateRequest,
+  ProgramMentorshipMatchSchema,
+  type ProgramMentorshipMatch,
   ProgramSchema,
-  type Program
+  type Program,
+  ProgramSessionAttendanceSchema,
+  type ProgramSessionAttendance,
+  ProgramSessionAttendanceUpsertRequestSchema,
+  type ProgramSessionAttendanceUpsertRequest,
+  ProgramSessionCreateRequestSchema,
+  type ProgramSessionCreateRequest,
+  ProgramSessionSchema,
+  type ProgramSession
 } from "@script-manifest/contracts";
 import { ensureCoreTables, ensureProgramsTables, getPool } from "@script-manifest/db";
 
@@ -28,6 +46,29 @@ export interface ProgramsRepository {
     reviewerUserId: string,
     input: ProgramApplicationReviewRequest
   ): Promise<ProgramApplication | null>;
+  listProgramCohorts(programId: string): Promise<ProgramCohort[]>;
+  createProgramCohort(
+    programId: string,
+    adminUserId: string,
+    input: ProgramCohortCreateRequest
+  ): Promise<ProgramCohort | null>;
+  createProgramSession(
+    programId: string,
+    adminUserId: string,
+    input: ProgramSessionCreateRequest
+  ): Promise<ProgramSession | null>;
+  upsertSessionAttendance(
+    programId: string,
+    sessionId: string,
+    adminUserId: string,
+    input: ProgramSessionAttendanceUpsertRequest
+  ): Promise<ProgramSessionAttendance | null>;
+  createMentorshipMatches(
+    programId: string,
+    adminUserId: string,
+    input: ProgramMentorshipMatchCreateRequest
+  ): Promise<ProgramMentorshipMatch[] | null>;
+  getProgramAnalytics(programId: string): Promise<ProgramAnalyticsSummary | null>;
 }
 
 function mapProgram(row: Record<string, unknown>): Program {
@@ -60,6 +101,94 @@ function mapApplication(row: Record<string, unknown>): ProgramApplication {
     createdAt: new Date(String(row.created_at)).toISOString(),
     updatedAt: new Date(String(row.updated_at)).toISOString()
   });
+}
+
+function mapCohort(row: Record<string, unknown>): ProgramCohort {
+  return ProgramCohortSchema.parse({
+    id: row.id,
+    programId: row.program_id,
+    name: row.name,
+    summary: row.summary ?? "",
+    startAt: new Date(String(row.start_at)).toISOString(),
+    endAt: new Date(String(row.end_at)).toISOString(),
+    capacity: typeof row.capacity === "number" ? row.capacity : null,
+    createdByUserId: row.created_by_user_id,
+    createdAt: new Date(String(row.created_at)).toISOString(),
+    updatedAt: new Date(String(row.updated_at)).toISOString()
+  });
+}
+
+function mapSession(row: Record<string, unknown>): ProgramSession {
+  return ProgramSessionSchema.parse({
+    id: row.id,
+    programId: row.program_id,
+    cohortId: typeof row.cohort_id === "string" ? row.cohort_id : null,
+    title: row.title,
+    description: row.description ?? "",
+    sessionType: row.session_type,
+    startsAt: new Date(String(row.starts_at)).toISOString(),
+    endsAt: new Date(String(row.ends_at)).toISOString(),
+    provider: row.provider ?? "",
+    meetingUrl: typeof row.meeting_url === "string" ? row.meeting_url : null,
+    createdByUserId: row.created_by_user_id,
+    createdAt: new Date(String(row.created_at)).toISOString(),
+    updatedAt: new Date(String(row.updated_at)).toISOString()
+  });
+}
+
+function mapAttendance(row: Record<string, unknown>): ProgramSessionAttendance {
+  return ProgramSessionAttendanceSchema.parse({
+    sessionId: row.session_id,
+    userId: row.user_id,
+    status: row.status,
+    notes: row.notes ?? "",
+    markedByUserId: typeof row.marked_by_user_id === "string" ? row.marked_by_user_id : null,
+    markedAt: row.marked_at ? new Date(String(row.marked_at)).toISOString() : null,
+    createdAt: new Date(String(row.created_at)).toISOString(),
+    updatedAt: new Date(String(row.updated_at)).toISOString()
+  });
+}
+
+function mapMentorshipMatch(row: Record<string, unknown>): ProgramMentorshipMatch {
+  return ProgramMentorshipMatchSchema.parse({
+    id: row.id,
+    programId: row.program_id,
+    cohortId: typeof row.cohort_id === "string" ? row.cohort_id : null,
+    mentorUserId: row.mentor_user_id,
+    menteeUserId: row.mentee_user_id,
+    status: row.status,
+    notes: row.notes ?? "",
+    createdByUserId: row.created_by_user_id,
+    createdAt: new Date(String(row.created_at)).toISOString(),
+    updatedAt: new Date(String(row.updated_at)).toISOString()
+  });
+}
+
+async function ensureUserExists(userId: string): Promise<boolean> {
+  const db = getPool();
+  const result = await db.query("SELECT 1 FROM app_users WHERE id = $1 LIMIT 1", [userId]);
+  return (result.rowCount ?? 0) > 0;
+}
+
+async function ensureProgramOpen(programId: string): Promise<boolean> {
+  const db = getPool();
+  const programResult = await db.query(
+    `SELECT 1
+       FROM programs
+      WHERE id = $1
+        AND status = 'open'
+        AND application_opens_at <= NOW()
+        AND application_closes_at >= NOW()
+      LIMIT 1`,
+    [programId]
+  );
+  return (programResult.rowCount ?? 0) > 0;
+}
+
+async function ensureProgramExists(programId: string): Promise<boolean> {
+  const db = getPool();
+  const programResult = await db.query("SELECT 1 FROM programs WHERE id = $1 LIMIT 1", [programId]);
+  return (programResult.rowCount ?? 0) > 0;
 }
 
 export class PgProgramsRepository implements ProgramsRepository {
@@ -119,24 +248,15 @@ export class PgProgramsRepository implements ProgramsRepository {
     input: ProgramApplicationCreateRequest
   ): Promise<ProgramApplication | null> {
     const parsed = ProgramApplicationCreateRequestSchema.parse(input);
-    const db = getPool();
-    const [userResult, programResult] = await Promise.all([
-      db.query("SELECT 1 FROM app_users WHERE id = $1 LIMIT 1", [userId]),
-      db.query(
-        `SELECT 1
-           FROM programs
-          WHERE id = $1
-            AND status = 'open'
-            AND application_opens_at <= NOW()
-            AND application_closes_at >= NOW()
-          LIMIT 1`,
-        [programId]
-      )
+    const [userExists, programOpen] = await Promise.all([
+      ensureUserExists(userId),
+      ensureProgramOpen(programId)
     ]);
-    if ((userResult.rowCount ?? 0) < 1 || (programResult.rowCount ?? 0) < 1) {
+    if (!userExists || !programOpen) {
       return null;
     }
 
+    const db = getPool();
     const now = new Date().toISOString();
     const result = await db.query(
       `INSERT INTO program_applications (
@@ -180,12 +300,12 @@ export class PgProgramsRepository implements ProgramsRepository {
     input: ProgramApplicationReviewRequest
   ): Promise<ProgramApplication | null> {
     const parsed = ProgramApplicationReviewRequestSchema.parse(input);
-    const db = getPool();
-    const reviewerResult = await db.query("SELECT 1 FROM app_users WHERE id = $1 LIMIT 1", [reviewerUserId]);
-    if ((reviewerResult.rowCount ?? 0) < 1) {
+    const reviewerExists = await ensureUserExists(reviewerUserId);
+    if (!reviewerExists) {
       return null;
     }
 
+    const db = getPool();
     const now = new Date().toISOString();
     const result = await db.query(
       `UPDATE program_applications
@@ -213,5 +333,430 @@ export class PgProgramsRepository implements ProgramsRepository {
       return null;
     }
     return mapApplication(result.rows[0] as Record<string, unknown>);
+  }
+
+  async listProgramCohorts(programId: string): Promise<ProgramCohort[]> {
+    const db = getPool();
+    const result = await db.query(
+      `SELECT *
+         FROM program_cohorts
+        WHERE program_id = $1
+        ORDER BY start_at ASC`,
+      [programId]
+    );
+    return result.rows.map((row) => mapCohort(row as Record<string, unknown>));
+  }
+
+  async createProgramCohort(
+    programId: string,
+    adminUserId: string,
+    input: ProgramCohortCreateRequest
+  ): Promise<ProgramCohort | null> {
+    const parsed = ProgramCohortCreateRequestSchema.parse(input);
+    const [adminExists, programExists] = await Promise.all([
+      ensureUserExists(adminUserId),
+      ensureProgramExists(programId)
+    ]);
+    if (!adminExists || !programExists) {
+      return null;
+    }
+
+    const db = getPool();
+    const now = new Date().toISOString();
+    const cohortId = `program_cohort_${randomUUID()}`;
+
+    await db.query("BEGIN");
+    try {
+      const inserted = await db.query(
+        `INSERT INTO program_cohorts (
+           id,
+           program_id,
+           name,
+           summary,
+           start_at,
+           end_at,
+           capacity,
+           created_by_user_id,
+           created_at,
+           updated_at
+         ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+         RETURNING *`,
+        [
+          cohortId,
+          programId,
+          parsed.name,
+          parsed.summary,
+          parsed.startAt,
+          parsed.endAt,
+          parsed.capacity ?? null,
+          adminUserId,
+          now,
+          now
+        ]
+      );
+
+      if (parsed.memberApplicationIds.length > 0) {
+        const appRows = await db.query(
+          `SELECT id, user_id
+             FROM program_applications
+            WHERE program_id = $1
+              AND id = ANY($2::text[])`,
+          [programId, parsed.memberApplicationIds]
+        );
+
+        for (const appRow of appRows.rows as Array<Record<string, unknown>>) {
+          await db.query(
+            `INSERT INTO program_cohort_members (
+               cohort_id,
+               user_id,
+               source_application_id,
+               status,
+               created_at,
+               updated_at
+             ) VALUES ($1,$2,$3,'active',$4,$5)
+             ON CONFLICT (cohort_id, user_id)
+             DO UPDATE SET
+               source_application_id = EXCLUDED.source_application_id,
+               status = 'active',
+               updated_at = EXCLUDED.updated_at`,
+            [cohortId, appRow.user_id, appRow.id, now, now]
+          );
+        }
+      }
+
+      await db.query("COMMIT");
+      return mapCohort(inserted.rows[0] as Record<string, unknown>);
+    } catch (error) {
+      await db.query("ROLLBACK");
+      throw error;
+    }
+  }
+
+  async createProgramSession(
+    programId: string,
+    adminUserId: string,
+    input: ProgramSessionCreateRequest
+  ): Promise<ProgramSession | null> {
+    const parsed = ProgramSessionCreateRequestSchema.parse(input);
+    const [adminExists, programExists] = await Promise.all([
+      ensureUserExists(adminUserId),
+      ensureProgramExists(programId)
+    ]);
+    if (!adminExists || !programExists) {
+      return null;
+    }
+
+    const db = getPool();
+    if (parsed.cohortId) {
+      const cohortResult = await db.query(
+        "SELECT 1 FROM program_cohorts WHERE id = $1 AND program_id = $2 LIMIT 1",
+        [parsed.cohortId, programId]
+      );
+      if ((cohortResult.rowCount ?? 0) < 1) {
+        return null;
+      }
+    }
+
+    const now = new Date().toISOString();
+    const sessionId = `program_session_${randomUUID()}`;
+
+    await db.query("BEGIN");
+    try {
+      const inserted = await db.query(
+        `INSERT INTO program_sessions (
+           id,
+           program_id,
+           cohort_id,
+           title,
+           description,
+           session_type,
+           starts_at,
+           ends_at,
+           provider,
+           meeting_url,
+           created_by_user_id,
+           created_at,
+           updated_at
+         ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+         RETURNING *`,
+        [
+          sessionId,
+          programId,
+          parsed.cohortId ?? null,
+          parsed.title,
+          parsed.description,
+          parsed.sessionType,
+          parsed.startsAt,
+          parsed.endsAt,
+          parsed.provider,
+          parsed.meetingUrl ?? null,
+          adminUserId,
+          now,
+          now
+        ]
+      );
+
+      if (parsed.attendeeUserIds.length > 0) {
+        const users = await db.query(
+          "SELECT id FROM app_users WHERE id = ANY($1::text[])",
+          [parsed.attendeeUserIds]
+        );
+        for (const user of users.rows as Array<Record<string, unknown>>) {
+          await db.query(
+            `INSERT INTO program_session_attendance (
+               session_id,
+               user_id,
+               status,
+               notes,
+               marked_by_user_id,
+               marked_at,
+               created_at,
+               updated_at
+             ) VALUES ($1,$2,'invited','',NULL,NULL,$3,$4)
+             ON CONFLICT (session_id, user_id)
+             DO UPDATE SET
+               status = 'invited',
+               updated_at = EXCLUDED.updated_at`,
+            [sessionId, user.id, now, now]
+          );
+        }
+      }
+
+      await db.query("COMMIT");
+      return mapSession(inserted.rows[0] as Record<string, unknown>);
+    } catch (error) {
+      await db.query("ROLLBACK");
+      throw error;
+    }
+  }
+
+  async upsertSessionAttendance(
+    programId: string,
+    sessionId: string,
+    adminUserId: string,
+    input: ProgramSessionAttendanceUpsertRequest
+  ): Promise<ProgramSessionAttendance | null> {
+    const parsed = ProgramSessionAttendanceUpsertRequestSchema.parse(input);
+    const [adminExists, userExists] = await Promise.all([
+      ensureUserExists(adminUserId),
+      ensureUserExists(parsed.userId)
+    ]);
+    if (!adminExists || !userExists) {
+      return null;
+    }
+
+    const db = getPool();
+    const sessionResult = await db.query(
+      "SELECT 1 FROM program_sessions WHERE id = $1 AND program_id = $2 LIMIT 1",
+      [sessionId, programId]
+    );
+    if ((sessionResult.rowCount ?? 0) < 1) {
+      return null;
+    }
+
+    const now = new Date().toISOString();
+    const result = await db.query(
+      `INSERT INTO program_session_attendance (
+         session_id,
+         user_id,
+         status,
+         notes,
+         marked_by_user_id,
+         marked_at,
+         created_at,
+         updated_at
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+       ON CONFLICT (session_id, user_id)
+       DO UPDATE SET
+         status = EXCLUDED.status,
+         notes = EXCLUDED.notes,
+         marked_by_user_id = EXCLUDED.marked_by_user_id,
+         marked_at = EXCLUDED.marked_at,
+         updated_at = EXCLUDED.updated_at
+       RETURNING *`,
+      [
+        sessionId,
+        parsed.userId,
+        parsed.status,
+        parsed.notes,
+        adminUserId,
+        now,
+        now,
+        now
+      ]
+    );
+
+    return mapAttendance(result.rows[0] as Record<string, unknown>);
+  }
+
+  async createMentorshipMatches(
+    programId: string,
+    adminUserId: string,
+    input: ProgramMentorshipMatchCreateRequest
+  ): Promise<ProgramMentorshipMatch[] | null> {
+    const parsed = ProgramMentorshipMatchCreateRequestSchema.parse(input);
+    const [adminExists, programExists] = await Promise.all([
+      ensureUserExists(adminUserId),
+      ensureProgramExists(programId)
+    ]);
+    if (!adminExists || !programExists) {
+      return null;
+    }
+
+    const db = getPool();
+    if (parsed.cohortId) {
+      const cohortResult = await db.query(
+        "SELECT 1 FROM program_cohorts WHERE id = $1 AND program_id = $2 LIMIT 1",
+        [parsed.cohortId, programId]
+      );
+      if ((cohortResult.rowCount ?? 0) < 1) {
+        return null;
+      }
+    }
+
+    const userIds = [...new Set(parsed.matches.flatMap((item) => [item.mentorUserId, item.menteeUserId]))];
+    const existingUsers = await db.query("SELECT id FROM app_users WHERE id = ANY($1::text[])", [userIds]);
+    const existingSet = new Set(existingUsers.rows.map((row) => String((row as Record<string, unknown>).id)));
+    for (const userId of userIds) {
+      if (!existingSet.has(userId)) {
+        return null;
+      }
+    }
+
+    const now = new Date().toISOString();
+    const created: ProgramMentorshipMatch[] = [];
+
+    for (const match of parsed.matches) {
+      if (match.mentorUserId === match.menteeUserId) {
+        continue;
+      }
+
+      const inserted = await db.query(
+        `INSERT INTO program_mentorship_matches (
+           id,
+           program_id,
+           cohort_id,
+           mentor_user_id,
+           mentee_user_id,
+           status,
+           notes,
+           created_by_user_id,
+           created_at,
+           updated_at
+         ) VALUES ($1,$2,$3,$4,$5,'active',$6,$7,$8,$9)
+         ON CONFLICT (program_id, mentor_user_id, mentee_user_id)
+         DO UPDATE SET
+           cohort_id = EXCLUDED.cohort_id,
+           status = 'active',
+           notes = EXCLUDED.notes,
+           created_by_user_id = EXCLUDED.created_by_user_id,
+           updated_at = EXCLUDED.updated_at
+         RETURNING *`,
+        [
+          `program_mentorship_${randomUUID()}`,
+          programId,
+          parsed.cohortId ?? null,
+          match.mentorUserId,
+          match.menteeUserId,
+          match.notes,
+          adminUserId,
+          now,
+          now
+        ]
+      );
+      created.push(mapMentorshipMatch(inserted.rows[0] as Record<string, unknown>));
+    }
+
+    return created;
+  }
+
+  async getProgramAnalytics(programId: string): Promise<ProgramAnalyticsSummary | null> {
+    const programExists = await ensureProgramExists(programId);
+    if (!programExists) {
+      return null;
+    }
+
+    const db = getPool();
+    const [applications, cohorts, members, sessions, attendance, mentorship] = await Promise.all([
+      db.query(
+        `SELECT
+            COUNT(*)::int AS submitted,
+            COUNT(*) FILTER (WHERE status = 'under_review')::int AS under_review,
+            COUNT(*) FILTER (WHERE status = 'accepted')::int AS accepted,
+            COUNT(*) FILTER (WHERE status = 'waitlisted')::int AS waitlisted,
+            COUNT(*) FILTER (WHERE status = 'rejected')::int AS rejected
+         FROM program_applications
+         WHERE program_id = $1`,
+        [programId]
+      ),
+      db.query(
+        `SELECT COUNT(*)::int AS total
+         FROM program_cohorts
+         WHERE program_id = $1`,
+        [programId]
+      ),
+      db.query(
+        `SELECT COUNT(*)::int AS active_members
+         FROM program_cohort_members pcm
+         JOIN program_cohorts pc ON pc.id = pcm.cohort_id
+         WHERE pc.program_id = $1
+           AND pcm.status = 'active'`,
+        [programId]
+      ),
+      db.query(
+        `SELECT
+            COUNT(*)::int AS scheduled,
+            COUNT(*) FILTER (WHERE ends_at < NOW())::int AS completed
+         FROM program_sessions
+         WHERE program_id = $1`,
+        [programId]
+      ),
+      db.query(
+        `SELECT
+            COUNT(*)::int AS invited,
+            COUNT(*) FILTER (WHERE status <> 'invited')::int AS marked,
+            COUNT(*) FILTER (WHERE status = 'attended')::int AS attended
+         FROM program_session_attendance psa
+         JOIN program_sessions ps ON ps.id = psa.session_id
+         WHERE ps.program_id = $1`,
+        [programId]
+      ),
+      db.query(
+        `SELECT
+            COUNT(*) FILTER (WHERE status = 'active')::int AS active,
+            COUNT(*) FILTER (WHERE status = 'completed')::int AS completed
+         FROM program_mentorship_matches
+         WHERE program_id = $1`,
+        [programId]
+      )
+    ]);
+
+    const appRow = applications.rows[0] as Record<string, unknown>;
+    const cohortRow = cohorts.rows[0] as Record<string, unknown>;
+    const memberRow = members.rows[0] as Record<string, unknown>;
+    const sessionRow = sessions.rows[0] as Record<string, unknown>;
+    const attendanceRow = attendance.rows[0] as Record<string, unknown>;
+    const mentorshipRow = mentorship.rows[0] as Record<string, unknown>;
+
+    const invited = Number(attendanceRow.invited ?? 0);
+    const attended = Number(attendanceRow.attended ?? 0);
+
+    return ProgramAnalyticsSummarySchema.parse({
+      applicationsSubmitted: Number(appRow.submitted ?? 0),
+      applicationsUnderReview: Number(appRow.under_review ?? 0),
+      applicationsAccepted: Number(appRow.accepted ?? 0),
+      applicationsWaitlisted: Number(appRow.waitlisted ?? 0),
+      applicationsRejected: Number(appRow.rejected ?? 0),
+      cohortsTotal: Number(cohortRow.total ?? 0),
+      cohortMembersActive: Number(memberRow.active_members ?? 0),
+      sessionsScheduled: Number(sessionRow.scheduled ?? 0),
+      sessionsCompleted: Number(sessionRow.completed ?? 0),
+      attendanceInvited: invited,
+      attendanceMarked: Number(attendanceRow.marked ?? 0),
+      attendanceAttended: attended,
+      attendanceRate: invited > 0 ? attended / invited : 0,
+      mentorshipMatchesActive: Number(mentorshipRow.active ?? 0),
+      mentorshipMatchesCompleted: Number(mentorshipRow.completed ?? 0)
+    });
   }
 }


### PR DESCRIPTION
## Summary
- complete program operations workflows beyond kickoff
- add cohorts, session scheduling, attendance, mentorship matching, and analytics APIs
- extend contracts and DB schema for Phase 6 entities
- update compose and docker build matrix for programs-service
- refresh Phase 6 docs and operations manual

## Validation
- pnpm --filter @script-manifest/contracts build
- pnpm --filter @script-manifest/contracts test
- pnpm --filter @script-manifest/db build
- pnpm --filter @script-manifest/programs-service test
- pnpm --filter @script-manifest/api-gateway test
- docker compose -f compose.yml config -q:
