### PR TITLE
feat(writer-web): add typed fetcher + ApiError (CHAOS-1522)

### DIFF
--- a/apps/writer-web/app/lib/fetcher.test.ts
+++ b/apps/writer-web/app/lib/fetcher.test.ts
@@ -125,7 +125,9 @@ describe("fetcher", () => {
       await fetcher("/api/test");
 
       expect(mockFetch).toHaveBeenCalledOnce();
-      const [, init] = mockFetch.mock.calls[0];
+      const firstCall = mockFetch.mock.calls[0];
+      expect(firstCall).toBeDefined();
+      const [, init] = firstCall as [string | URL | Request, RequestInit | undefined];
       expect(init).toMatchObject({
         credentials: "include",
         cache: "no-store",
@@ -149,7 +151,7 @@ describe("fetcher", () => {
         },
       });
 
-      const [, init] = mockFetch.mock.calls[0];
+      const [, init] = mockFetch.mock.calls[0] as [string | URL | Request, RequestInit | undefined];
       const sentHeaders = new Headers(init?.headers as HeadersInit);
       expect(sentHeaders.get("accept")).toBe("text/plain");
       expect(sentHeaders.get("x-custom")).toBe("yes");
@@ -163,7 +165,7 @@ describe("fetcher", () => {
       const callerHeaders = new Headers({ "Authorization": "Bearer token123" });
       await fetcher("/api/secure", { headers: callerHeaders });
 
-      const [, init] = mockFetch.mock.calls[0];
+      const [, init] = mockFetch.mock.calls[0] as [string | URL | Request, RequestInit | undefined];
       const sentHeaders = new Headers(init?.headers as HeadersInit);
       expect(sentHeaders.get("authorization")).toBe("Bearer token123");
       expect(sentHeaders.get("accept")).toBe("application/json");
@@ -179,7 +181,7 @@ describe("fetcher", () => {
 
       await fetcher("/api/data", { signal: controller.signal });
 
-      const [, init] = mockFetch.mock.calls[0];
+      const [, init] = mockFetch.mock.calls[0] as [string | URL | Request, RequestInit | undefined];
       expect(init).toMatchObject({ signal: controller.signal });
     });
 

--- a/apps/writer-web/app/lib/fetcher.test.ts
+++ b/apps/writer-web/app/lib/fetcher.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError, fetcher } from "./fetcher";
+
+function makeResponse(opts: {
+  status: number;
+  body?: string;
+  contentType?: string;
+}): Response {
+  const body = opts.body ?? "";
+  const ok = opts.status >= 200 && opts.status < 300;
+  const headers = new Headers({
+    "Content-Type": opts.contentType ?? "application/json",
+  });
+  return {
+    ok,
+    status: opts.status,
+    headers,
+    text: () => Promise.resolve(body),
+    json: () => Promise.resolve(JSON.parse(body)),
+  } as unknown as Response;
+}
+
+describe("fetcher", () => {
+  const mockFetch = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    mockFetch.mockReset();
+  });
+
+  describe("successful responses", () => {
+    it("returns parsed JSON body typed as T on 200", async () => {
+      const payload = { id: 1, name: "Alice" };
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({ status: 200, body: JSON.stringify(payload) })
+      );
+
+      const result = await fetcher<{ id: number; name: string }>("/api/users/1");
+
+      expect(result).toEqual(payload);
+    });
+
+    it("returns undefined on 204 No Content", async () => {
+      mockFetch.mockResolvedValueOnce(makeResponse({ status: 204, body: "" }));
+
+      const result = await fetcher("/api/resource");
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("error responses", () => {
+    it("throws ApiError with parsed body on 4xx JSON error", async () => {
+      const errorBody = { code: "AUTH_INVALID", message: "Token expired" };
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({ status: 401, body: JSON.stringify(errorBody) })
+      );
+
+      await expect(fetcher("/api/protected")).rejects.toSatisfy((err: unknown) => {
+        if (!(err instanceof ApiError)) return false;
+        expect(err.status).toBe(401);
+        expect(err.code).toBe("AUTH_INVALID");
+        expect(err.message).toBe("Token expired");
+        expect(err.body).toEqual(errorBody);
+        return true;
+      });
+    });
+
+    it("throws ApiError with raw text body on 5xx non-JSON response", async () => {
+      const htmlBody = "<html><body>Internal Server Error</body></html>";
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({ status: 500, body: htmlBody, contentType: "text/html" })
+      );
+
+      await expect(fetcher("/api/data")).rejects.toSatisfy((err: unknown) => {
+        if (!(err instanceof ApiError)) return false;
+        expect(err.status).toBe(500);
+        expect(err.code).toBeUndefined();
+        expect(err.body).toBe(htmlBody);
+        expect(err.message).toBe("HTTP 500");
+        return true;
+      });
+    });
+
+    it("uses generic 'HTTP <status>' message when JSON body has no message field", async () => {
+      const errorBody = { code: "NOT_FOUND" };
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({ status: 404, body: JSON.stringify(errorBody) })
+      );
+
+      await expect(fetcher("/api/thing")).rejects.toSatisfy((err: unknown) => {
+        if (!(err instanceof ApiError)) return false;
+        expect(err.message).toBe("HTTP 404");
+        expect(err.code).toBe("NOT_FOUND");
+        return true;
+      });
+    });
+
+    it("instanceof ApiError is true for thrown errors", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({ status: 400, body: JSON.stringify({ message: "Bad request" }) })
+      );
+
+      let caught: unknown;
+      try {
+        await fetcher("/api/thing");
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(ApiError);
+    });
+  });
+
+  describe("default request options", () => {
+    it("sends credentials=include, cache=no-store, Accept=application/json by default", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({ status: 200, body: JSON.stringify({}) })
+      );
+
+      await fetcher("/api/test");
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [, init] = mockFetch.mock.calls[0];
+      expect(init).toMatchObject({
+        credentials: "include",
+        cache: "no-store",
+      });
+
+      const sentHeaders = new Headers(init?.headers as HeadersInit);
+      expect(sentHeaders.get("accept")).toBe("application/json");
+    });
+  });
+
+  describe("header merging", () => {
+    it("merges caller headers with defaults, caller wins on conflicts", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({ status: 200, body: JSON.stringify({}) })
+      );
+
+      await fetcher("/api/test", {
+        headers: {
+          "Accept": "text/plain",
+          "X-Custom": "yes",
+        },
+      });
+
+      const [, init] = mockFetch.mock.calls[0];
+      const sentHeaders = new Headers(init?.headers as HeadersInit);
+      expect(sentHeaders.get("accept")).toBe("text/plain");
+      expect(sentHeaders.get("x-custom")).toBe("yes");
+    });
+
+    it("accepts Headers instance from caller and merges correctly", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({ status: 200, body: JSON.stringify({}) })
+      );
+
+      const callerHeaders = new Headers({ "Authorization": "Bearer token123" });
+      await fetcher("/api/secure", { headers: callerHeaders });
+
+      const [, init] = mockFetch.mock.calls[0];
+      const sentHeaders = new Headers(init?.headers as HeadersInit);
+      expect(sentHeaders.get("authorization")).toBe("Bearer token123");
+      expect(sentHeaders.get("accept")).toBe("application/json");
+    });
+  });
+
+  describe("AbortController / signal", () => {
+    it("forwards caller signal to fetch", async () => {
+      const controller = new AbortController();
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({ status: 200, body: JSON.stringify({ ok: true }) })
+      );
+
+      await fetcher("/api/data", { signal: controller.signal });
+
+      const [, init] = mockFetch.mock.calls[0];
+      expect(init).toMatchObject({ signal: controller.signal });
+    });
+
+    it("propagates AbortError when controller aborts", async () => {
+      const controller = new AbortController();
+      const abortError = Object.assign(new Error("The operation was aborted"), {
+        name: "AbortError",
+      });
+      mockFetch.mockRejectedValueOnce(abortError);
+
+      controller.abort();
+
+      await expect(
+        fetcher("/api/slow", { signal: controller.signal })
+      ).rejects.toMatchObject({ name: "AbortError" });
+    });
+  });
+});

--- a/apps/writer-web/app/lib/fetcher.ts
+++ b/apps/writer-web/app/lib/fetcher.ts
@@ -1,0 +1,86 @@
+export class ApiError extends Error {
+  readonly status: number;
+  readonly code?: string;
+  readonly body?: unknown;
+
+  constructor(
+    message: string,
+    options: { status: number; code?: string; body?: unknown }
+  ) {
+    super(message);
+    this.name = "ApiError";
+    this.status = options.status;
+    this.code = options.code;
+    this.body = options.body;
+  }
+}
+
+type JsonParseResult =
+  | { ok: true; value: unknown }
+  | { ok: false };
+
+function tryParseJson(text: string): JsonParseResult {
+  try {
+    return { ok: true, value: JSON.parse(text) as unknown };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function buildHeaders(callerHeaders?: HeadersInit): Headers {
+  const result = new Headers({ "Accept": "application/json" });
+  if (callerHeaders) {
+    new Headers(callerHeaders).forEach((value, key) => {
+      result.set(key, value);
+    });
+  }
+  return result;
+}
+
+export async function fetcher<T = unknown>(
+  input: string | URL,
+  init?: RequestInit
+): Promise<T> {
+  const { headers: callerHeaders, ...restInit } = init ?? {};
+
+  const response = await fetch(input, {
+    credentials: "include",
+    cache: "no-store",
+    ...restInit,
+    headers: buildHeaders(callerHeaders),
+  });
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  if (!response.ok) {
+    const rawText = await response.text();
+    const parseResult = tryParseJson(rawText);
+
+    const body: unknown = parseResult.ok ? parseResult.value : rawText;
+
+    let code: string | undefined;
+    if (
+      parseResult.ok &&
+      parseResult.value !== null &&
+      typeof parseResult.value === "object" &&
+      "code" in parseResult.value &&
+      typeof (parseResult.value as Record<string, unknown>)["code"] === "string"
+    ) {
+      code = (parseResult.value as Record<string, unknown>)["code"] as string;
+    }
+
+    const message =
+      body !== null &&
+      typeof body === "object" &&
+      "message" in body &&
+      typeof (body as Record<string, unknown>)["message"] === "string"
+        ? ((body as Record<string, unknown>)["message"] as string)
+        : `HTTP ${response.status}`;
+
+    throw new ApiError(message, { status: response.status, code, body });
+  }
+
+  return (await response.json()) as T;
+}


### PR DESCRIPTION
## Summary
- Adds `apps/writer-web/app/lib/fetcher.ts` with typed `fetcher<T>()` and `ApiError` class
- Adds `apps/writer-web/app/lib/fetcher.test.ts` covering 2xx / 4xx / 5xx / abort / headers / signals
- No new dependencies (native `fetch`)
- Foundation for SWR (CHAOS-1521) and page migrations (Phase 1+)

## Linear
- Closes part of CHAOS-1515
- Implements CHAOS-1522
- Unblocks CHAOS-1521 (SWRProvider)

## Verification
- `pnpm --filter @script-manifest/writer-web test` ✅ (11/11 fetcher tests + 424 existing pass)
- `pnpm --filter @script-manifest/writer-web typecheck` ✅ (fetcher.ts, fetcher.test.ts clean; pre-existing @contracts errors unrelated)
- `pnpm --filter @script-manifest/writer-web lint` ✅ (no issues in fetcher files)
- `pnpm --filter @script-manifest/writer-web build` ✅
- LSP diagnostics: no errors on either file