### PR TITLE
fix: add dedicated db-migrator Dockerfile for CI builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,11 +68,11 @@ jobs:
       - name: Resolve Dockerfile
         id: dockerfile
         run: |
-          if [ "${{ matrix.name }}" = "writer-web" ]; then
-            echo "path=infra/docker/frontend.Dockerfile" >> "$GITHUB_OUTPUT"
-          else
-            echo "path=infra/docker/service.Dockerfile" >> "$GITHUB_OUTPUT"
-          fi
+          case "${{ matrix.name }}" in
+            writer-web)    echo "path=infra/docker/frontend.Dockerfile" >> "$GITHUB_OUTPUT" ;;
+            db-migrator)   echo "path=infra/docker/db-migrator.Dockerfile" >> "$GITHUB_OUTPUT" ;;
+            *)             echo "path=infra/docker/service.Dockerfile" >> "$GITHUB_OUTPUT" ;;
+          esac
 
       - name: Build and push
         id: build

--- a/infra/docker/db-migrator.Dockerfile
+++ b/infra/docker/db-migrator.Dockerfile
@@ -1,0 +1,76 @@
+# syntax=docker/dockerfile:1.7
+
+# Dedicated Dockerfile for the db-migrator one-shot container.
+#
+# Unlike service.Dockerfile (which uses turbo prune for a single service),
+# the migration script imports repositories from EVERY service to run
+# schema init across the entire database. A turbo prune would pull in
+# the whole monorepo anyway, so we skip it and install directly.
+
+# ── Stage 1: Install deps & build ─────────────────────────────────────
+FROM node:25-alpine AS builder
+ENV NPM_CONFIG_REGISTRY=https://registry.npmjs.org/ \
+    NPM_CONFIG_FETCH_RETRIES=5 \
+    NPM_CONFIG_FETCH_RETRY_FACTOR=2 \
+    NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=10000 \
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000
+RUN for attempt in 1 2 3 4 5; do \
+      npm install -g pnpm@10.31.0 && exit 0; \
+      echo "pnpm install failed (attempt ${attempt}), retrying..."; \
+      sleep $((attempt * 5)); \
+    done; \
+    exit 1
+WORKDIR /app
+COPY . .
+RUN --mount=type=cache,id=pnpm-store-db-migrator,target=/pnpm/store,sharing=locked \
+    pnpm install \
+      --frozen-lockfile \
+      --store-dir /pnpm/store \
+      --prefer-offline \
+      --network-concurrency=8 \
+      --fetch-retries=5 \
+      --fetch-retry-factor=2 \
+      --fetch-retry-mintimeout=10000 \
+      --fetch-retry-maxtimeout=120000
+RUN pnpm build
+
+# ── Stage 2: Production runtime ──────────────────────────────────────
+FROM node:25-alpine AS runner
+RUN apk update \
+ && apk upgrade --no-cache zlib \
+ && apk add --no-cache curl
+ENV NPM_CONFIG_REGISTRY=https://registry.npmjs.org/ \
+    NPM_CONFIG_FETCH_RETRIES=5 \
+    NPM_CONFIG_FETCH_RETRY_FACTOR=2 \
+    NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=10000 \
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000
+RUN for attempt in 1 2 3 4 5; do \
+      npm install -g pnpm@10.31.0 && exit 0; \
+      echo "pnpm install failed (attempt ${attempt}), retrying..."; \
+      sleep $((attempt * 5)); \
+    done; \
+    exit 1
+WORKDIR /app
+
+# Install production dependencies
+COPY --from=builder /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml ./
+COPY --from=builder /app/packages/ ./packages/
+COPY --from=builder /app/services/ ./services/
+COPY --from=builder /app/scripts/run-migrations.ts ./scripts/run-migrations.ts
+COPY --from=builder /app/tsconfig.base.json ./tsconfig.base.json
+RUN --mount=type=cache,id=pnpm-store-db-migrator,target=/pnpm/store,sharing=locked \
+    pnpm install \
+      --frozen-lockfile \
+      --store-dir /pnpm/store \
+      --prefer-offline \
+      --network-concurrency=8 \
+      --fetch-retries=5 \
+      --fetch-retry-factor=2 \
+      --fetch-retry-mintimeout=10000 \
+      --fetch-retry-maxtimeout=120000
+
+ENV NODE_ENV=production
+ENV OTEL_SERVICE_NAME=db-migrator
+
+USER node
+CMD ["node", "--import", "tsx", "scripts/run-migrations.ts"]


### PR DESCRIPTION
## Summary

- Adds `infra/docker/db-migrator.Dockerfile` — a dedicated Dockerfile that installs the full workspace instead of using `turbo prune`
- Updates `.github/workflows/docker.yml` to route `db-migrator` builds to the new Dockerfile

## Why

The migration script (`scripts/run-migrations.ts`) imports repositories from **every** service to run schema init. `turbo prune @script-manifest/db-migrator` fails because no such package exists — `db-migrator` is a root-level script, not a workspace package. Even if a package existed, pruning would pull in the entire monorepo since every service is a dependency.

## What changed

| File | Change |
|---|---|
| `infra/docker/db-migrator.Dockerfile` | New multi-stage Dockerfile: builds full workspace, runs `node --import tsx scripts/run-migrations.ts` |
| `.github/workflows/docker.yml` | Resolve Dockerfile step now uses `case` to route `db-migrator` → `db-migrator.Dockerfile` |

Fixes the CI build failure from #419.