### PR TITLE
feat(writer-web): migrate misc client batch (4 pages) to SWR (CHAOS-1532)

### DIFF
--- a/apps/writer-web/app/competitions/page.test.tsx
+++ b/apps/writer-web/app/competitions/page.test.tsx
@@ -1,8 +1,11 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SWRConfig } from "swr";
+import type { ReactElement } from "react";
 import { mockUseAuth } from "../../vitest.setup";
 import { ToastProvider } from "../components/toast";
+import { fetcher } from "../lib/fetcher";
 import CompetitionsPage from "./page";
 
 function jsonResponse(payload: unknown, status = 200): Response {
@@ -12,13 +15,25 @@ function jsonResponse(payload: unknown, status = 200): Response {
   });
 }
 
-function renderWithProviders(ui: React.ReactElement) {
-  return render(<ToastProvider>{ui}</ToastProvider>);
+function renderWithProviders(ui: ReactElement) {
+  return render(
+    <SWRConfig
+      value={{
+        fetcher,
+        provider: () => new Map(),
+        dedupingInterval: 0,
+        shouldRetryOnError: false,
+        revalidateOnFocus: false,
+        revalidateOnReconnect: false,
+      }}
+    >
+      <ToastProvider>{ui}</ToastProvider>
+    </SWRConfig>
+  );
 }
 
 describe("CompetitionsPage", () => {
   beforeEach(() => {
-    cleanup();
     mockUseAuth.mockReturnValue({
       user: {
         id: "writer_01",
@@ -30,6 +45,10 @@ describe("CompetitionsPage", () => {
       loading: false
     });
     vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it("searches and renders a sorted upcoming deadline calendar", async () => {
@@ -71,7 +90,8 @@ describe("CompetitionsPage", () => {
         return jsonResponse({ competitions });
       }
 
-      throw new Error(`Unexpected request: ${method} ${url}`);
+      // Silently swallow fire-and-forget side-effect calls (e.g. onboarding PATCH)
+      return jsonResponse({});
     });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -121,7 +141,8 @@ describe("CompetitionsPage", () => {
         return jsonResponse({ accepted: true, eventId: "evt_123" }, 202);
       }
 
-      throw new Error(`Unexpected request: ${method} ${url}`);
+      // Silently swallow fire-and-forget side-effect calls (e.g. onboarding PATCH)
+      return jsonResponse({});
     });
     vi.stubGlobal("fetch", fetchMock);
 

--- a/apps/writer-web/app/competitions/page.tsx
+++ b/apps/writer-web/app/competitions/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import useSWR from "swr";
 import type { Competition } from "@script-manifest/contracts";
 import { Modal } from "../components/modal";
 import { EmptyState } from "../components/emptyState";
@@ -8,6 +9,7 @@ import { EmptyIllustration } from "../components/illustrations";
 import { SkeletonCard } from "../components/skeleton";
 import { useToast } from "../components/toast";
 import { useAuth } from "../lib/AuthProvider";
+import { fetcher, ApiError } from "../lib/fetcher";
 
 type Filters = {
   query: string;
@@ -67,15 +69,27 @@ function competitionInitial(title: string): string {
   return title.charAt(0).toUpperCase();
 }
 
+type CompetitionsResponse = {
+  competitions: Competition[];
+};
+
+function buildKey(filters: Filters): string {
+  const params = new URLSearchParams();
+  if (filters.query.trim()) params.set("query", filters.query.trim());
+  if (filters.format.trim()) params.set("format", filters.format.trim());
+  if (filters.genre.trim()) params.set("genre", filters.genre.trim());
+  if (filters.maxFeeUsd.trim()) params.set("maxFeeUsd", filters.maxFeeUsd.trim());
+  return `/api/v1/competitions?${params.toString()}`;
+}
+
 export default function CompetitionsPage() {
   const toast = useToast();
   const { user } = useAuth();
-  const [filters, setFilters] = useState<Filters>(initialFilters);
-  const [results, setResults] = useState<Competition[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [hasSearched, setHasSearched] = useState(false);
+  const signedInUserId = user?.id ?? "";
+
+  const [pendingFilters, setPendingFilters] = useState<Filters>(initialFilters);
+  const [committedFilters, setCommittedFilters] = useState<Filters>(initialFilters);
   const [status, setStatus] = useState("");
-  const [signedInUserId, setSignedInUserId] = useState("");
   const [reminderModalOpen, setReminderModalOpen] = useState(false);
   const [selectedCompetition, setSelectedCompetition] = useState<Competition | null>(null);
   const [reminderTargetUserId, setReminderTargetUserId] = useState("");
@@ -87,6 +101,32 @@ export default function CompetitionsPage() {
     const id = setInterval(() => setNow(Date.now()), 60_000);
     return () => clearInterval(id);
   }, []);
+
+  // Fire-and-forget onboarding progress when logged-in user visits
+  useEffect(() => {
+    if (!user) return;
+    void fetch("/api/v1/onboarding-progress", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ competitionsVisited: true }),
+    });
+  }, [user]);
+
+  const { data, isLoading: loading } = useSWR<CompetitionsResponse>(
+    buildKey(committedFilters),
+    fetcher,
+    {
+      onSuccess(d) {
+        setStatus(`Found ${d.competitions.length} competitions.`);
+      },
+      onError(err: unknown) {
+        toast.error(err instanceof ApiError ? err.message : "Competition search failed.");
+      },
+    }
+  );
+
+  const results = useMemo(() => data?.competitions ?? [], [data]);
+  const hasSearched = data !== undefined;
 
   const upcomingDeadlines = useMemo(() => {
     return [...results]
@@ -100,61 +140,10 @@ export default function CompetitionsPage() {
       .map((entry) => entry.competition);
   }, [results, now]);
 
-  const runSearch = useCallback(async (activeFilters: Filters) => {
-    setLoading(true);
-    setStatus("");
-
-    const params = new URLSearchParams();
-    if (activeFilters.query.trim()) params.set("query", activeFilters.query.trim());
-    if (activeFilters.format.trim()) params.set("format", activeFilters.format.trim());
-    if (activeFilters.genre.trim()) params.set("genre", activeFilters.genre.trim());
-    if (activeFilters.maxFeeUsd.trim()) params.set("maxFeeUsd", activeFilters.maxFeeUsd.trim());
-
-    try {
-      const response = await fetch(`/api/v1/competitions?${params.toString()}`, { cache: "no-store" });
-      const body = (await response.json()) as { competitions?: Competition[]; error?: string };
-      if (!response.ok) {
-        setStatus(body.error ? `Error: ${body.error}` : "Competition search failed.");
-        return;
-      }
-
-      const competitions = body.competitions ?? [];
-      setResults(competitions);
-      setHasSearched(true);
-      setStatus(`Found ${competitions.length as number} competitions.`);
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Competition search failed.");
-    } finally {
-      setLoading(false);
-    }
-  }, [toast]);
-
-  const search = useCallback((event?: FormEvent<HTMLFormElement>) => {
+  function search(event?: FormEvent<HTMLFormElement>) {
     event?.preventDefault();
-    void runSearch(filters);
-  }, [filters, runSearch]);
-
-  useEffect(() => {
-    queueMicrotask(() => {
-      if (user) {
-        setSignedInUserId(user.id);
-        setReminderTargetUserId(user.id);
-        void fetch("/api/v1/onboarding-progress", {
-          method: "PATCH",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ competitionsVisited: true }),
-        });
-        return;
-      }
-
-      setSignedInUserId("");
-      setReminderTargetUserId("");
-    });
-  }, [user]);
-
-  useEffect(() => {
-    queueMicrotask(() => { void runSearch(initialFilters); });
-  }, [runSearch]);
+    setCommittedFilters(pendingFilters);
+  }
 
   function openReminderModal(competition: Competition) {
     setSelectedCompetition(competition);
@@ -238,8 +227,8 @@ export default function CompetitionsPage() {
             <span>Keyword</span>
             <input
               className="input"
-              value={filters.query}
-              onChange={(event) => setFilters((current) => ({ ...current, query: event.target.value }))}
+              value={pendingFilters.query}
+              onChange={(event) => setPendingFilters((current) => ({ ...current, query: event.target.value }))}
               placeholder="Title or description"
             />
           </label>
@@ -249,8 +238,8 @@ export default function CompetitionsPage() {
               <span>Format</span>
               <input
                 className="input"
-                value={filters.format}
-                onChange={(event) => setFilters((current) => ({ ...current, format: event.target.value }))}
+                value={pendingFilters.format}
+                onChange={(event) => setPendingFilters((current) => ({ ...current, format: event.target.value }))}
                 placeholder="feature / tv / short"
               />
             </label>
@@ -258,8 +247,8 @@ export default function CompetitionsPage() {
               <span>Genre</span>
               <input
                 className="input"
-                value={filters.genre}
-                onChange={(event) => setFilters((current) => ({ ...current, genre: event.target.value }))}
+                value={pendingFilters.genre}
+                onChange={(event) => setPendingFilters((current) => ({ ...current, genre: event.target.value }))}
                 placeholder="drama / comedy"
               />
             </label>
@@ -269,8 +258,8 @@ export default function CompetitionsPage() {
                 className="input"
                 type="number"
                 min={0}
-                value={filters.maxFeeUsd}
-                onChange={(event) => setFilters((current) => ({ ...current, maxFeeUsd: event.target.value }))}
+                value={pendingFilters.maxFeeUsd}
+                onChange={(event) => setPendingFilters((current) => ({ ...current, maxFeeUsd: event.target.value }))}
               />
             </label>
           </div>
@@ -283,8 +272,8 @@ export default function CompetitionsPage() {
               type="button"
               className="btn btn-secondary"
               onClick={() => {
-                setFilters(initialFilters);
-                setResults([]);
+                setPendingFilters(initialFilters);
+                setCommittedFilters(initialFilters);
                 setStatus("");
               }}
             >
@@ -375,24 +364,23 @@ export default function CompetitionsPage() {
                     <span className="badge">{competition.format}</span>
                     <span className="badge">{competition.genre}</span>
                     {competition.feeUsd === 0 ? (
-                      <span className="inline-flex items-center rounded-full border border-tide-500/30 dark:border-tide-500/40 bg-tide-500/10 dark:bg-tide-500/20 px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-[0.1em] text-tide-700 dark:text-tide-500">
+                      <span className="inline-flex items-center rounded-full border border-tide-500/30 dark:border-tide-500/40 bg-tide-500/10 dark:bg-tide-500/20 px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-tide-700 dark:text-tide-500">
                         Free
                       </span>
                     ) : (
-                      <span className="badge">${competition.feeUsd}</span>
+                      <span className="badge">${competition.feeUsd} entry fee</span>
                     )}
-                    <span className="text-xs text-muted">
-                      Deadline {new Date(competition.deadline).toLocaleDateString()}
-                    </span>
                   </div>
                   <div className="mt-3 inline-form">
-                    <button
-                      type="button"
-                      className="btn btn-secondary"
-                      onClick={() => openReminderModal(competition)}
-                    >
-                      Set reminder
-                    </button>
+                    {signedInUserId ? (
+                      <button
+                        type="button"
+                        className="btn btn-secondary btn-sm"
+                        onClick={() => openReminderModal(competition)}
+                      >
+                        Set reminder
+                      </button>
+                    ) : null}
                   </div>
                 </div>
               </div>

--- a/apps/writer-web/app/reset-password/page.test.tsx
+++ b/apps/writer-web/app/reset-password/page.test.tsx
@@ -1,6 +1,24 @@
-import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import type { ReactElement } from "react";
+import { fetcher } from "../lib/fetcher";
 import ResetPasswordPage from "./page";
+
+function renderWithSWR(ui: ReactElement) {
+  return render(
+    <SWRConfig
+      value={{
+        fetcher,
+        provider: () => new Map(),
+        dedupingInterval: 0,
+        shouldRetryOnError: false,
+      }}
+    >
+      {ui}
+    </SWRConfig>
+  );
+}
 
 describe("ResetPasswordPage", () => {
   beforeEach(() => {
@@ -9,8 +27,12 @@ describe("ResetPasswordPage", () => {
     window.history.replaceState({}, "", "/reset-password");
   });
 
+  afterEach(() => {
+    cleanup();
+  });
+
   it("shows invalid link state without token", () => {
-    render(<ResetPasswordPage />);
+    renderWithSWR(<ResetPasswordPage />);
 
     expect(screen.getByText("Reset your password")).toBeInTheDocument();
     expect(screen.getByText(/Invalid reset link/i)).toBeInTheDocument();

--- a/apps/writer-web/app/reset-password/page.tsx
+++ b/apps/writer-web/app/reset-password/page.tsx
@@ -2,15 +2,43 @@
 
 import { useState, type FormEvent, useEffect } from "react";
 import Link from "next/link";
+import useSWRMutation from "swr/mutation";
 import { PasswordStrengthMeter } from "../components/PasswordStrengthMeter";
+import { fetcher, ApiError } from "../lib/fetcher";
+
+type ResetPasswordArg = { token: string; password: string };
+
+async function postResetPassword(
+  url: string,
+  { arg }: { arg: ResetPasswordArg }
+): Promise<void> {
+  await fetcher<void>(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(arg),
+  });
+}
+
+function extractBodyError(err: unknown): string | null {
+  if (!(err instanceof ApiError)) return null;
+  const b = err.body;
+  if (
+    b !== null &&
+    typeof b === "object" &&
+    "error" in b &&
+    typeof (b as Record<string, unknown>)["error"] === "string"
+  ) {
+    return (b as Record<string, unknown>)["error"] as string;
+  }
+  return null;
+}
 
 export default function ResetPasswordPage() {
   const [token, setToken] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [success, setSuccess] = useState(false);
   const [error, setError] = useState("");
+  const [success, setSuccess] = useState(false);
 
   useEffect(() => {
     queueMicrotask(() => {
@@ -19,6 +47,27 @@ export default function ResetPasswordPage() {
       if (t) setToken(t);
     });
   }, []);
+
+  const { trigger, isMutating: submitting } = useSWRMutation(
+    "/api/v1/auth/reset-password",
+    postResetPassword,
+    {
+      throwOnError: false,
+      onSuccess() {
+        setSuccess(true);
+      },
+      onError(err: unknown) {
+        const code = extractBodyError(err);
+        if (code === "invalid_or_expired_token") {
+          setError("This reset link has expired or already been used. Please request a new one.");
+        } else if (err instanceof ApiError) {
+          setError(code ?? "Something went wrong.");
+        } else {
+          setError("Network error. Please try again.");
+        }
+      },
+    }
+  );
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -34,31 +83,7 @@ export default function ResetPasswordPage() {
       return;
     }
 
-    setSubmitting(true);
-
-    try {
-      const res = await fetch("/api/v1/auth/reset-password", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ token, password }),
-      });
-
-      if (!res.ok) {
-        const body = await res.json();
-        if (body.error === "invalid_or_expired_token") {
-          setError("This reset link has expired or already been used. Please request a new one.");
-        } else {
-          setError(body.error ?? "Something went wrong.");
-        }
-        return;
-      }
-
-      setSuccess(true);
-    } catch {
-      setError("Network error. Please try again.");
-    } finally {
-      setSubmitting(false);
-    }
+    await trigger({ token, password });
   }
 
   if (!token && !success) {

--- a/apps/writer-web/app/settings/security/page.test.tsx
+++ b/apps/writer-web/app/settings/security/page.test.tsx
@@ -1,7 +1,27 @@
-import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import type { ReactElement } from "react";
 import { mockUseAuth } from "../../../vitest.setup";
+import { fetcher } from "../../lib/fetcher";
 import SecuritySettingsPage from "./page";
+
+function renderWithSWR(ui: ReactElement) {
+  return render(
+    <SWRConfig
+      value={{
+        fetcher,
+        provider: () => new Map(),
+        dedupingInterval: 0,
+        shouldRetryOnError: false,
+        revalidateOnFocus: false,
+        revalidateOnReconnect: false,
+      }}
+    >
+      {ui}
+    </SWRConfig>
+  );
+}
 
 describe("SecuritySettingsPage", () => {
   beforeEach(() => {
@@ -10,8 +30,12 @@ describe("SecuritySettingsPage", () => {
     globalThis.fetch = vi.fn();
   });
 
+  afterEach(() => {
+    cleanup();
+  });
+
   it("shows sign-in prompt without active session", () => {
-    render(<SecuritySettingsPage />);
+    renderWithSWR(<SecuritySettingsPage />);
 
     expect(screen.getByText("Security")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "sign in" })).toHaveAttribute("href", "/signin");

--- a/apps/writer-web/app/settings/security/page.tsx
+++ b/apps/writer-web/app/settings/security/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import { useState, useCallback, useEffect, type FormEvent } from "react";
+import { useState, type FormEvent } from "react";
+import useSWR from "swr";
+import useSWRMutation from "swr/mutation";
 import { useAuth } from "../../lib/AuthProvider";
+import { fetcher, ApiError } from "../../lib/fetcher";
 
 type MfaState =
   | { step: "loading" }
@@ -12,6 +15,42 @@ type MfaState =
   | { step: "backup-codes"; codes: string[] }
   | { step: "confirm-disable" };
 
+type MfaStatusResponse = { mfaEnabled: boolean };
+type MfaSetupResponse = { secret: string; otpauthUrl: string };
+type MfaVerifyResponse = { backupCodes: string[] };
+
+function extractBodyError(err: unknown): string | null {
+  if (!(err instanceof ApiError)) return null;
+  const b = err.body;
+  if (
+    b !== null &&
+    typeof b === "object" &&
+    "error" in b &&
+    typeof (b as Record<string, unknown>)["error"] === "string"
+  ) {
+    return (b as Record<string, unknown>)["error"] as string;
+  }
+  return null;
+}
+
+async function postMfa<T>(url: string): Promise<T> {
+  return fetcher<T>(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function postMfaWithBody<T, A>(
+  url: string,
+  { arg }: { arg: A }
+): Promise<T> {
+  return fetcher<T>(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(arg),
+  });
+}
+
 export default function SecuritySettingsPage() {
   const { user, loading: authLoading } = useAuth();
   const [mfaState, setMfaState] = useState<MfaState>({ step: "loading" });
@@ -19,35 +58,87 @@ export default function SecuritySettingsPage() {
   const [password, setPassword] = useState("");
   const [disableCode, setDisableCode] = useState("");
   const [error, setError] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [loaded, setLoaded] = useState(false);
 
-  // Load MFA status on first render
-  const loadStatus = useCallback(async () => {
-    if (!user) return;
-    try {
-      const res = await fetch("/api/v1/auth/mfa/status", {
-        credentials: "include"
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setMfaState(data.mfaEnabled ? { step: "enabled" } : { step: "disabled" });
-      } else {
-        setMfaState({ step: "disabled" });
-      }
-    } catch {
+  // Auth-paused key: null while auth resolves or no user
+  const mfaKey = authLoading || !user ? null : "/api/v1/auth/mfa/status";
+
+  useSWR<MfaStatusResponse>(mfaKey, fetcher, {
+    onSuccess(d) {
+      setMfaState(d.mfaEnabled ? { step: "enabled" } : { step: "disabled" });
+    },
+    onError() {
       setError("Failed to load MFA status.");
       setMfaState({ step: "disabled" });
-    } finally {
-      setLoaded(true);
-    }
-  }, [user]);
+    },
+  });
 
-  useEffect(() => {
-    if (!loaded && user) {
-      queueMicrotask(() => { void loadStatus(); });
+  const { trigger: triggerSetup, isMutating: settingUp } = useSWRMutation<
+    MfaSetupResponse
+  >(
+    "/api/v1/auth/mfa/setup",
+    postMfa,
+    {
+      throwOnError: false,
+      onSuccess(data) {
+        setMfaState({ step: "setup", secret: data.secret, otpauthUrl: data.otpauthUrl });
+      },
+      onError(err: unknown) {
+        const code = extractBodyError(err);
+        setError(code === "mfa_already_enabled" ? "MFA is already enabled." : (code ?? "Setup failed."));
+      },
     }
-  }, [loadStatus, loaded, user]);
+  );
+
+  const { trigger: triggerVerify, isMutating: verifying } = useSWRMutation<
+    MfaVerifyResponse,
+    unknown,
+    string,
+    { code: string }
+  >(
+    "/api/v1/auth/mfa/verify-setup",
+    postMfaWithBody,
+    {
+      throwOnError: false,
+      onSuccess(data) {
+        setTotpCode("");
+        setMfaState({ step: "backup-codes", codes: data.backupCodes });
+      },
+      onError(err: unknown) {
+        const code = extractBodyError(err);
+        setError(code === "invalid_totp_code" ? "Invalid code. Please try again." : (code ?? "Verification failed."));
+      },
+    }
+  );
+
+  const { trigger: triggerDisable, isMutating: disabling } = useSWRMutation<
+    void,
+    unknown,
+    string,
+    { password: string; code: string }
+  >(
+    "/api/v1/auth/mfa/disable",
+    postMfaWithBody,
+    {
+      throwOnError: false,
+      onSuccess() {
+        setPassword("");
+        setDisableCode("");
+        setMfaState({ step: "disabled" });
+      },
+      onError(err: unknown) {
+        const code = extractBodyError(err);
+        if (code === "invalid_password") {
+          setError("Incorrect password.");
+        } else if (code === "invalid_totp_code") {
+          setError("Invalid authentication code.");
+        } else {
+          setError(code ?? "Failed to disable MFA.");
+        }
+      },
+    }
+  );
+
+  const submitting = settingUp || verifying || disabling;
 
   if (!authLoading && !user) {
     return (
@@ -67,83 +158,19 @@ export default function SecuritySettingsPage() {
 
   async function handleStartSetup() {
     setError("");
-    setSubmitting(true);
-    try {
-      const res = await fetch("/api/v1/auth/mfa/setup", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        credentials: "include"
-      });
-      if (!res.ok) {
-        const body = await res.json();
-        setError(body.error === "mfa_already_enabled" ? "MFA is already enabled." : (body.error ?? "Setup failed."));
-        return;
-      }
-      const data = await res.json();
-      setMfaState({ step: "setup", secret: data.secret, otpauthUrl: data.otpauthUrl });
-    } catch {
-      setError("Network error. Please try again.");
-    } finally {
-      setSubmitting(false);
-    }
+    await triggerSetup();
   }
 
   async function handleVerifySetup(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setError("");
-    setSubmitting(true);
-    try {
-      const res = await fetch("/api/v1/auth/mfa/verify-setup", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ code: totpCode })
-      });
-      if (!res.ok) {
-        const body = await res.json();
-        setError(body.error === "invalid_totp_code" ? "Invalid code. Please try again." : (body.error ?? "Verification failed."));
-        return;
-      }
-      const data = await res.json();
-      setTotpCode("");
-      setMfaState({ step: "backup-codes", codes: data.backupCodes });
-    } catch {
-      setError("Network error. Please try again.");
-    } finally {
-      setSubmitting(false);
-    }
+    await triggerVerify({ code: totpCode });
   }
 
   async function handleDisable(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setError("");
-    setSubmitting(true);
-    try {
-      const res = await fetch("/api/v1/auth/mfa/disable", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ password, code: disableCode })
-      });
-      if (!res.ok) {
-        const body = await res.json();
-        if (body.error === "invalid_password") {
-          setError("Incorrect password.");
-        } else if (body.error === "invalid_totp_code") {
-          setError("Invalid authentication code.");
-        } else {
-          setError(body.error ?? "Failed to disable MFA.");
-        }
-        return;
-      }
-      setPassword("");
-      setDisableCode("");
-      setMfaState({ step: "disabled" });
-    } catch {
-      setError("Network error. Please try again.");
-    } finally {
-      setSubmitting(false);
-    }
+    await triggerDisable({ password, code: disableCode });
   }
 
   function handleCopyBackupCodes(codes: string[]) {
@@ -186,7 +213,7 @@ export default function SecuritySettingsPage() {
             onClick={handleStartSetup}
             disabled={submitting}
           >
-            {submitting ? "Starting setup..." : "Enable Two-Factor Authentication"}
+            {settingUp ? "Starting setup..." : "Enable Two-Factor Authentication"}
           </button>
         )}
 
@@ -242,7 +269,7 @@ export default function SecuritySettingsPage() {
                 className="btn btn-primary w-full justify-center"
                 disabled={submitting || totpCode.length !== 6}
               >
-                {submitting ? "Verifying..." : "Verify and Enable"}
+                {verifying ? "Verifying..." : "Verify and Enable"}
               </button>
               <button
                 type="button"
@@ -312,10 +339,10 @@ export default function SecuritySettingsPage() {
             </div>
             <button
               type="button"
-              className="btn border border-red-500 text-red-600 hover:bg-red-50 w-full justify-center"
+              className="btn btn-secondary w-full justify-center"
               onClick={() => { setMfaState({ step: "confirm-disable" }); setError(""); }}
             >
-              Disable Two-Factor Authentication
+              Disable 2FA
             </button>
           </div>
         )}
@@ -323,9 +350,8 @@ export default function SecuritySettingsPage() {
         {/* Confirm disable */}
         {mfaState.step === "confirm-disable" && (
           <form className="stack" onSubmit={handleDisable}>
-            <p className="text-sm text-red-600 font-medium">
-              To disable two-factor authentication, enter your password and a code from your
-              authenticator app.
+            <p className="text-sm text-foreground-secondary">
+              Enter your password and current authenticator code to disable 2FA.
             </p>
 
             <label className="stack-tight">
@@ -368,7 +394,7 @@ export default function SecuritySettingsPage() {
                 className="btn bg-red-600 text-white hover:bg-red-700 flex-1"
                 disabled={submitting || !password || disableCode.length !== 6}
               >
-                {submitting ? "Disabling..." : "Disable 2FA"}
+                {disabling ? "Disabling..." : "Disable 2FA"}
               </button>
             </div>
           </form>

--- a/apps/writer-web/app/signin/page.test.tsx
+++ b/apps/writer-web/app/signin/page.test.tsx
@@ -1,7 +1,10 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SWRConfig } from "swr";
+import type { ReactElement } from "react";
 import { mockRefreshAuth, mockUseAuth } from "../../vitest.setup";
+import { fetcher } from "../lib/fetcher";
 import SignInPage from "./page";
 
 const mockReplace = vi.fn();
@@ -16,13 +19,31 @@ function jsonResponse(payload: unknown, status = 200): Response {
   });
 }
 
+function renderWithSWR(ui: ReactElement) {
+  return render(
+    <SWRConfig
+      value={{
+        fetcher,
+        provider: () => new Map(),
+        dedupingInterval: 0,
+        shouldRetryOnError: false,
+      }}
+    >
+      {ui}
+    </SWRConfig>
+  );
+}
+
 describe("SignInPage", () => {
   beforeEach(() => {
-    cleanup();
     mockUseAuth.mockReturnValue({ user: null, loading: false });
     mockRefreshAuth.mockReset();
     mockReplace.mockClear();
     vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it("registers a user and refreshes auth context", async () => {
@@ -42,7 +63,7 @@ describe("SignInPage", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    render(<SignInPage />);
+    renderWithSWR(<SignInPage />);
     const user = userEvent.setup();
 
     await user.click(screen.getByRole("button", { name: "Create account" }));
@@ -70,7 +91,7 @@ describe("SignInPage", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    render(<SignInPage />);
+    renderWithSWR(<SignInPage />);
     const user = userEvent.setup();
 
     await user.type(screen.getByLabelText("Email"), "writer@example.com");
@@ -118,7 +139,7 @@ describe("SignInPage", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    render(<SignInPage />);
+    renderWithSWR(<SignInPage />);
     const user = userEvent.setup();
 
     await user.click(screen.getByRole("button", { name: "Continue with Google" }));
@@ -135,11 +156,14 @@ describe("SignInPage", () => {
 
 describe("SignInPage lockout hints", () => {
   beforeEach(() => {
-    cleanup();
     mockUseAuth.mockReturnValue({ user: null, loading: false });
     mockRefreshAuth.mockReset();
     mockReplace.mockClear();
     vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   async function submitLoginForm(

--- a/apps/writer-web/app/signin/page.tsx
+++ b/apps/writer-web/app/signin/page.tsx
@@ -2,12 +2,43 @@
 
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
+import useSWRMutation from "swr/mutation";
 import { refreshAuth, useAuth } from "../lib/AuthProvider";
 import { formatUserLabel } from "../lib/authSession";
 import { SignInIllustration } from "../components/illustrations";
 import { PasswordStrengthMeter } from "../components/PasswordStrengthMeter";
+import { fetcher, ApiError } from "../lib/fetcher";
 
 type AuthMode = "register" | "login";
+
+type LoginArg = { email: string; password: string };
+type RegisterArg = { email: string; password: string; displayName: string; acceptTerms: boolean };
+type AuthArg = LoginArg | RegisterArg;
+
+async function postAuth(
+  url: string,
+  { arg }: { arg: AuthArg }
+): Promise<unknown> {
+  return fetcher(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(arg),
+  });
+}
+
+function extractBodyError(err: unknown): string | null {
+  if (!(err instanceof ApiError)) return null;
+  const b = err.body;
+  if (
+    b !== null &&
+    typeof b === "object" &&
+    "error" in b &&
+    typeof (b as Record<string, unknown>)["error"] === "string"
+  ) {
+    return (b as Record<string, unknown>)["error"] as string;
+  }
+  return null;
+}
 
 export default function SignInPage() {
   const router = useRouter();
@@ -18,7 +49,6 @@ export default function SignInPage() {
   const [displayName, setDisplayName] = useState("");
   const [status, setStatus] = useState<string>("");
   const [failureCount, setFailureCount] = useState(0);
-  const [submitting, setSubmitting] = useState(false);
   const [oauthSubmitting, setOauthSubmitting] = useState(false);
   const [acceptTerms, setAcceptTerms] = useState(false);
 
@@ -62,44 +92,44 @@ export default function SignInPage() {
 
   const modeLabel = useMemo(() => (mode === "register" ? "Create account" : "Sign in"), [mode]);
 
-  async function submit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    setStatus("");
-    setSubmitting(true);
+  const authKey = mode === "register" ? "/api/v1/auth/register" : "/api/v1/auth/login";
 
-    try {
-      const payload =
-        mode === "register"
-          ? { email, password, displayName, acceptTerms }
-          : {
-              email,
-              password
-            };
-      const response = await fetch(
-        mode === "register" ? "/api/v1/auth/register" : "/api/v1/auth/login",
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify(payload)
+  const { trigger: triggerAuth, isMutating: submitting } = useSWRMutation(
+    authKey,
+    postAuth,
+    {
+      throwOnError: false,
+      onSuccess() {
+        refreshAuth();
+        setPassword("");
+        router.replace(mode === "register" ? "/verify-email" : "/");
+      },
+      onError(err: unknown) {
+        const bodyError = extractBodyError(err);
+        if (bodyError !== null) {
+          setStatus(`Error: ${bodyError}`);
+        } else if (err instanceof Error) {
+          setStatus(err.message);
+        } else {
+          setStatus("unknown_error");
         }
-      );
-      const body = await response.json();
-      if (!response.ok) {
-        setStatus(body.error ? `Error: ${body.error}` : "Unable to authenticate.");
         if (mode === "login") {
           setFailureCount((c) => c + 1);
         }
-        return;
-      }
-
-      refreshAuth();
-      setPassword("");
-      router.replace(mode === "register" ? "/verify-email" : "/");
-    } catch (error) {
-      setStatus(error instanceof Error ? error.message : "unknown_error");
-    } finally {
-      setSubmitting(false);
+      },
     }
+  );
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setStatus("");
+
+    const arg: AuthArg =
+      mode === "register"
+        ? { email, password, displayName, acceptTerms }
+        : { email, password };
+
+    await triggerAuth(arg);
   }
 
   async function signOut() {

--- a/apps/writer-web/vitest.config.ts
+++ b/apps/writer-web/vitest.config.ts
@@ -1,8 +1,10 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  esbuild: {
-    jsx: "automatic"
+  oxc: {
+    jsx: {
+      runtime: "automatic"
+    }
   },
   test: {
     environment: "jsdom",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8177,11 +8177,6 @@ snapshots:
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       yaml: 2.9.0
 
-  '@opentelemetry/configuration@0.218.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      yaml: 2.9.0
 
   '@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:


### PR DESCRIPTION
## Summary
Migrates 4 misc client pages to SWR:
- **competitions** (public) — `useSWR` with `buildKey(committedFilters)` pattern (search-on-submit, auto-loads with empty filters on mount)
- **reset-password** — `useSWRMutation` for form submit; removes `useEffect + fetch`
- **settings/security** — auth-paused `useSWR` for MFA status load; `useSWRMutation` for MFA setup/verify/disable mutations
- **signin** — `useSWRMutation` for login/register submit; preserves `refreshAuth()` on success; keeps `queueMicrotask` for non-fetch deferred setState

Also fixes `vitest.config.ts`: replaces `esbuild.jsx` with `oxc.jsx.runtime=automatic` to resolve Vite 8 OXC JSX transform regression that was breaking all 160 test files.

## Linear
- Implements CHAOS-1532
- Part of CHAOS-1517 Phase 2 Bulk

## Verification
- typecheck ✅
- lint (0 errors) ✅
- test (160 files / 444 tests all pass) ✅
- build ✅