### PR TITLE
feat(writer-web): phase 3 special cases - SWR + useClock (CHAOS-1518)

### DIFF
--- a/apps/writer-web/app/competitions/page.tsx
+++ b/apps/writer-web/app/competitions/page.tsx
@@ -10,6 +10,7 @@ import { SkeletonCard } from "../components/skeleton";
 import { useToast } from "../components/toast";
 import { useAuth } from "../lib/AuthProvider";
 import { fetcher, ApiError } from "../lib/fetcher";
+import { useClock } from "../lib/useClock";
 
 type Filters = {
   query: string;
@@ -96,11 +97,7 @@ export default function CompetitionsPage() {
   const [reminderMessage, setReminderMessage] = useState("");
   const [sendingReminder, setSendingReminder] = useState(false);
 
-  const [now, setNow] = useState<number>(() => Date.now());
-  useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), 60_000);
-    return () => clearInterval(id);
-  }, []);
+  const now = useClock(60_000);
 
   // Fire-and-forget onboarding progress when logged-in user visits
   useEffect(() => {

--- a/apps/writer-web/app/components/notificationBell.test.tsx
+++ b/apps/writer-web/app/components/notificationBell.test.tsx
@@ -1,6 +1,20 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, waitFor, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { SWRConfig } from "swr";
 import { NotificationBell } from "./notificationBell";
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0, shouldRetryOnError: false }}>
+      {children}
+    </SWRConfig>
+  );
+}
+
+function renderBell() {
+  return render(<NotificationBell />, { wrapper: Wrapper });
+}
 
 function mockFetch(responses: Record<string, unknown>) {
   const entries = Object.entries(responses).sort(([a], [b]) => b.length - a.length);
@@ -31,13 +45,13 @@ describe("NotificationBell", () => {
 
   it("renders bell button", () => {
     mockFetch({ "unread-count": { count: 0 } });
-    render(<NotificationBell />);
+    renderBell();
     expect(screen.getByTestId("notification-bell")).toBeInTheDocument();
   });
 
   it("shows unread badge when count > 0", async () => {
     mockFetch({ "unread-count": { count: 3 } });
-    render(<NotificationBell />);
+    renderBell();
 
     await waitFor(() => {
       expect(screen.getByTestId("unread-badge")).toBeInTheDocument();
@@ -48,7 +62,7 @@ describe("NotificationBell", () => {
 
   it("shows 99+ when count exceeds 99", async () => {
     mockFetch({ "unread-count": { count: 150 } });
-    render(<NotificationBell />);
+    renderBell();
 
     await waitFor(() => {
       expect(screen.getByTestId("unread-badge")).toHaveTextContent("99+");
@@ -57,7 +71,7 @@ describe("NotificationBell", () => {
 
   it("does not show badge when count is 0", async () => {
     mockFetch({ "unread-count": { count: 0 } });
-    render(<NotificationBell />);
+    renderBell();
 
     await vi.advanceTimersByTimeAsync(100);
     expect(screen.queryByTestId("unread-badge")).not.toBeInTheDocument();
@@ -80,7 +94,7 @@ describe("NotificationBell", () => {
       },
     });
 
-    render(<NotificationBell />);
+    renderBell();
     fireEvent.click(screen.getByTestId("notification-bell"));
 
     await waitFor(() => {
@@ -94,7 +108,7 @@ describe("NotificationBell", () => {
       "notifications?": { events: [] },
     });
 
-    render(<NotificationBell />);
+    renderBell();
     fireEvent.click(screen.getByTestId("notification-bell"));
 
     await waitFor(() => {
@@ -122,7 +136,7 @@ describe("NotificationBell", () => {
       "evt_1/read": { updated: true },
     });
 
-    render(<NotificationBell />);
+    renderBell();
     fireEvent.click(screen.getByTestId("notification-bell"));
 
     await waitFor(() => {
@@ -145,7 +159,7 @@ describe("NotificationBell", () => {
       "notifications?": { events: [] },
     });
 
-    render(<NotificationBell />);
+    renderBell();
     fireEvent.click(screen.getByTestId("notification-bell"));
 
     await waitFor(() => {
@@ -157,5 +171,42 @@ describe("NotificationBell", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("notification-dropdown")).not.toBeInTheDocument();
     });
+  });
+
+  it("polls unread-count every 30 seconds (SWR refreshInterval)", async () => {
+    let currentCount = 0;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("unread-count")) {
+        return { ok: true, json: async () => ({ count: currentCount }) } as Response;
+      }
+      return { ok: false, status: 404, json: async () => ({}) } as Response;
+    });
+
+    renderBell();
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("unread-count"),
+        expect.any(Object),
+      );
+    });
+    const initialCalls = fetchSpy.mock.calls.filter(([input]) =>
+      String(input).includes("unread-count"),
+    ).length;
+
+    currentCount = 7;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("unread-badge")).toHaveTextContent("7");
+    });
+
+    const laterCalls = fetchSpy.mock.calls.filter(([input]) =>
+      String(input).includes("unread-count"),
+    ).length;
+    expect(laterCalls).toBeGreaterThan(initialCalls);
   });
 });

--- a/apps/writer-web/app/components/notificationBell.tsx
+++ b/apps/writer-web/app/components/notificationBell.tsx
@@ -1,12 +1,20 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Bell } from "lucide-react";
+import useSWR, { useSWRConfig } from "swr";
+import useSWRMutation from "swr/mutation";
 import type { NotificationEventEnvelope } from "@script-manifest/contracts";
+import { fetcher } from "../lib/fetcher";
 
 const POLL_INTERVAL_MS = 30_000;
+const UNREAD_COUNT_KEY = "/api/v1/notifications/unread-count";
+const NOTIFICATIONS_KEY = "/api/v1/notifications?limit=20";
 
 type NotificationItem = NotificationEventEnvelope & { readAt?: string | null };
+
+type UnreadCountResponse = { count?: number };
+type NotificationsResponse = { events?: NotificationItem[] };
 
 function formatEventLabel(event: NotificationItem): string {
   const labels: Record<string, string> = {
@@ -37,28 +45,37 @@ function timeAgo(isoDate: string): string {
   return `${days}d ago`;
 }
 
+async function patchMarkRead(url: string, { arg }: { arg: string }): Promise<void> {
+  await fetch(`${url}/${encodeURIComponent(arg)}/read`, { method: "PATCH" });
+}
+
 export function NotificationBell() {
-  const [unreadCount, setUnreadCount] = useState(0);
-  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
   const [open, setOpen] = useState(false);
-  const [loading, setLoading] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  const fetchUnreadCount = useCallback(async () => {
-    try {
-      const res = await fetch("/api/v1/notifications/unread-count", { cache: "no-store" });
-      if (res.ok) {
-        const body = (await res.json()) as { count?: number };
-        setUnreadCount(body.count ?? 0);
-      }
-    } catch { /* non-critical */ }
-  }, []);
+  const { data: unreadData, mutate: mutateUnread } = useSWR<UnreadCountResponse>(
+    UNREAD_COUNT_KEY,
+    fetcher,
+    { refreshInterval: POLL_INTERVAL_MS, shouldRetryOnError: false },
+  );
+  const unreadCount = unreadData?.count ?? 0;
 
-  useEffect(() => {
-    queueMicrotask(() => { void fetchUnreadCount(); });
-    const interval = setInterval(() => void fetchUnreadCount(), POLL_INTERVAL_MS);
-    return () => clearInterval(interval);
-  }, [fetchUnreadCount]);
+  const {
+    data: notificationsData,
+    isLoading: notificationsLoading,
+    mutate: mutateNotifications,
+  } = useSWR<NotificationsResponse>(
+    open ? NOTIFICATIONS_KEY : null,
+    fetcher,
+    { shouldRetryOnError: false },
+  );
+  const notifications = notificationsData?.events ?? [];
+
+  const { trigger: triggerMarkRead } = useSWRMutation(
+    "/api/v1/notifications",
+    patchMarkRead,
+  );
+  const { mutate: globalMutate } = useSWRConfig();
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -72,45 +89,42 @@ export function NotificationBell() {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [open]);
 
-  async function fetchNotifications() {
-    setLoading(true);
-    try {
-      const res = await fetch("/api/v1/notifications?limit=20", { cache: "no-store" });
-      if (res.ok) {
-        const body = (await res.json()) as { events?: NotificationItem[] };
-        setNotifications(body.events ?? []);
-      }
-    } catch { /* non-critical */ } finally {
-      setLoading(false);
-    }
-  }
-
-  async function handleToggle() {
-    if (!open) {
-      void fetchNotifications();
-    }
+  function handleToggle() {
     setOpen((prev) => !prev);
   }
 
   async function markRead(eventId: string) {
-    setNotifications((prev) =>
-      prev.map((n) => (n.eventId === eventId ? { ...n, readAt: new Date().toISOString() } : n))
+    await mutateNotifications(
+      (prev: NotificationsResponse | undefined) => ({
+        events: (prev?.events ?? []).map((n) =>
+          n.eventId === eventId ? { ...n, readAt: new Date().toISOString() } : n,
+        ),
+      }),
+      { revalidate: false },
     );
-    setUnreadCount((prev) => Math.max(0, prev - 1));
+    await mutateUnread(
+      (prev: UnreadCountResponse | undefined) => ({
+        count: Math.max(0, (prev?.count ?? 0) - 1),
+      }),
+      { revalidate: false },
+    );
 
     try {
-      await fetch(`/api/v1/notifications/${encodeURIComponent(eventId)}/read`, {
-        method: "PATCH",
-      });
-    } catch { /* non-critical */ }
+      await triggerMarkRead(eventId);
+    } catch {
+      void globalMutate(UNREAD_COUNT_KEY);
+      void globalMutate(NOTIFICATIONS_KEY);
+    }
   }
+
+  const loading = notificationsLoading && notifications.length === 0;
 
   return (
     <div className="relative" ref={dropdownRef}>
       <button
         type="button"
         className="btn btn-secondary p-2! relative"
-        onClick={() => void handleToggle()}
+        onClick={handleToggle}
         aria-label={`Notifications${unreadCount > 0 ? `, ${unreadCount} unread` : ""}`}
         data-testid="notification-bell"
       >
@@ -135,7 +149,7 @@ export function NotificationBell() {
           </div>
 
           <div className="max-h-80 overflow-y-auto">
-            {loading && notifications.length === 0 && (
+            {loading && (
               <div className="px-4 py-6 text-center text-sm text-foreground-secondary">Loading…</div>
             )}
 

--- a/apps/writer-web/app/lib/AuthProvider.test.tsx
+++ b/apps/writer-web/app/lib/AuthProvider.test.tsx
@@ -1,0 +1,210 @@
+import { vi } from "vitest";
+vi.unmock("./AuthProvider");
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { SWRConfig, mutate as globalMutate } from "swr";
+import {
+  AuthProvider,
+  AUTH_CHANGED_EVENT,
+  SESSION_CHANGED_EVENT,
+  refreshAuth,
+  useAuth,
+} from "./AuthProvider";
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <SWRConfig value={{ dedupingInterval: 0, shouldRetryOnError: false, revalidateOnFocus: false, revalidateOnReconnect: false }}>
+      <AuthProvider>{children}</AuthProvider>
+    </SWRConfig>
+  );
+}
+
+function Probe() {
+  const { user, loading } = useAuth();
+  return (
+    <div>
+      <span data-testid="loading">{loading ? "yes" : "no"}</span>
+      <span data-testid="user">{user ? user.id : "anon"}</span>
+    </div>
+  );
+}
+
+type SessionFixture = { user: { id: string; email: string; displayName: string; role: string; emailVerified: boolean } };
+
+function buildUser(id: string): SessionFixture {
+  return {
+    user: {
+      id,
+      email: `${id}@example.com`,
+      displayName: id,
+      role: "writer",
+      emailVerified: true,
+    },
+  };
+}
+
+function mockAuthFetch(
+  sequence: Array<"ok" | "unauthorized" | "error"> | ((call: number) => "ok" | "unauthorized" | "error"),
+  userIds: string[] = ["u_1"],
+) {
+  let call = 0;
+  let nextId = 0;
+  const getOutcome =
+    typeof sequence === "function" ? sequence : (c: number) => sequence[Math.min(c, sequence.length - 1)];
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (!url.includes("/api/v1/auth/me")) {
+      return { ok: false, status: 404, json: async () => ({}) } as Response;
+    }
+    const outcome = getOutcome(call);
+    call += 1;
+    if (outcome === "ok") {
+      const id = userIds[Math.min(nextId, userIds.length - 1)] ?? "u_1";
+      nextId += 1;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => buildUser(id),
+      } as Response;
+    }
+    if (outcome === "unauthorized") {
+      return { ok: false, status: 401, json: async () => ({}) } as Response;
+    }
+    throw new Error("network");
+  });
+}
+
+describe("AuthProvider", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(async () => {
+    cleanup();
+    await globalMutate(() => true, undefined, { revalidate: false });
+    vi.restoreAllMocks();
+  });
+
+  it("populates user from /api/v1/auth/me on mount", async () => {
+    mockAuthFetch(["ok"]);
+    render(<Probe />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user")).toHaveTextContent("u_1");
+    });
+    expect(screen.getByTestId("loading")).toHaveTextContent("no");
+  });
+
+  it("returns null user on 401", async () => {
+    mockAuthFetch(["unauthorized"]);
+    render(<Probe />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("no");
+    });
+    expect(screen.getByTestId("user")).toHaveTextContent("anon");
+  });
+
+  it("returns null user on network error (does not throw)", async () => {
+    mockAuthFetch(["error"]);
+    render(<Probe />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("no");
+    });
+    expect(screen.getByTestId("user")).toHaveTextContent("anon");
+  });
+
+  it("revalidates session when AUTH_CHANGED_EVENT fires", async () => {
+    const spy = mockAuthFetch(["unauthorized", "ok"], ["u_revalidated"]);
+    render(<Probe />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user")).toHaveTextContent("anon");
+    });
+    const initialCalls = spy.mock.calls.length;
+
+    act(() => {
+      window.dispatchEvent(new Event(AUTH_CHANGED_EVENT));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user")).toHaveTextContent("u_revalidated");
+    });
+    expect(spy.mock.calls.length).toBeGreaterThan(initialCalls);
+  });
+
+  it("refreshAuth() triggers SWR revalidation", async () => {
+    const spy = mockAuthFetch(["ok", "ok"], ["u_first", "u_second"]);
+    render(<Probe />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user")).toHaveTextContent("u_first");
+    });
+    const initialCalls = spy.mock.calls.length;
+
+    act(() => {
+      refreshAuth();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user")).toHaveTextContent("u_second");
+    });
+    expect(spy.mock.calls.length).toBeGreaterThan(initialCalls);
+  });
+
+  it("dispatches SESSION_CHANGED_EVENT when user identity changes", async () => {
+    mockAuthFetch(["ok", "ok"], ["u_a", "u_b"]);
+    const sessionListener = vi.fn();
+    window.addEventListener(SESSION_CHANGED_EVENT, sessionListener);
+
+    try {
+      render(<Probe />, { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("user")).toHaveTextContent("u_a");
+      });
+      expect(sessionListener).toHaveBeenCalled();
+      const callsAfterMount = sessionListener.mock.calls.length;
+
+      act(() => {
+        refreshAuth();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("user")).toHaveTextContent("u_b");
+      });
+      expect(sessionListener.mock.calls.length).toBeGreaterThan(callsAfterMount);
+    } finally {
+      window.removeEventListener(SESSION_CHANGED_EVENT, sessionListener);
+    }
+  });
+
+  it("does not dispatch SESSION_CHANGED_EVENT when user is unchanged", async () => {
+    mockAuthFetch(["ok", "ok"], ["u_same", "u_same"]);
+    const sessionListener = vi.fn();
+    window.addEventListener(SESSION_CHANGED_EVENT, sessionListener);
+
+    try {
+      render(<Probe />, { wrapper: Wrapper });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("user")).toHaveTextContent("u_same");
+      });
+      const callsAfterMount = sessionListener.mock.calls.length;
+
+      act(() => {
+        refreshAuth();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("user")).toHaveTextContent("u_same");
+      });
+      expect(sessionListener.mock.calls.length).toBe(callsAfterMount);
+    } finally {
+      window.removeEventListener(SESSION_CHANGED_EVENT, sessionListener);
+    }
+  });
+});

--- a/apps/writer-web/app/lib/AuthProvider.tsx
+++ b/apps/writer-web/app/lib/AuthProvider.tsx
@@ -3,17 +3,18 @@
 import type { AuthSessionResponse, AuthUser } from "@script-manifest/contracts";
 import {
   createContext,
-  useCallback,
   useContext,
   useEffect,
   useMemo,
   useRef,
-  useState,
   type ReactNode,
 } from "react";
+import useSWR, { mutate } from "swr";
 
 export const AUTH_CHANGED_EVENT = "auth-changed";
 export const SESSION_CHANGED_EVENT = "script_manifest_session_changed";
+
+export const AUTH_SESSION_KEY = "/api/v1/auth/me";
 
 type AuthContextValue = {
   user: AuthUser | null;
@@ -45,98 +46,83 @@ export function refreshAuth(): void {
     return;
   }
 
-  window.dispatchEvent(new Event(AUTH_CHANGED_EVENT));
+  void mutate(AUTH_SESSION_KEY);
+}
+
+// Returns null on 401/error so the global SWR 401 handler (in SWRProvider)
+// never loops back into refreshAuth() through the auth session itself.
+async function fetchSession(): Promise<AuthUser | null> {
+  try {
+    const response = await fetch(AUTH_SESSION_KEY, {
+      credentials: "include",
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = (await response.json()) as Pick<
+      AuthSessionResponse,
+      "user" | "expiresAt"
+    >;
+    return payload.user;
+  } catch {
+    return null;
+  }
 }
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [user, setUser] = useState<AuthUser | null>(null);
-  const [loading, setLoading] = useState(true);
-  const mountedRef = useRef(true);
+  const { data, isLoading } = useSWR<AuthUser | null>(
+    AUTH_SESSION_KEY,
+    fetchSession,
+    {
+      shouldRetryOnError: false,
+      keepPreviousData: true,
+    },
+  );
 
-  const setUserWithCompatEvent = useCallback((nextUser: AuthUser | null) => {
-    setUser((currentUser: AuthUser | null) => {
-      if (sameUser(currentUser, nextUser)) {
-        return currentUser;
-      }
+  const user = data ?? null;
+  const previousUserRef = useRef<AuthUser | null>(null);
 
-      if (typeof window !== "undefined") {
-        window.dispatchEvent(new CustomEvent(SESSION_CHANGED_EVENT));
-      }
-
-      return nextUser;
-    });
-  }, []);
-
-  const loadAuth = useCallback(async () => {
-    setLoading(true);
-
-    try {
-      const response = await fetch("/api/v1/auth/me", {
-        credentials: "include",
-        cache: "no-store",
-      });
-
-      if (!response.ok) {
-        if (!mountedRef.current) {
-          return;
-        }
-
-        setUserWithCompatEvent(null);
-        return;
-      }
-
-      const payload = (await response.json()) as Pick<AuthSessionResponse, "user" | "expiresAt">;
-
-      if (!mountedRef.current) {
-        return;
-      }
-
-      setUserWithCompatEvent(payload.user);
-    } catch {
-      if (!mountedRef.current) {
-        return;
-      }
-
-      setUserWithCompatEvent(null);
-    } finally {
-      if (mountedRef.current) {
-        setLoading(false);
-      }
-    }
-  }, [setUserWithCompatEvent]);
-
+  // Dispatch the legacy SESSION_CHANGED_EVENT when user identity actually
+  // changes. This keeps external listeners (analytics, integrations) working.
   useEffect(() => {
-    mountedRef.current = true;
-    queueMicrotask(() => { void loadAuth(); });
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const previous = previousUserRef.current;
+    if (!sameUser(previous, user)) {
+      previousUserRef.current = user;
+      window.dispatchEvent(new CustomEvent(SESSION_CHANGED_EVENT));
+    }
+  }, [user]);
+
+  // Wire the legacy AUTH_CHANGED_EVENT into the SWR cache. Other code paths
+  // (e.g. cross-component imperatives) may dispatch this event directly; we
+  // translate it into a cache revalidation.
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
 
     const handleAuthChanged = () => {
-      void loadAuth();
-    };
-
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
-        void loadAuth();
-      }
+      void mutate(AUTH_SESSION_KEY);
     };
 
     window.addEventListener(AUTH_CHANGED_EVENT, handleAuthChanged);
-    window.addEventListener("focus", handleAuthChanged);
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-
     return () => {
-      mountedRef.current = false;
       window.removeEventListener(AUTH_CHANGED_EVENT, handleAuthChanged);
-      window.removeEventListener("focus", handleAuthChanged);
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [loadAuth]);
+  }, []);
 
   const value = useMemo<AuthContextValue>(
     () => ({
       user,
-      loading,
+      loading: isLoading,
     }),
-    [loading, user],
+    [isLoading, user],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/apps/writer-web/app/lib/useClock.ts
+++ b/apps/writer-web/app/lib/useClock.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useClock(intervalMs: number): number {
+  const [now, setNow] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+
+  return now;
+}

--- a/apps/writer-web/app/signin/page.tsx
+++ b/apps/writer-web/app/signin/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import useSWRMutation from "swr/mutation";
 import { refreshAuth, useAuth } from "../lib/AuthProvider";
@@ -14,10 +14,22 @@ type AuthMode = "register" | "login";
 type LoginArg = { email: string; password: string };
 type RegisterArg = { email: string; password: string; displayName: string; acceptTerms: boolean };
 type AuthArg = LoginArg | RegisterArg;
+type OAuthCompleteArg = { state: string; code: string };
 
 async function postAuth(
   url: string,
   { arg }: { arg: AuthArg }
+): Promise<unknown> {
+  return fetcher(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(arg),
+  });
+}
+
+async function postOAuthComplete(
+  url: string,
+  { arg }: { arg: OAuthCompleteArg }
 ): Promise<unknown> {
   return fetcher(url, {
     method: "POST",
@@ -52,33 +64,27 @@ export default function SignInPage() {
   const [oauthSubmitting, setOauthSubmitting] = useState(false);
   const [acceptTerms, setAcceptTerms] = useState(false);
 
-  const completeOAuthFromRedirect = useCallback(async (state: string, code: string) => {
-    setOauthSubmitting(true);
-    setStatus("");
-
-    try {
-      const completeResponse = await fetch("/api/v1/auth/oauth/google/complete", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ state, code })
-      });
-      const completeBody = await completeResponse.json();
-      if (!completeResponse.ok) {
-        setStatus(
-          completeBody.error ? `Error: ${completeBody.error}` : "OAuth callback failed."
-        );
-        return;
-      }
-
+  const {
+    trigger: triggerOAuthComplete,
+    isMutating: oauthRedirectSubmitting,
+  } = useSWRMutation("/api/v1/auth/oauth/google/complete", postOAuthComplete, {
+    throwOnError: false,
+    onSuccess() {
       refreshAuth();
       setPassword("");
       router.replace("/");
-    } catch (error) {
-      setStatus(error instanceof Error ? error.message : "unknown_error");
-    } finally {
-      setOauthSubmitting(false);
-    }
-  }, [router]);
+    },
+    onError(err: unknown) {
+      const bodyError = extractBodyError(err);
+      if (bodyError !== null) {
+        setStatus(`Error: ${bodyError}`);
+      } else if (err instanceof Error) {
+        setStatus(err.message);
+      } else {
+        setStatus("unknown_error");
+      }
+    },
+  });
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -86,9 +92,9 @@ export default function SignInPage() {
     const state = params.get("state");
     if (code && state) {
       window.history.replaceState({}, "", window.location.pathname);
-      queueMicrotask(() => { void completeOAuthFromRedirect(state, code); });
+      void triggerOAuthComplete({ state, code });
     }
-  }, [completeOAuthFromRedirect]);
+  }, [triggerOAuthComplete]);
 
   const modeLabel = useMemo(() => (mode === "register" ? "Create account" : "Sign in"), [mode]);
 
@@ -256,9 +262,9 @@ export default function SignInPage() {
               type="button"
               className="btn btn-primary w-full justify-center"
               onClick={() => void signInWithGoogle()}
-              disabled={oauthSubmitting}
+              disabled={oauthSubmitting || oauthRedirectSubmitting}
             >
-              {oauthSubmitting ? "Connecting..." : "Continue with Google"}
+              {oauthSubmitting || oauthRedirectSubmitting ? "Connecting..." : "Continue with Google"}
             </button>
 
             <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary

Phase 3 of CHAOS-1514 (Modernize writer-web data fetching architecture). Migrates the three remaining special-case data flows away from bespoke \`useState + useEffect + queueMicrotask\` patterns.

- **AuthProvider** — manual \`mountedRef\` + \`loadAuth\` replaced with \`useSWR(\"/api/v1/auth/me\")\`. \`refreshAuth()\` now calls \`mutate()\` directly. \`AUTH_CHANGED_EVENT\` listener preserved for back-compat; \`SESSION_CHANGED_EVENT\` still dispatches on user identity change. Focus/visibility/reconnect revalidation handled by the global \`SWRProvider\`.
- **NotificationBell** — hand-rolled \`setInterval\` polling replaced with \`useSWR({ refreshInterval: 30_000 })\` for the unread count, and an on-demand \`useSWR\` for the dropdown list. Mark-read uses \`useSWRMutation\` with optimistic local cache updates.
- **competitions** — extracted the \`now\` clock into a shared \`useClock(intervalMs)\` hook in \`app/lib/useClock.ts\`.
- **signin** — final \`queueMicrotask\` remnant removed by replacing the OAuth-redirect callback with \`useSWRMutation\` triggered from the redirect \`useEffect\`.

## Tests

- New \`AuthProvider.test.tsx\` covers: mount fetch, 401 → null user, network error → null user, \`AUTH_CHANGED_EVENT\` revalidation, \`refreshAuth()\` revalidation, and \`SESSION_CHANGED_EVENT\` change-vs-no-change dispatch behavior.
- Extended \`notificationBell.test.tsx\` with explicit \`refreshInterval\` polling assertion (count updates after 30s tick) and isolated each test in a fresh \`SWRConfig\` provider.

## Verification

\`\`\`
pnpm --filter @script-manifest/writer-web typecheck   # clean
pnpm --filter @script-manifest/writer-web lint        # 0 errors (27 pre-existing warnings)
pnpm --filter @script-manifest/writer-web test        # 487/487 passing
\`\`\`

## Out of scope

- \`OnboardingChecklist.tsx\` and \`reset-password/page.tsx\` still contain \`queueMicrotask\` calls but are out of CHAOS-1518's declared scope (separate non-data-fetching state-init patterns).
- Phase 4 (RSC opportunities) and Phase 5 (cleanup + custom ESLint rule) tracked in CHAOS-1519 / CHAOS-1520.

Closes CHAOS-1518.