### PR TITLE
fix: dedupe @opentelemetry/configuration in pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8177,11 +8177,6 @@ snapshots:
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       yaml: 2.9.0
 
-  '@opentelemetry/configuration@0.218.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      yaml: 2.9.0
 
   '@opentelemetry/context-async-hooks@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:


### PR DESCRIPTION
## Problem
`pnpm-lock.yaml` has a duplicated mapping key `'@opentelemetry/configuration@0.218.0(@opentelemetry/api@1.9.1)'` at lines 8174 and 8180 — left over from overlapping merges of #462 (auto-instrumentations-node) and #463 (sdk-node).

CI fails on every PR with:
```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at "...pnpm-lock.yaml" is broken: duplicated mapping key (8180:3)
```

Local pnpm (10.31.0) tolerates the dup; CI's `pnpm install --frozen-lockfile` does not.

## Fix
Remove the duplicate block. Verified: `pnpm install --frozen-lockfile` now succeeds.

## Impact
Unblocks Phase 2 PRs #468 #469 #470 #471.