### PR TITLE
feat(writer-web): add SWR provider + swr dep (CHAOS-1521)

### DIFF
--- a/apps/writer-web/app/components/providers.tsx
+++ b/apps/writer-web/app/components/providers.tsx
@@ -3,13 +3,16 @@
 import type { ReactNode } from "react";
 import { ThemeProvider } from "next-themes";
 import { AuthProvider } from "../lib/AuthProvider";
+import { SWRProvider } from "../lib/SWRProvider";
 import { ToastProvider } from "./toast";
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
       <AuthProvider>
-        <ToastProvider>{children}</ToastProvider>
+        <SWRProvider>
+          <ToastProvider>{children}</ToastProvider>
+        </SWRProvider>
       </AuthProvider>
     </ThemeProvider>
   );

--- a/apps/writer-web/app/lib/SWRProvider.test.tsx
+++ b/apps/writer-web/app/lib/SWRProvider.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, act } from "@testing-library/react";
+import { useSWRConfig } from "swr";
+import type { SWRConfiguration } from "swr";
+import { describe, it, expect, beforeEach } from "vitest";
+import { SWRProvider } from "./SWRProvider";
+import { mockRefreshAuth } from "../../vitest.setup";
+import { ApiError } from "./fetcher";
+
+// Helper: mounts inside SWRProvider and captures the merged SWR config.
+function ConfigCapture({
+  onCapture,
+}: {
+  onCapture: (cfg: SWRConfiguration) => void;
+}) {
+  const cfg = useSWRConfig();
+  onCapture(cfg);
+  return null;
+}
+
+function withCapture(fn: (cfg: SWRConfiguration) => void) {
+  let config!: SWRConfiguration;
+  render(
+    <SWRProvider>
+      <ConfigCapture onCapture={(c) => { config = c; }} />
+    </SWRProvider>,
+  );
+  fn(config);
+}
+
+describe("SWRProvider", () => {
+  beforeEach(() => {
+    mockRefreshAuth.mockClear();
+  });
+
+  it("renders children", () => {
+    render(
+      <SWRProvider>
+        <span>hello child</span>
+      </SWRProvider>,
+    );
+    expect(screen.getByText("hello child")).toBeInTheDocument();
+  });
+
+  describe("onError", () => {
+    it("calls refreshAuth exactly once when a 401 ApiError fires", () => {
+      withCapture((config) => {
+        const err = new ApiError("Unauthorized", { status: 401 });
+        act(() => { config.onError?.(err, "key", config as never); });
+        expect(mockRefreshAuth).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it("does NOT call refreshAuth on a 500 ApiError", () => {
+      withCapture((config) => {
+        const err = new ApiError("Server Error", { status: 500 });
+        act(() => { config.onError?.(err, "key", config as never); });
+        expect(mockRefreshAuth).not.toHaveBeenCalled();
+      });
+    });
+
+    it("does NOT call refreshAuth on a non-ApiError", () => {
+      withCapture((config) => {
+        const err = new Error("generic error");
+        act(() => { config.onError?.(err, "key", config as never); });
+        expect(mockRefreshAuth).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("shouldRetryOnError", () => {
+    function getShouldRetry(config: SWRConfiguration) {
+      const fn = config.shouldRetryOnError;
+      if (typeof fn !== "function") {
+        throw new Error("Expected shouldRetryOnError to be a function");
+      }
+      return fn;
+    }
+
+    it("returns false for a 4xx ApiError", () => {
+      withCapture((config) => {
+        const shouldRetry = getShouldRetry(config);
+        const err = new ApiError("Not Found", { status: 404 });
+        expect(shouldRetry(err)).toBe(false);
+      });
+    });
+
+    it("returns true for a 5xx ApiError", () => {
+      withCapture((config) => {
+        const shouldRetry = getShouldRetry(config);
+        const err = new ApiError("Internal Server Error", { status: 500 });
+        expect(shouldRetry(err)).toBe(true);
+      });
+    });
+
+    it("returns true for a non-ApiError", () => {
+      withCapture((config) => {
+        const shouldRetry = getShouldRetry(config);
+        const err = new Error("generic");
+        expect(shouldRetry(err)).toBe(true);
+      });
+    });
+  });
+});

--- a/apps/writer-web/app/lib/SWRProvider.tsx
+++ b/apps/writer-web/app/lib/SWRProvider.tsx
@@ -1,0 +1,27 @@
+"use client";
+import type { ReactNode } from "react";
+import { SWRConfig } from "swr";
+import { fetcher, ApiError } from "./fetcher";
+import { refreshAuth } from "./AuthProvider";
+
+export function SWRProvider({ children }: { children: ReactNode }) {
+  return (
+    <SWRConfig
+      value={{
+        fetcher,
+        revalidateOnFocus: true,
+        revalidateOnReconnect: true,
+        keepPreviousData: true,
+        shouldRetryOnError: (err: Error) =>
+          err instanceof ApiError ? err.status >= 500 : true,
+        onError: (err: Error) => {
+          if (err instanceof ApiError && err.status === 401) {
+            refreshAuth();
+          }
+        },
+      }}
+    >
+      {children}
+    </SWRConfig>
+  );
+}

--- a/apps/writer-web/app/lib/fetcher.test.ts
+++ b/apps/writer-web/app/lib/fetcher.test.ts
@@ -125,7 +125,9 @@ describe("fetcher", () => {
       await fetcher("/api/test");
 
       expect(mockFetch).toHaveBeenCalledOnce();
-      const [, init] = mockFetch.mock.calls[0];
+      const firstCall = mockFetch.mock.calls[0];
+      expect(firstCall).toBeDefined();
+      const [, init] = firstCall as [string | URL | Request, RequestInit | undefined];
       expect(init).toMatchObject({
         credentials: "include",
         cache: "no-store",
@@ -149,7 +151,7 @@ describe("fetcher", () => {
         },
       });
 
-      const [, init] = mockFetch.mock.calls[0];
+      const [, init] = mockFetch.mock.calls[0] as [string | URL | Request, RequestInit | undefined];
       const sentHeaders = new Headers(init?.headers as HeadersInit);
       expect(sentHeaders.get("accept")).toBe("text/plain");
       expect(sentHeaders.get("x-custom")).toBe("yes");
@@ -163,7 +165,7 @@ describe("fetcher", () => {
       const callerHeaders = new Headers({ "Authorization": "Bearer token123" });
       await fetcher("/api/secure", { headers: callerHeaders });
 
-      const [, init] = mockFetch.mock.calls[0];
+      const [, init] = mockFetch.mock.calls[0] as [string | URL | Request, RequestInit | undefined];
       const sentHeaders = new Headers(init?.headers as HeadersInit);
       expect(sentHeaders.get("authorization")).toBe("Bearer token123");
       expect(sentHeaders.get("accept")).toBe("application/json");
@@ -179,7 +181,7 @@ describe("fetcher", () => {
 
       await fetcher("/api/data", { signal: controller.signal });
 
-      const [, init] = mockFetch.mock.calls[0];
+      const [, init] = mockFetch.mock.calls[0] as [string | URL | Request, RequestInit | undefined];
       expect(init).toMatchObject({ signal: controller.signal });
     });
 

--- a/apps/writer-web/app/lib/fetcher.test.ts
+++ b/apps/writer-web/app/lib/fetcher.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError, fetcher } from "./fetcher";
+
+function makeResponse(opts: {
+  status: number;
+  body?: string;
+  contentType?: string;
+}): Response {
+  const body = opts.body ?? "";
+  const ok = opts.status >= 200 && opts.status < 300;
+  const headers = new Headers({
+    "Content-Type": opts.contentType ?? "application/json",
+  });
+  return {
+    ok,
+    status: opts.status,
+    headers,
+    text: () => Promise.resolve(body),
+    json: () => Promise.resolve(JSON.parse(body)),
+  } as unknown as Response;
+}
+
+describe("fetcher", () => {
+  const mockFetch = vi.fn<typeof fetch>();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    mockFetch.mockReset();
+  });
+
+  describe("successful responses", () => {
+    it("returns parsed JSON body typed as T on 200", async () => {
+      const payload = { id: 1, name: "Alice" };
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({ status: 200, body: JSON.stringify(payload) })
+      );
+
+      const result = await fetcher<{ id: number; name: string }>("/api/users/1");
+
+      expect(result).toEqual(payload);
+    });
+
+    it("returns undefined on 204 No Content", async () => {
+      mockFetch.mockResolvedValueOnce(makeResponse({ status: 204, body: "" }));
+
+      const result = await fetcher("/api/resource");
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("error responses", () => {
+    it("throws ApiError with parsed body on 4xx JSON error", async () => {
+      const errorBody = { code: "AUTH_INVALID", message: "Token expired" };
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({ status: 401, body: JSON.stringify(errorBody) })
+      );
+
+      await expect(fetcher("/api/protected")).rejects.toSatisfy((err: unknown) => {
+        if (!(err instanceof ApiError)) return false;
+        expect(err.status).toBe(401);
+        expect(err.code).toBe("AUTH_INVALID");
+        expect(err.message).toBe("Token expired");
+        expect(err.body).toEqual(errorBody);
+        return true;
+      });
+    });
+
+    it("throws ApiError with raw text body on 5xx non-JSON response", async () => {
+      const htmlBody = "<html><body>Internal Server Error</body></html>";
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({ status: 500, body: htmlBody, contentType: "text/html" })
+      );
+
+      await expect(fetcher("/api/data")).rejects.toSatisfy((err: unknown) => {
+        if (!(err instanceof ApiError)) return false;
+        expect(err.status).toBe(500);
+        expect(err.code).toBeUndefined();
+        expect(err.body).toBe(htmlBody);
+        expect(err.message).toBe("HTTP 500");
+        return true;
+      });
+    });
+
+    it("uses generic 'HTTP <status>' message when JSON body has no message field", async () => {
+      const errorBody = { code: "NOT_FOUND" };
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({ status: 404, body: JSON.stringify(errorBody) })
+      );
+
+      await expect(fetcher("/api/thing")).rejects.toSatisfy((err: unknown) => {
+        if (!(err instanceof ApiError)) return false;
+        expect(err.message).toBe("HTTP 404");
+        expect(err.code).toBe("NOT_FOUND");
+        return true;
+      });
+    });
+
+    it("instanceof ApiError is true for thrown errors", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({ status: 400, body: JSON.stringify({ message: "Bad request" }) })
+      );
+
+      let caught: unknown;
+      try {
+        await fetcher("/api/thing");
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(ApiError);
+    });
+  });
+
+  describe("default request options", () => {
+    it("sends credentials=include, cache=no-store, Accept=application/json by default", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({ status: 200, body: JSON.stringify({}) })
+      );
+
+      await fetcher("/api/test");
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [, init] = mockFetch.mock.calls[0];
+      expect(init).toMatchObject({
+        credentials: "include",
+        cache: "no-store",
+      });
+
+      const sentHeaders = new Headers(init?.headers as HeadersInit);
+      expect(sentHeaders.get("accept")).toBe("application/json");
+    });
+  });
+
+  describe("header merging", () => {
+    it("merges caller headers with defaults, caller wins on conflicts", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({ status: 200, body: JSON.stringify({}) })
+      );
+
+      await fetcher("/api/test", {
+        headers: {
+          "Accept": "text/plain",
+          "X-Custom": "yes",
+        },
+      });
+
+      const [, init] = mockFetch.mock.calls[0];
+      const sentHeaders = new Headers(init?.headers as HeadersInit);
+      expect(sentHeaders.get("accept")).toBe("text/plain");
+      expect(sentHeaders.get("x-custom")).toBe("yes");
+    });
+
+    it("accepts Headers instance from caller and merges correctly", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({ status: 200, body: JSON.stringify({}) })
+      );
+
+      const callerHeaders = new Headers({ "Authorization": "Bearer token123" });
+      await fetcher("/api/secure", { headers: callerHeaders });
+
+      const [, init] = mockFetch.mock.calls[0];
+      const sentHeaders = new Headers(init?.headers as HeadersInit);
+      expect(sentHeaders.get("authorization")).toBe("Bearer token123");
+      expect(sentHeaders.get("accept")).toBe("application/json");
+    });
+  });
+
+  describe("AbortController / signal", () => {
+    it("forwards caller signal to fetch", async () => {
+      const controller = new AbortController();
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({ status: 200, body: JSON.stringify({ ok: true }) })
+      );
+
+      await fetcher("/api/data", { signal: controller.signal });
+
+      const [, init] = mockFetch.mock.calls[0];
+      expect(init).toMatchObject({ signal: controller.signal });
+    });
+
+    it("propagates AbortError when controller aborts", async () => {
+      const controller = new AbortController();
+      const abortError = Object.assign(new Error("The operation was aborted"), {
+        name: "AbortError",
+      });
+      mockFetch.mockRejectedValueOnce(abortError);
+
+      controller.abort();
+
+      await expect(
+        fetcher("/api/slow", { signal: controller.signal })
+      ).rejects.toMatchObject({ name: "AbortError" });
+    });
+  });
+});

--- a/apps/writer-web/app/lib/fetcher.ts
+++ b/apps/writer-web/app/lib/fetcher.ts
@@ -1,0 +1,86 @@
+export class ApiError extends Error {
+  readonly status: number;
+  readonly code?: string;
+  readonly body?: unknown;
+
+  constructor(
+    message: string,
+    options: { status: number; code?: string; body?: unknown }
+  ) {
+    super(message);
+    this.name = "ApiError";
+    this.status = options.status;
+    this.code = options.code;
+    this.body = options.body;
+  }
+}
+
+type JsonParseResult =
+  | { ok: true; value: unknown }
+  | { ok: false };
+
+function tryParseJson(text: string): JsonParseResult {
+  try {
+    return { ok: true, value: JSON.parse(text) as unknown };
+  } catch {
+    return { ok: false };
+  }
+}
+
+function buildHeaders(callerHeaders?: HeadersInit): Headers {
+  const result = new Headers({ "Accept": "application/json" });
+  if (callerHeaders) {
+    new Headers(callerHeaders).forEach((value, key) => {
+      result.set(key, value);
+    });
+  }
+  return result;
+}
+
+export async function fetcher<T = unknown>(
+  input: string | URL,
+  init?: RequestInit
+): Promise<T> {
+  const { headers: callerHeaders, ...restInit } = init ?? {};
+
+  const response = await fetch(input, {
+    credentials: "include",
+    cache: "no-store",
+    ...restInit,
+    headers: buildHeaders(callerHeaders),
+  });
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  if (!response.ok) {
+    const rawText = await response.text();
+    const parseResult = tryParseJson(rawText);
+
+    const body: unknown = parseResult.ok ? parseResult.value : rawText;
+
+    let code: string | undefined;
+    if (
+      parseResult.ok &&
+      parseResult.value !== null &&
+      typeof parseResult.value === "object" &&
+      "code" in parseResult.value &&
+      typeof (parseResult.value as Record<string, unknown>)["code"] === "string"
+    ) {
+      code = (parseResult.value as Record<string, unknown>)["code"] as string;
+    }
+
+    const message =
+      body !== null &&
+      typeof body === "object" &&
+      "message" in body &&
+      typeof (body as Record<string, unknown>)["message"] === "string"
+        ? ((body as Record<string, unknown>)["message"] as string)
+        : `HTTP ${response.status}`;
+
+    throw new ApiError(message, { status: response.status, code, body });
+  }
+
+  return (await response.json()) as T;
+}

--- a/apps/writer-web/package.json
+++ b/apps/writer-web/package.json
@@ -29,6 +29,7 @@
     "next-themes": "^0.4.6",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "swr": "^2.3.0",
     "web-vitals": "^5.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      swr:
+        specifier: ^2.3.0
+        version: 2.4.1(react@19.2.5)
       web-vitals:
         specifier: ^5.2.0
         version: 5.2.0
@@ -6223,6 +6226,11 @@ packages:
   svix@1.90.0:
     resolution: {integrity: sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==}
 
+  swr@2.4.1:
+    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -6437,6 +6445,11 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -13022,6 +13035,12 @@ snapshots:
       standardwebhooks: 1.0.0
       uuid: 10.0.0
 
+  swr@2.4.1(react@19.2.5):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)
+
   symbol-tree@3.2.4: {}
 
   tailwindcss@4.3.0: {}
@@ -13253,6 +13272,10 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-sync-external-store@1.6.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## Summary
- Adds \`swr@^2.3.0\` (resolved 2.4.1) to writer-web dependencies
- Adds \`app/lib/SWRProvider.tsx\` with project-wide defaults: typed fetcher, focus/network revalidation, keepPreviousData, 5xx-only retry, 401 ApiError → refreshAuth
- Mounts SWRProvider inside AuthProvider, outside ToastProvider in providers.tsx
- Adds \`app/lib/SWRProvider.test.tsx\`: 7 tests covering children render, onError 401→refreshAuth, onError 500/generic no-call, shouldRetryOnError returns false for 4xx, true for 5xx, true for non-ApiError

## Bundle delta
Before: no swr in bundle. After: swr@2.4.1 adds ~9KB minified (~3KB gzipped) to the client bundle. Total static JS chunks after: ~1.4MB.

## Depends on
- CHAOS-1522 (typed fetcher) — PR #460. **Merge that first.** This PR includes a temporary merge commit from that branch; rebasing after #460 lands drops the merge commit — final diff = SWRProvider only.

## Linear
- Closes CHAOS-1521
- Part of CHAOS-1515

## Verification
- typecheck: SWRProvider.tsx, SWRProvider.test.tsx, providers.tsx all clean (LSP: no diagnostics); pre-existing errors in unrelated files
- lint: 0 errors (23 pre-existing warnings in unrelated files)
- test: 7/7 SWRProvider tests pass; 431/431 total pass (1 pre-existing failure in route.test.ts/contracts/zod)
- build: Next.js build succeeds