### PR TITLE
feat(writer-web): migrate leaderboard to SWR (CHAOS-1525)

### DIFF
--- a/apps/writer-web/app/leaderboard/page.test.tsx
+++ b/apps/writer-web/app/leaderboard/page.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, cleanup } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SWRConfig } from "swr";
+import type { ReactElement } from "react";
 import LeaderboardPage from "./page";
 
 function jsonResponse(payload: unknown, status = 200): Response {
@@ -10,10 +12,23 @@ function jsonResponse(payload: unknown, status = 200): Response {
   });
 }
 
+function renderWithSWR(ui: ReactElement) {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0, shouldRetryOnError: false }}>
+      {ui}
+    </SWRConfig>
+  );
+}
+
 describe("LeaderboardPage", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
+
+  afterEach(() => {
+    cleanup();
+  });
+
 
   it("loads leaderboard rows and applies filters", async () => {
     const fetchMock = vi.fn<typeof fetch>(async (input) => {
@@ -40,10 +55,11 @@ describe("LeaderboardPage", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    render(<LeaderboardPage />);
+    renderWithSWR(<LeaderboardPage />);
     const user = userEvent.setup();
 
-    await screen.findByText(/Loaded 0 leaderboard rows/);
+    // Wait for initial fetch to settle (button leaves "Refreshing..." state)
+    await screen.findByRole("button", { name: "Refresh leaderboard" });
 
     await user.type(screen.getByLabelText("Format filter"), "feature");
     await user.type(screen.getByLabelText("Genre filter"), "drama");
@@ -76,7 +92,7 @@ describe("LeaderboardPage", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    render(<LeaderboardPage />);
+    renderWithSWR(<LeaderboardPage />);
     await screen.findAllByText("writer_01");
     // Tier badge is a span with the tier class, distinct from the <option> elements
     const tierBadges = screen.getAllByText("Top 1%");
@@ -105,7 +121,7 @@ describe("LeaderboardPage", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    render(<LeaderboardPage />);
+    renderWithSWR(<LeaderboardPage />);
     await screen.findAllByText("writer_01");
     expect(screen.getByText("Winner - Sundance 2026")).toBeInTheDocument();
   });
@@ -131,8 +147,76 @@ describe("LeaderboardPage", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    render(<LeaderboardPage />);
+    renderWithSWR(<LeaderboardPage />);
     await screen.findAllByText("writer_01");
     expect(screen.getByText(/5\.5/)).toBeInTheDocument();
+  });
+
+  it("initial load renders empty state when no writers", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      return jsonResponse({ leaderboard: [], total: 0 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithSWR(<LeaderboardPage />);
+
+    await screen.findByText("The spotlight is waiting");
+    expect(screen.getByText("0 total")).toBeInTheDocument();
+  });
+
+  it("changing a filter triggers a new fetch with updated URL", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("format=feature")) {
+        return jsonResponse({
+          leaderboard: [
+            {
+              writerId: "writer_feature",
+              rank: 1,
+              totalScore: 15,
+              submissionCount: 5,
+              placementCount: 3,
+              tier: "top_10",
+              badges: [],
+              scoreChange30d: 0,
+              lastUpdatedAt: "2026-02-06T00:00:00.000Z"
+            }
+          ],
+          total: 1
+        });
+      }
+      return jsonResponse({ leaderboard: [], total: 0 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithSWR(<LeaderboardPage />);
+    const user = userEvent.setup();
+
+    // Wait for initial fetch to complete
+    await screen.findByRole("button", { name: "Refresh leaderboard" });
+
+    // Change format filter — SWR auto-refetches because the cache key changes
+    await user.type(screen.getByLabelText("Format filter"), "feature");
+
+    // Wait for writer to appear (confirms the new-key fetch completed)
+    await screen.findByText("writer_feature");
+
+    // Verify a fetch was made with format=feature in the URL
+    const formatCalls = fetchMock.mock.calls.filter((args) => {
+      const url = typeof args[0] === "string" ? args[0] : String(args[0]);
+      return url.includes("format=feature");
+    });
+    expect(formatCalls.length).toBeGreaterThan(0);
+  });
+
+  it("ApiError 4xx renders error message", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      return jsonResponse({ message: "Forbidden access" }, 403);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithSWR(<LeaderboardPage />);
+
+    await screen.findByText("Forbidden access");
   });
 });

--- a/apps/writer-web/app/leaderboard/page.tsx
+++ b/apps/writer-web/app/leaderboard/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+import { useMemo, useState, type FormEvent } from "react";
+import useSWR from "swr";
 import type { Route } from "next";
 import type { RankedWriterEntry, TierDesignation } from "@script-manifest/contracts";
 import { EmptyState } from "../components/emptyState";
 import { EmptyIllustration } from "../components/illustrations";
+import { fetcher, ApiError } from "../lib/fetcher";
 
 type LeaderboardResponse = {
   leaderboard: RankedWriterEntry[];
@@ -69,63 +71,44 @@ function scorePercent(score: number, maxScore: number): number {
   return Math.min(100, Math.round((score / maxScore) * 100));
 }
 
+function buildKey(filters: Filters): string {
+  const search = new URLSearchParams();
+  if (filters.format.trim()) {
+    search.set("format", filters.format.trim());
+  }
+  if (filters.genre.trim()) {
+    search.set("genre", filters.genre.trim());
+  }
+  if (filters.tier) {
+    search.set("tier", filters.tier);
+  }
+  if (filters.trending) {
+    search.set("trending", "true");
+  }
+  const qs = search.toString();
+  return qs ? `/api/v1/leaderboard?${qs}` : "/api/v1/leaderboard";
+}
+
 export default function LeaderboardPage() {
   const [filters, setFilters] = useState<Filters>(initialFilters);
-  const [rows, setRows] = useState<RankedWriterEntry[]>([]);
-  const [total, setTotal] = useState(0);
-  const [loading, setLoading] = useState(false);
-  const [status, setStatus] = useState("");
+
+  const { data, error, isLoading, mutate } = useSWR<LeaderboardResponse>(
+    buildKey(filters),
+    fetcher
+  );
+
+  const rows = useMemo(() => data?.leaderboard ?? [], [data]);
+  const total = data?.total ?? 0;
 
   const maxScore = useMemo(() => {
     if (rows.length === 0) return 1;
     return Math.max(...rows.map((r) => r.totalScore), 1);
   }, [rows]);
 
-  const runLeaderboardQuery = useCallback(async (activeFilters: Filters) => {
-    setLoading(true);
-    setStatus("");
-
-    const search = new URLSearchParams();
-    if (activeFilters.format.trim()) {
-      search.set("format", activeFilters.format.trim());
-    }
-    if (activeFilters.genre.trim()) {
-      search.set("genre", activeFilters.genre.trim());
-    }
-    if (activeFilters.tier) {
-      search.set("tier", activeFilters.tier);
-    }
-    if (activeFilters.trending) {
-      search.set("trending", "true");
-    }
-
-    try {
-      const response = await fetch(`/api/v1/leaderboard?${search.toString()}`, { cache: "no-store" });
-      const body = (await response.json()) as Partial<LeaderboardResponse> & { error?: string };
-      if (!response.ok) {
-        setStatus(body.error ? `Error: ${body.error}` : "Leaderboard load failed.");
-        return;
-      }
-
-      const nextRows = body.leaderboard ?? [];
-      setRows(nextRows);
-      setTotal(body.total ?? nextRows.length);
-      setStatus(`Loaded ${nextRows.length} leaderboard rows.`);
-    } catch (error) {
-      setStatus(error instanceof Error ? error.message : "unknown_error");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  const loadLeaderboard = useCallback((event?: FormEvent<HTMLFormElement>) => {
-    event?.preventDefault();
-    void runLeaderboardQuery(filters);
-  }, [filters, runLeaderboardQuery]);
-
-  useEffect(() => {
-    queueMicrotask(() => { void runLeaderboardQuery(initialFilters); });
-  }, [runLeaderboardQuery]);
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void mutate();
+  }
 
   return (
     <section className="space-y-4">
@@ -139,7 +122,7 @@ export default function LeaderboardPage() {
       </article>
 
       <article className="panel stack animate-in animate-in-delay-1">
-        <form className="stack" onSubmit={loadLeaderboard}>
+        <form className="stack" onSubmit={handleSubmit}>
           <div className="grid-two">
             <label className="stack-tight">
               <span>Format filter</span>
@@ -187,17 +170,16 @@ export default function LeaderboardPage() {
             </label>
           </div>
           <div className="inline-form">
-            <button type="submit" className="btn btn-primary" disabled={loading}>
-              {loading ? "Refreshing..." : "Refresh leaderboard"}
+            <button type="submit" className="btn btn-primary" disabled={isLoading}>
+              {isLoading ? "Refreshing..." : "Refresh leaderboard"}
             </button>
             <button
               type="button"
               className="btn btn-secondary"
               onClick={() => {
                 setFilters(initialFilters);
-                void runLeaderboardQuery(initialFilters);
               }}
-              disabled={loading}
+              disabled={isLoading}
             >
               Reset
             </button>
@@ -284,7 +266,11 @@ export default function LeaderboardPage() {
         ) : null}
       </article>
 
-      {status ? <p className={status.startsWith("Error:") ? "status-error" : "status-note"}>{status}</p> : null}
+      {error ? (
+        <p className="status-error">
+          {error instanceof ApiError ? error.message : "Leaderboard load failed."}
+        </p>
+      ) : null}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Migrates `apps/writer-web/app/leaderboard/page.tsx` from manual `useEffect + useCallback(runLeaderboardQuery) + queueMicrotask + fetch` to `useSWR` with a filter-derived cache key
- Filter changes auto-refetch via key change (no manual effect chain)
- Removed `queueMicrotask` wrap, `useCallback(runLeaderboardQuery)`, and `useCallback(loadLeaderboard)` + `useEffect` triple; manual `rows`, `total`, `loading`, `status` useState

## Before / after

**Before:** Page opened → `useEffect` fired `queueMicrotask(() => runLeaderboardQuery(initialFilters))`, which `setState` × 4 inside try/finally. Filter form submit called `runLeaderboardQuery(filters)` manually. Filter changes did not auto-fetch.

**After:** `buildKey(filters)` returns the full URL with URLSearchParams derived from active filter state. `useSWR<LeaderboardResponse>(buildKey(filters), fetcher)` owns the fetch lifecycle. Any filter state change changes the SWR key → auto-refetch with no effect chain. Form `onSubmit` calls `mutate()` for explicit refresh. `data.leaderboard`, `data.total`, `error`, `isLoading` replace all manual state.

## Linear
- Implements CHAOS-1525
- Part of CHAOS-1516 Phase 1 Pilot
- Canonical pattern for Phase 2 read-only public lists

## Verification
- typecheck ✅ / lint ✅ (0 errors) / test 438 passed ✅ / build ✅