### PR TITLE
chore: add typesense, db-migrator, and search-sync-worker to staging/prod compose

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,6 +31,7 @@ jobs:
           - api-gateway
           - competition-directory-service
           - coverage-marketplace-service
+          - db-migrator
           - feedback-exchange-service
           - industry-portal-service
           - identity-service
@@ -40,6 +41,7 @@ jobs:
           - profile-project-service
           - ranking-service
           - script-storage-service
+          - search-sync-worker
           - submission-tracking-service
           - writer-web
 
@@ -113,6 +115,7 @@ jobs:
           - name: api-gateway
           - name: competition-directory-service
           - name: coverage-marketplace-service
+          - name: db-migrator
           - name: feedback-exchange-service
           - name: industry-portal-service
           - name: identity-service
@@ -122,6 +125,7 @@ jobs:
           - name: profile-project-service
           - name: ranking-service
           - name: script-storage-service
+          - name: search-sync-worker
           - name: submission-tracking-service
           - name: writer-web
 

--- a/compose.harness.yml
+++ b/compose.harness.yml
@@ -99,6 +99,12 @@ services:
     environment:
       <<: *no-telemetry
 
+  search-sync-worker:
+    ports:
+      - "127.0.0.1:4020:4020"
+    environment:
+      <<: *no-telemetry
+
   api-gateway:
     ports:
       - "127.0.0.1:4000:4000"

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -103,6 +103,25 @@ services:
           cpus: '1.0'
           memory: 1G
 
+  typesense:
+    <<: *service-defaults
+    image: typesense/typesense:28.0
+    command:
+      - --data-dir=/data
+      - --api-key=${TYPESENSE_API_KEY:?TYPESENSE_API_KEY is required}
+      - --enable-cors
+    volumes:
+      - typesense_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c ':> /dev/tcp/127.0.0.1/8108' || exit 1"]
+      <<: *healthcheck
+    networks: [internal]
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1G
+
   traefik:
     <<: *service-defaults
     image: traefik:v3.3
@@ -197,6 +216,18 @@ services:
 
   # ── Backend Services ─────────────────────────────────────────────────
 
+  db-migrator:
+    <<: *service-defaults
+    image: ghcr.io/full-chaos/script-manifest/db-migrator:${IMAGE_TAG:?IMAGE_TAG is required}
+    environment:
+      NODE_ENV: production
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
+    restart: "no"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks: [internal]
+
   notification-service:
     <<: *service-defaults
     image: ghcr.io/full-chaos/script-manifest/notification-service:${IMAGE_TAG:?IMAGE_TAG is required}
@@ -232,6 +263,8 @@ services:
       EMAIL_FROM: ${EMAIL_FROM:-"Script Manifest <noreply@scriptmanifest.com>"}
       FRONTEND_URL: ${FRONTEND_URL:?FRONTEND_URL is required for email links}
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
     healthcheck:
@@ -253,10 +286,18 @@ services:
       DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"
       KAFKA_BROKERS: "redpanda:9092"
+      TYPESENSE_API_KEY: ${TYPESENSE_API_KEY:?TYPESENSE_API_KEY is required}
+      TYPESENSE_HOST: "typesense"
+      TYPESENSE_PORT: "8108"
+      TYPESENSE_PROTOCOL: "http"
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       notification-service:
+        condition: service_healthy
+      typesense:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:4001/health || exit 1"]
@@ -274,10 +315,22 @@ services:
     environment:
       PORT: "4002"
       NODE_ENV: production
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"
       KAFKA_BROKERS: "redpanda:9092"
+      TYPESENSE_API_KEY: ${TYPESENSE_API_KEY:?TYPESENSE_API_KEY is required}
+      TYPESENSE_HOST: "typesense"
+      TYPESENSE_PORT: "8108"
+      TYPESENSE_PROTOCOL: "http"
+      TYPESENSE_ENABLED: "true"
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
       notification-service:
+        condition: service_healthy
+      typesense:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:4002/health || exit 1"]
@@ -295,6 +348,7 @@ services:
     environment:
       PORT: "4011"
       NODE_ENV: production
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
       STORAGE_BUCKET: "scripts"
       # Browser-reachable URL for upload forms - MUST be externally accessible
       STORAGE_UPLOAD_BASE_URL: ${STORAGE_UPLOAD_BASE_URL:-http://localhost:9000}
@@ -306,6 +360,10 @@ services:
       STORAGE_S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
       STORAGE_S3_FORCE_PATH_STYLE: ${STORAGE_S3_FORCE_PATH_STYLE:-true}
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
       minio:
         condition: service_healthy
     healthcheck:
@@ -324,6 +382,12 @@ services:
     environment:
       PORT: "4004"
       NODE_ENV: production
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
+    depends_on:
+      db-migrator:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:4004/health || exit 1"]
       <<: *healthcheck
@@ -344,6 +408,8 @@ services:
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"
       KAFKA_BROKERS: "redpanda:9092"
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       notification-service:
@@ -371,6 +437,8 @@ services:
       COMPETITION_DIRECTORY_SERVICE_URL: "http://competition-directory-service:4002"
       PROFILE_SERVICE_URL: "http://profile-project-service:4001"
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       notification-service:
@@ -399,6 +467,8 @@ services:
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"
       KAFKA_BROKERS: "redpanda:9092"
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       notification-service:
@@ -424,6 +494,8 @@ services:
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"
       KAFKA_BROKERS: "redpanda:9092"
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       ranking-service:
@@ -526,6 +598,8 @@ services:
       STORAGE_BUCKET: "coverage-reports"
       FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3000}
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       notification-service:
@@ -552,15 +626,55 @@ services:
       SCRIPT_STORAGE_SERVICE_URL: "http://script-storage-service:4011"
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"
       KAFKA_BROKERS: "redpanda:9092"
+      TYPESENSE_API_KEY: ${TYPESENSE_API_KEY:?TYPESENSE_API_KEY is required}
+      TYPESENSE_HOST: "typesense"
+      TYPESENSE_PORT: "8108"
+      TYPESENSE_PROTOCOL: "http"
+      TYPESENSE_ENABLED: "true"
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       script-storage-service:
         condition: service_healthy
       notification-service:
         condition: service_healthy
+      typesense:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:4009/health || exit 1"]
+      <<: *healthcheck
+    networks: [internal]
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+
+  search-sync-worker:
+    <<: *service-defaults
+    image: ghcr.io/full-chaos/script-manifest/search-sync-worker:${IMAGE_TAG:?IMAGE_TAG is required}
+    environment:
+      PORT: "4020"
+      NODE_ENV: production
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
+      KAFKA_BROKERS: "redpanda:9092"
+      TYPESENSE_API_KEY: ${TYPESENSE_API_KEY:?TYPESENSE_API_KEY is required}
+      TYPESENSE_HOST: "typesense"
+      TYPESENSE_PORT: "8108"
+      TYPESENSE_PROTOCOL: "http"
+    depends_on:
+      db-migrator:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      typesense:
+        condition: service_healthy
+      redpanda:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:4020/health || exit 1"]
       <<: *healthcheck
     networks: [internal]
     deploy:
@@ -611,6 +725,7 @@ volumes:
   postgres_data:
   minio_data:
   traefik_certs:
+  typesense_data:
 
 networks:
   public:

--- a/compose.stage.yml
+++ b/compose.stage.yml
@@ -90,7 +90,39 @@ services:
           cpus: '1.0'
           memory: 1G
 
+  typesense:
+    <<: *service-defaults
+    image: typesense/typesense:28.0
+    command:
+      - --data-dir=/data
+      - --api-key=${TYPESENSE_API_KEY:?TYPESENSE_API_KEY is required}
+      - --enable-cors
+    volumes:
+      - typesense_data:/data
+    healthcheck:
+      test: [ "CMD-SHELL", "bash -c ':> /dev/tcp/127.0.0.1/8108' || exit 1" ]
+      <<: *healthcheck
+    networks: [ internal ]
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+
   # ── Backend Services ─────────────────────────────────────────────────
+
+  db-migrator:
+    <<: *service-defaults
+    image: ghcr.io/full-chaos/script-manifest/db-migrator:${IMAGE_TAG:-latest}
+    environment:
+      NODE_ENV: production
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
+    restart: "no"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks: [ internal ]
+
   traefik:
     <<: *service-defaults
     image: traefik:v3.3
@@ -152,6 +184,8 @@ services:
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
     healthcheck:
@@ -172,10 +206,19 @@ services:
       NODE_ENV: production
       DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"
+      KAFKA_BROKERS: "redpanda:9092"
+      TYPESENSE_API_KEY: ${TYPESENSE_API_KEY:?TYPESENSE_API_KEY is required}
+      TYPESENSE_HOST: "typesense"
+      TYPESENSE_PORT: "8108"
+      TYPESENSE_PROTOCOL: "http"
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       notification-service:
+        condition: service_healthy
+      typesense:
         condition: service_healthy
     healthcheck:
       test: [ "CMD-SHELL", "curl -sf http://localhost:4001/health || exit 1" ]
@@ -193,9 +236,22 @@ services:
     environment:
       PORT: "4002"
       NODE_ENV: production
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"
+      KAFKA_BROKERS: "redpanda:9092"
+      TYPESENSE_API_KEY: ${TYPESENSE_API_KEY:?TYPESENSE_API_KEY is required}
+      TYPESENSE_HOST: "typesense"
+      TYPESENSE_PORT: "8108"
+      TYPESENSE_PROTOCOL: "http"
+      TYPESENSE_ENABLED: "true"
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
       notification-service:
+        condition: service_healthy
+      typesense:
         condition: service_healthy
     healthcheck:
       test: [ "CMD-SHELL", "curl -sf http://localhost:4002/health || exit 1" ]
@@ -213,6 +269,7 @@ services:
     environment:
       PORT: "4011"
       NODE_ENV: production
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
       STORAGE_BUCKET: "scripts"
       # Browser-reachable URL for upload forms - MUST be externally accessible
       STORAGE_UPLOAD_BASE_URL: ${STORAGE_UPLOAD_BASE_URL:-http://localhost:9000}
@@ -224,6 +281,10 @@ services:
       STORAGE_S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
       STORAGE_S3_FORCE_PATH_STYLE: ${STORAGE_S3_FORCE_PATH_STYLE:-true}
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
       minio:
         condition: service_healthy
     healthcheck:
@@ -242,6 +303,12 @@ services:
     environment:
       PORT: "4004"
       NODE_ENV: production
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
+    depends_on:
+      db-migrator:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
     healthcheck:
       test: [ "CMD-SHELL", "curl -sf http://localhost:4004/health || exit 1" ]
       <<: *healthcheck
@@ -262,6 +329,8 @@ services:
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"
       KAFKA_BROKERS: "redpanda:9092"
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       notification-service:
@@ -289,6 +358,8 @@ services:
       COMPETITION_DIRECTORY_SERVICE_URL: "http://competition-directory-service:4002"
       PROFILE_SERVICE_URL: "http://profile-project-service:4001"
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       notification-service:
@@ -317,6 +388,8 @@ services:
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"
       KAFKA_BROKERS: "redpanda:9092"
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       notification-service:
@@ -341,6 +414,8 @@ services:
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"
       KAFKA_BROKERS: "redpanda:9092"
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       ranking-service:
@@ -440,6 +515,8 @@ services:
       STORAGE_BUCKET: "coverage-reports"
       FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3000}
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       notification-service:
@@ -466,15 +543,55 @@ services:
       SCRIPT_STORAGE_SERVICE_URL: "http://script-storage-service:4011"
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"
       KAFKA_BROKERS: "redpanda:9092"
+      TYPESENSE_API_KEY: ${TYPESENSE_API_KEY:?TYPESENSE_API_KEY is required}
+      TYPESENSE_HOST: "typesense"
+      TYPESENSE_PORT: "8108"
+      TYPESENSE_PROTOCOL: "http"
+      TYPESENSE_ENABLED: "true"
     depends_on:
+      db-migrator:
+        condition: service_completed_successfully
       postgres:
         condition: service_healthy
       script-storage-service:
         condition: service_healthy
       notification-service:
         condition: service_healthy
+      typesense:
+        condition: service_healthy
     healthcheck:
       test: [ "CMD-SHELL", "curl -sf http://localhost:4009/health || exit 1" ]
+      <<: *healthcheck
+    networks: [ internal ]
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+
+  search-sync-worker:
+    <<: *service-defaults
+    image: ghcr.io/full-chaos/script-manifest/search-sync-worker:${IMAGE_TAG:-latest}
+    environment:
+      PORT: "4020"
+      NODE_ENV: production
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
+      KAFKA_BROKERS: "redpanda:9092"
+      TYPESENSE_API_KEY: ${TYPESENSE_API_KEY:?TYPESENSE_API_KEY is required}
+      TYPESENSE_HOST: "typesense"
+      TYPESENSE_PORT: "8108"
+      TYPESENSE_PROTOCOL: "http"
+    depends_on:
+      db-migrator:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      typesense:
+        condition: service_healthy
+      redpanda:
+        condition: service_started
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -sf http://localhost:4020/health || exit 1" ]
       <<: *healthcheck
     networks: [ internal ]
     deploy:
@@ -519,6 +636,7 @@ volumes:
   postgres_data:
   minio_data:
   traefik_certs:
+  typesense_data:
 
 
 networks:

--- a/compose.yml
+++ b/compose.yml
@@ -13,9 +13,11 @@ x-node-dev: &node-dev
 
 x-telemetry-env: &telemetry-env
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://signoz-collection-agent:4317"
+  LOG_LEVEL: "debug"
 
 x-external-schema-init: &external-schema-init
   SKIP_SCHEMA_INIT: "1"
+  TYPESENSE_ENABLED: true
 
 networks:
   public:

--- a/deploy/helm/script-manifest/values.yaml
+++ b/deploy/helm/script-manifest/values.yaml
@@ -16,3 +16,6 @@ redis:
 
 notification-service:
   enabled: true
+
+search-sync-worker:
+  enabled: true

--- a/deploy/swarm/stack.staging.yml
+++ b/deploy/swarm/stack.staging.yml
@@ -100,6 +100,17 @@ services:
           cpus: '0.25'
           memory: 256M
 
+  db-migrator:
+    image: ghcr.io/full-chaos/script-manifest/db-migrator:latest
+
+  search-sync-worker:
+    image: ghcr.io/full-chaos/script-manifest/search-sync-worker:latest
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 256M
+
   # ── Gateway & Frontend — staging domains ───────────────────────────
 
   api-gateway:

--- a/deploy/swarm/stack.yml
+++ b/deploy/swarm/stack.yml
@@ -122,6 +122,25 @@ services:
           cpus: '1.0'
           memory: 1G
 
+  typesense:
+    image: typesense/typesense:28.0
+    command:
+      - --data-dir=/data
+      - --api-key=${TYPESENSE_API_KEY:?TYPESENSE_API_KEY is required}
+      - --enable-cors
+    volumes:
+      - typesense_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c ':> /dev/tcp/127.0.0.1/8108' || exit 1"]
+      <<: *healthcheck
+    networks: [internal]
+    deploy:
+      <<: *deploy-infra
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1G
+
   traefik:
     image: traefik:v3.3
     ports:
@@ -189,6 +208,18 @@ services:
 
   # ── Backend Services ───────────────────────────────────────────────
 
+  db-migrator:
+    image: ghcr.io/full-chaos/script-manifest/db-migrator:${IMAGE_TAG:?IMAGE_TAG is required}
+    env_file: ./.env
+    environment:
+      NODE_ENV: production
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
+    networks: [internal]
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: none
+
   notification-service:
     image: ghcr.io/full-chaos/script-manifest/notification-service:${IMAGE_TAG:?IMAGE_TAG is required}
     env_file: ./.env
@@ -241,6 +272,10 @@ services:
       DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"
       KAFKA_BROKERS: "redpanda:9092"
+      TYPESENSE_API_KEY: ${TYPESENSE_API_KEY:?TYPESENSE_API_KEY is required}
+      TYPESENSE_HOST: "typesense"
+      TYPESENSE_PORT: "8108"
+      TYPESENSE_PROTOCOL: "http"
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:4001/health || exit 1"]
       <<: *healthcheck
@@ -258,8 +293,14 @@ services:
     environment:
       PORT: "4002"
       NODE_ENV: production
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"
       KAFKA_BROKERS: "redpanda:9092"
+      TYPESENSE_API_KEY: ${TYPESENSE_API_KEY:?TYPESENSE_API_KEY is required}
+      TYPESENSE_HOST: "typesense"
+      TYPESENSE_PORT: "8108"
+      TYPESENSE_PROTOCOL: "http"
+      TYPESENSE_ENABLED: "true"
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:4002/health || exit 1"]
       <<: *healthcheck
@@ -395,6 +436,11 @@ services:
       SCRIPT_STORAGE_SERVICE_URL: "http://script-storage-service:4011"
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"
       KAFKA_BROKERS: "redpanda:9092"
+      TYPESENSE_API_KEY: ${TYPESENSE_API_KEY:?TYPESENSE_API_KEY is required}
+      TYPESENSE_HOST: "typesense"
+      TYPESENSE_PORT: "8108"
+      TYPESENSE_PROTOCOL: "http"
+      TYPESENSE_ENABLED: "true"
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:4009/health || exit 1"]
       <<: *healthcheck
@@ -438,6 +484,29 @@ services:
       KAFKA_BROKERS: "redpanda:9092"
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:4013/health || exit 1"]
+      <<: *healthcheck
+    networks: [internal]
+    deploy:
+      <<: *deploy-service
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+
+  search-sync-worker:
+    image: ghcr.io/full-chaos/script-manifest/search-sync-worker:${IMAGE_TAG:?IMAGE_TAG is required}
+    env_file: ./.env
+    environment:
+      PORT: "4020"
+      NODE_ENV: production
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
+      KAFKA_BROKERS: "redpanda:9092"
+      TYPESENSE_API_KEY: ${TYPESENSE_API_KEY:?TYPESENSE_API_KEY is required}
+      TYPESENSE_HOST: "typesense"
+      TYPESENSE_PORT: "8108"
+      TYPESENSE_PROTOCOL: "http"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:4020/health || exit 1"]
       <<: *healthcheck
     networks: [internal]
     deploy:
@@ -518,6 +587,7 @@ volumes:
   postgres_data:
   minio_data:
   traefik_certs:
+  typesense_data:
 
 networks:
   public:

--- a/scripts/compose-integration-harness.sh
+++ b/scripts/compose-integration-harness.sh
@@ -28,6 +28,7 @@ SERVICES=(
   partner-dashboard-service
   industry-portal-service
   script-storage-service
+  search-sync-worker
   api-gateway
 )
 
@@ -45,6 +46,7 @@ HEALTH_ENDPOINTS=(
   "http://localhost:4011/health"
   "http://localhost:4012/health"
   "http://localhost:4013/health"
+  "http://localhost:4020/health/live"
 )
 
 run_compose() {


### PR DESCRIPTION
## Summary

- Adds **typesense** (v28.0), **db-migrator** (one-shot GHCR image), and **search-sync-worker** services to both `compose.stage.yml` and `compose.prod.yml`
- Adds `db-migrator: service_completed_successfully` dependency to all database-dependent services so migrations complete before any service reads the DB
- Adds Typesense env vars (`TYPESENSE_API_KEY`, `HOST`, `PORT`, `PROTOCOL`, `ENABLED`) and `typesense: service_healthy` dependency to `profile-project-service`, `competition-directory-service`, and `industry-portal-service`
- Backfills missing `DATABASE_URL` on `competition-directory-service`, `submission-tracking-service`, and `script-storage-service` in both stage/prod (was present in dev compose but absent)
- Adds `typesense_data` named volume to both files

## New env vars required in `.env`

| Variable | Required | Notes |
|---|---|---|
| `TYPESENSE_API_KEY` | Yes | API key for Typesense (shared across all services) |

## Checklist

- [x] Both files pass `docker compose config` validation
- [x] Service dependency graph matches dev compose
- [x] `db-migrator` uses `restart: "no"` (one-shot)
- [x] Staging uses `IMAGE_TAG:-latest`, prod uses `IMAGE_TAG:?required`