### PR TITLE
sec(CHAOS-1533): resolve trivy CI failures from vulnerable deps

### DIFF
--- a/infra/docker/db-migrator.Dockerfile
+++ b/infra/docker/db-migrator.Dockerfile
@@ -69,6 +69,11 @@ RUN --mount=type=cache,id=pnpm-store-db-migrator,target=/pnpm/store,sharing=lock
       --fetch-retry-mintimeout=10000 \
       --fetch-retry-maxtimeout=120000
 
+# Strip pnpm + npm from the final image — runtime uses `node --import tsx`
+# and these CLIs ship bundled tar/picomatch that Trivy flags as HIGH.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/pnpm \
+ && rm -f /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/pnpm /usr/local/bin/pnpx
+
 ENV NODE_ENV=production
 ENV OTEL_SERVICE_NAME=db-migrator
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
     "overrides": {
       "fast-xml-parser": "^5.5.6",
       "readdir-glob>minimatch": "^5.1.8",
-      "lodash": ">=4.18.0"
+      "lodash": ">=4.18.0",
+      "protobufjs@>=8.0.0 <8.0.2": "^8.0.2",
+      "fast-uri@<3.1.2": "^3.1.2",
+      "defu@<6.1.5": "^6.1.5"
     }
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ overrides:
   fast-xml-parser: ^5.5.6
   readdir-glob>minimatch: ^5.1.8
   lodash: '>=4.18.0'
+  protobufjs@>=8.0.0 <8.0.2: ^8.0.2
+  fast-uri@<3.1.2: ^3.1.2
+  defu@<6.1.5: ^6.1.5
 
 importers:
 
@@ -4729,11 +4732,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
-
-  fast-uri@3.1.1:
-    resolution: {integrity: sha512-h2r7rcm6Ee/J8o0LD5djLuFVcfbZxhvho4vvsbeV0aMvXjUgqv4YpxpkEx0d68l6+IleVfLAdVEfhR7QNMkGHQ==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-xml-builder@1.1.7:
     resolution: {integrity: sha512-Yh7/7rQuMXICNr0oMYDR2yHP6oUvmQsTToFeOWj/kIDhAwQ+c4Ol/lbcwOmEM5OHYQmh6S6EQSQ1sljCKP36bQ==}
@@ -5865,8 +5865,8 @@ packages:
     resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
     engines: {node: '>=12.0.0'}
 
-  protobufjs@8.0.1:
-    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
+  protobufjs@8.3.0:
+    resolution: {integrity: sha512-JpJpFaR7yKNb6WqKvJJ1MLbiuIQWQnbUUb06nDtf2/i8YWYYLEfP6xf9BwSJoJQg1wAy61EQB8dssQg64oX4aA==}
     engines: {node: '>=12.0.0'}
 
   proxy-from-env@1.1.0:
@@ -7715,7 +7715,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.1
+      fast-uri: 3.1.2
 
   '@fastify/cookie@11.0.2':
     dependencies:
@@ -8867,7 +8867,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.216.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-      protobufjs: 8.0.1
+      protobufjs: 8.3.0
 
   '@opentelemetry/otlp-transformer@0.218.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -10484,7 +10484,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.1
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -11485,7 +11485,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.1
+      fast-uri: 3.1.2
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -11497,9 +11497,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@3.1.0: {}
-
-  fast-uri@3.1.1: {}
+  fast-uri@3.1.2: {}
 
   fast-xml-builder@1.1.7:
     dependencies:
@@ -12084,7 +12082,7 @@ snapshots:
   json-schema-resolver@3.0.0:
     dependencies:
       debug: 4.4.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       rfdc: 1.4.1
     transitivePeerDependencies:
       - supports-color
@@ -12655,19 +12653,8 @@ snapshots:
       '@types/node': 25.7.0
       long: 5.3.2
 
-  protobufjs@8.0.1:
+  protobufjs@8.3.0:
     dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.1
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.1
-      '@types/node': 25.7.0
       long: 5.3.2
 
   proxy-from-env@1.1.0: {}

--- a/services/script-storage-service/src/index.ts
+++ b/services/script-storage-service/src/index.ts
@@ -147,7 +147,7 @@ export function buildServer(options: ScriptStorageServiceOptions = {}): FastifyI
     )}`;
     const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
 
-    let uploadUrl = `${uploadBaseUrl.replace(/\/+$/g, "")}/${storageBucket}`;
+    let uploadUrl = `${stripTrailingSlashes(uploadBaseUrl)}/${storageBucket}`;
     let uploadFields: Record<string, string> = {
       key: objectKey,
       bucket: storageBucket,
@@ -374,6 +374,12 @@ function normalizeFilename(filename: string): string {
       .replace(/[^a-z0-9._-]+/g, "-")
       .replace(/^-+|-+$/g, "") || "script.pdf"
   );
+}
+
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47 /* '/' */) end--;
+  return value.slice(0, end);
 }
 
 function buildS3Client(options: {


### PR DESCRIPTION
## Summary

Docker build & push workflow (Trivy gate) has been failing on `main` for every push. This PR resolves all open **HIGH** findings from both Trivy and the related Dependabot alerts.

Failing run: <https://github.com/full-chaos/script-manifest/actions/runs/25835266858/job/75909319706>
Linear: [CHAOS-1533](https://linear.app/fullchaos/issue/CHAOS-1533)

## Changes

### 1. App dependency CVEs — pnpm overrides

Added narrow-scope `pnpm.overrides` in root `package.json` so transitive deps resolve to patched versions without forcing an unsafe major bump:

| Package | Before | After | CVEs fixed |
|---|---|---|---|
| `protobufjs` | 8.0.1 | 8.3.0 (any `^8.0.2`) | CVE-2026-44289/44290/44291/44293 |
| `fast-uri` | 3.1.0, 3.1.1 | 3.1.2 | CVE-2026-6321, CVE-2026-6322 |
| `defu` | already 6.1.7 | unchanged | CVE-2026-35209 (defensive) |

### 2. db-migrator runtime image strips pnpm + npm

`infra/docker/db-migrator.Dockerfile` was installing pnpm in the runner stage but never removing it. The bundled tar (CVE-2026-31802) and picomatch (CVE-2026-33671) inside that pnpm CLI were tripping Trivy. The same npm bundle (also shipping vulnerable picomatch) was likewise unstripped.

Final image now removes both, mirroring the existing cleanup in `service.Dockerfile`. Runtime entrypoint is `node --import tsx scripts/run-migrations.ts` — neither CLI is needed.

### 3. CodeQL `js/polynomial-redos`

`services/script-storage-service/src/index.ts:150` was running `uploadBaseUrl.replace(/\/+\$/g, '')` on a user/operator-controlled URL, flagged by CodeQL as polynomial ReDoS. Replaced with a bounded slice loop helper `stripTrailingSlashes` — same behaviour, no regex engine on tainted input.

## Verification

- `pnpm install --lockfile-only` — lockfile diff is small (14+/27-) and resolves only the targeted packages
- `pnpm --filter @script-manifest/script-storage-service typecheck` — clean
- `pnpm --filter @script-manifest/script-storage-service test` — **11/11 pass**
- `pnpm --filter @script-manifest/script-storage-service lint` — **0 errors** (only pre-existing warnings in untouched `repository.ts`)
- LSP diagnostics on changed file — clean

End-to-end image validation will be performed by the Docker workflow Trivy gate itself when this PR merges.