### PR TITLE
feat(writer-web): phase 4 RSC migration - leaderboard + coverage (CHAOS-1519)

### DIFF
--- a/apps/writer-web/app/coverage/filters.tsx
+++ b/apps/writer-web/app/coverage/filters.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { CoverageTier } from "@script-manifest/contracts";
+import { useRouter, useSearchParams } from "next/navigation";
+
+type CoverageFiltersProps = {
+  tier: CoverageTier | "";
+  minPrice: string;
+  maxPrice: string;
+};
+
+function buildQueryString(form: HTMLFormElement): string {
+  const formData = new FormData(form);
+  const params = new URLSearchParams();
+  for (const key of ["tier", "minPrice", "maxPrice"]) {
+    const value = formData.get(key);
+    if (typeof value === "string" && value) {
+      params.set(key, value);
+    }
+  }
+  return params.toString();
+}
+
+export function CoverageFilters({ tier, minPrice, maxPrice }: CoverageFiltersProps) {
+  const router = useRouter();
+  useSearchParams();
+
+  function pushFilters(form: HTMLFormElement) {
+    const qs = buildQueryString(form);
+    router.push(qs ? `/coverage?${qs}` : "/coverage");
+  }
+
+  function handleFieldChange(form: HTMLFormElement | null) {
+    if (form) {
+      pushFilters(form);
+    }
+  }
+
+  return (
+    <article className="panel stack animate-in animate-in-delay-1">
+      <h2 className="section-title">Filter Services</h2>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          pushFilters(event.currentTarget);
+        }}
+        className="grid grid-cols-1 gap-4 sm:grid-cols-3"
+      >
+        <label className="stack-tight">
+          <span className="text-sm font-medium text-foreground">Tier</span>
+          <select
+            name="tier"
+            className="input"
+            defaultValue={tier}
+            onChange={(event) => handleFieldChange(event.currentTarget.form)}
+          >
+            <option value="">All tiers</option>
+            <option value="concept_notes">Concept Notes</option>
+            <option value="early_draft">Early Draft</option>
+            <option value="polish_proofread">Polish Proofread</option>
+            <option value="competition_ready">Competition Ready</option>
+          </select>
+        </label>
+        <label className="stack-tight">
+          <span className="text-sm font-medium text-foreground">Min Price ($)</span>
+          <input
+            name="minPrice"
+            type="number"
+            className="input"
+            placeholder="0"
+            min={0}
+            step={1}
+            defaultValue={minPrice}
+            onChange={(event) => handleFieldChange(event.currentTarget.form)}
+          />
+        </label>
+        <label className="stack-tight">
+          <span className="text-sm font-medium text-foreground">Max Price ($)</span>
+          <input
+            name="maxPrice"
+            type="number"
+            className="input"
+            placeholder="500"
+            min={0}
+            step={1}
+            defaultValue={maxPrice}
+            onChange={(event) => handleFieldChange(event.currentTarget.form)}
+          />
+        </label>
+      </form>
+    </article>
+  );
+}
+
+export function OnboardingPing() {
+  const onboardingMarked = useRef(false);
+
+  useEffect(() => {
+    if (!onboardingMarked.current) {
+      onboardingMarked.current = true;
+      void fetch("/api/v1/onboarding-progress", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ coverageVisited: true }),
+      });
+    }
+  }, []);
+
+  return null;
+}

--- a/apps/writer-web/app/coverage/page.test.tsx
+++ b/apps/writer-web/app/coverage/page.test.tsx
@@ -1,159 +1,144 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { SWRConfig } from "swr";
-import type { ReactElement } from "react";
-import { fetcher } from "../lib/fetcher";
-import { ToastProvider } from "../components/toast";
+import { ApiError } from "../lib/fetcher";
+import { serverFetch } from "../lib/serverFetch";
+import { CoverageFilters } from "./filters";
 import CoverageMarketplacePage from "./page";
 
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
-}
+const { pushMock } = vi.hoisted(() => ({
+  pushMock: vi.fn(),
+}));
 
-function renderPage(ui: ReactElement = <CoverageMarketplacePage />) {
-  return render(
-    <SWRConfig
-      value={{
-        fetcher,
-        provider: () => new Map(),
-        dedupingInterval: 0,
-        shouldRetryOnError: false,
-      }}
-    >
-      <ToastProvider>{ui}</ToastProvider>
-    </SWRConfig>
-  );
-}
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+  useSearchParams: () => new URLSearchParams(),
+}));
 
-function makeServicesResponse(services: unknown[] = []) {
-  return jsonResponse({ services });
-}
+vi.mock("../lib/serverFetch", () => ({
+  serverFetch: vi.fn(),
+}));
 
-function makeProvidersResponse(providers: unknown[] = []) {
-  return jsonResponse({ providers });
+const serverFetchMock = vi.mocked(serverFetch);
+
+const service = {
+  id: "svc_01",
+  title: "Full Feature Coverage",
+  description: "Comprehensive notes on your feature.",
+  tier: "early_draft" as const,
+  priceCents: 14900,
+  turnaroundDays: 5,
+  maxPages: 120,
+  providerId: "prov_01",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  active: true,
+};
+
+const provider = {
+  id: "prov_01",
+  displayName: "Script Experts",
+  bio: "Professional coverage since 2010",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+async function renderPage(params: Record<string, string | string[] | undefined> = {}) {
+  const element = await CoverageMarketplacePage({ searchParams: Promise.resolve(params) });
+  return render(element);
 }
 
 describe("CoverageMarketplacePage", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    pushMock.mockClear();
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>(async () => new Response(null, { status: 204 })));
+    serverFetchMock
+      .mockResolvedValueOnce({ services: [] })
+      .mockResolvedValueOnce({ providers: [] });
   });
 
   afterEach(() => {
     cleanup();
+    vi.unstubAllGlobals();
   });
 
   it("renders hero section with heading and description", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn<typeof fetch>(async () => makeServicesResponse())
-    );
+    await renderPage();
 
-    renderPage();
-
-    expect(await screen.findByText("Professional script coverage")).toBeInTheDocument();
+    expect(screen.getByText("Professional script coverage")).toBeInTheDocument();
     expect(screen.getByText("Coverage Marketplace")).toBeInTheDocument();
   });
 
   it("renders filter controls for tier and price", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn<typeof fetch>(async () => makeServicesResponse())
-    );
-
-    renderPage();
-
-    await screen.findByText("Professional script coverage");
+    await renderPage();
 
     expect(screen.getByRole("combobox")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("0")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("500")).toBeInTheDocument();
   });
 
-  it("shows empty state when no services are found", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn<typeof fetch>(async (input) => {
-        const url = typeof input === "string" ? input : (input as Request).url;
-        if (url.includes("providers")) return makeProvidersResponse();
-        return makeServicesResponse([]);
-      })
-    );
+  it("sends URL filter values to serverFetch as coverage service cents", async () => {
+    await renderPage({ tier: "early_draft", minPrice: "10", maxPrice: "250" });
 
-    renderPage();
-
-    await waitFor(() => {
-      expect(screen.getByText("No services found")).toBeInTheDocument();
+    expect(serverFetchMock).toHaveBeenNthCalledWith(1, "/api/v1/coverage/services", {
+      searchParams: new URLSearchParams({ tier: "early_draft", minPrice: "1000", maxPrice: "25000" }),
     });
+    expect(serverFetchMock).toHaveBeenNthCalledWith(2, "/api/v1/coverage/providers");
+  });
+
+  it("shows empty state when no services are found", async () => {
+    await renderPage();
+
+    expect(screen.getByText("No services found")).toBeInTheDocument();
+    expect(screen.getByText("Try adjusting your filters or check back later.")).toBeInTheDocument();
   });
 
   it("renders provider service cards with title and pricing", async () => {
-    const service = {
-      id: "svc_01",
-      title: "Full Feature Coverage",
-      description: "Comprehensive notes on your feature.",
-      tier: "early_draft" as const,
-      priceCents: 14900,
-      turnaroundDays: 5,
-      maxPages: 120,
-      providerId: "prov_01",
-      createdAt: new Date().toISOString(),
-      active: true
-    };
+    serverFetchMock.mockReset();
+    serverFetchMock
+      .mockResolvedValueOnce({ services: [service] })
+      .mockResolvedValueOnce({ providers: [provider] });
 
-    const provider = {
-      id: "prov_01",
-      displayName: "Script Experts",
-      bio: "Professional coverage since 2010",
-      createdAt: new Date().toISOString()
-    };
+    await renderPage();
 
-    vi.stubGlobal(
-      "fetch",
-      vi.fn<typeof fetch>(async (input) => {
-        const url = typeof input === "string" ? input : (input as Request).url;
-        if (url.includes("providers")) return makeProvidersResponse([provider]);
-        return makeServicesResponse([service]);
-      })
-    );
-
-    renderPage();
-
-    expect(await screen.findByText("Full Feature Coverage")).toBeInTheDocument();
+    expect(screen.getByText("Full Feature Coverage")).toBeInTheDocument();
     expect(screen.getByText("$149.00")).toBeInTheDocument();
     expect(screen.getByText("5d turnaround")).toBeInTheDocument();
     expect(screen.getByText("Script Experts")).toBeInTheDocument();
   });
 
   it("shows 'Unknown Provider' when provider is not found for a service", async () => {
-    const service = {
-      id: "svc_02",
-      title: "Mystery Coverage",
-      description: null,
-      tier: "concept_notes" as const,
-      priceCents: 4900,
-      turnaroundDays: 3,
-      maxPages: 60,
-      providerId: "prov_unknown",
-      createdAt: new Date().toISOString(),
-      active: true
-    };
+    serverFetchMock.mockReset();
+    serverFetchMock
+      .mockResolvedValueOnce({ services: [{ ...service, id: "svc_02", providerId: "prov_unknown" }] })
+      .mockResolvedValueOnce({ providers: [] });
 
-    vi.stubGlobal(
-      "fetch",
-      vi.fn<typeof fetch>(async (input) => {
-        const url = typeof input === "string" ? input : (input as Request).url;
-        if (url.includes("providers")) return makeProvidersResponse([]);
-        return makeServicesResponse([service]);
-      })
+    await renderPage();
+
+    expect(screen.getByText("Unknown Provider")).toBeInTheDocument();
+  });
+
+  it("renders an inline ApiError state", async () => {
+    serverFetchMock.mockReset();
+    serverFetchMock.mockRejectedValueOnce(
+      new ApiError("Coverage service unavailable", { status: 503 })
     );
 
-    renderPage();
+    await renderPage();
 
-    await waitFor(() => {
-      expect(screen.getByText("Unknown Provider")).toBeInTheDocument();
-    });
+    expect(screen.getByText("Coverage service unavailable")).toBeInTheDocument();
+  });
+
+  it("pushes updated query strings from the filter form", () => {
+    render(<CoverageFilters tier="" minPrice="" maxPrice="" />);
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "concept_notes" } });
+    expect(pushMock).toHaveBeenLastCalledWith("/coverage?tier=concept_notes");
+
+    fireEvent.change(screen.getByPlaceholderText("0"), { target: { value: "25" } });
+    expect(pushMock).toHaveBeenLastCalledWith("/coverage?tier=concept_notes&minPrice=25");
+
+    fireEvent.change(screen.getByPlaceholderText("500"), { target: { value: "100" } });
+    expect(pushMock).toHaveBeenLastCalledWith(
+      "/coverage?tier=concept_notes&minPrice=25&maxPrice=100"
+    );
   });
 });

--- a/apps/writer-web/app/coverage/page.test.tsx
+++ b/apps/writer-web/app/coverage/page.test.tsx
@@ -48,6 +48,7 @@ async function renderPage(params: Record<string, string | string[] | undefined> 
 describe("CoverageMarketplacePage", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    serverFetchMock.mockReset();
     pushMock.mockClear();
     vi.stubGlobal("fetch", vi.fn<typeof fetch>(async () => new Response(null, { status: 204 })));
     serverFetchMock
@@ -78,10 +79,13 @@ describe("CoverageMarketplacePage", () => {
   it("sends URL filter values to serverFetch as coverage service cents", async () => {
     await renderPage({ tier: "early_draft", minPrice: "10", maxPrice: "250" });
 
-    expect(serverFetchMock).toHaveBeenNthCalledWith(1, "/api/v1/coverage/services", {
-      searchParams: new URLSearchParams({ tier: "early_draft", minPrice: "1000", maxPrice: "25000" }),
-    });
-    expect(serverFetchMock).toHaveBeenNthCalledWith(2, "/api/v1/coverage/providers");
+    const [firstCallPath, firstCallInit] = serverFetchMock.mock.calls[0]!;
+    expect(firstCallPath).toBe("/api/v1/coverage/services");
+    const sentParams = firstCallInit?.searchParams as URLSearchParams;
+    expect(sentParams.toString()).toBe(
+      new URLSearchParams({ tier: "early_draft", minPrice: "1000", maxPrice: "25000" }).toString(),
+    );
+    expect(serverFetchMock.mock.calls[1]?.[0]).toBe("/api/v1/coverage/providers");
   });
 
   it("shows empty state when no services are found", async () => {

--- a/apps/writer-web/app/coverage/page.tsx
+++ b/apps/writer-web/app/coverage/page.tsx
@@ -1,80 +1,94 @@
-"use client";
-
-import { useEffect, useRef, useState } from "react";
-import useSWR from "swr";
-import type { CoverageService, CoverageProvider, CoverageTier } from "@script-manifest/contracts";
+import type { CoverageProvider, CoverageService, CoverageTier } from "@script-manifest/contracts";
 import { EmptyState } from "../components/emptyState";
 import { EmptyIllustration } from "../components/illustrations";
-import { SkeletonCard } from "../components/skeleton";
-import { useToast } from "../components/toast";
-import { fetcher, ApiError } from "../lib/fetcher";
+import { ApiError } from "../lib/fetcher";
+import { serverFetch } from "../lib/serverFetch";
+import { CoverageFilters, OnboardingPing } from "./filters";
 
-function buildServicesKey(
-  tierFilter: CoverageTier | "",
-  minPrice: string,
-  maxPrice: string
-): string {
-  const params = new URLSearchParams();
-  if (tierFilter) params.set("tier", tierFilter);
-  if (minPrice) params.set("minPrice", String(Number(minPrice) * 100));
-  if (maxPrice) params.set("maxPrice", String(Number(maxPrice) * 100));
-  const qs = params.toString();
-  return qs ? `/api/v1/coverage/services?${qs}` : "/api/v1/coverage/services";
+type CoverageSearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+type CoverageMarketplacePageProps = {
+  searchParams?: CoverageSearchParams;
+};
+
+type CoverageFiltersValue = {
+  tier: CoverageTier | "";
+  minPrice: string;
+  maxPrice: string;
+};
+
+const SERVICES_PATH = "/api/v1/coverage/services";
+const PROVIDERS_PATH = "/api/v1/coverage/providers";
+
+function firstParam(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) {
+    return value[0] ?? "";
+  }
+  return value ?? "";
 }
 
-const PROVIDERS_KEY = "/api/v1/coverage/providers";
+function readFilters(params: Record<string, string | string[] | undefined>): CoverageFiltersValue {
+  return {
+    tier: firstParam(params.tier) as CoverageTier | "",
+    minPrice: firstParam(params.minPrice),
+    maxPrice: firstParam(params.maxPrice),
+  };
+}
 
-export default function CoverageMarketplacePage() {
-  const toast = useToast();
-  const [tierFilter, setTierFilter] = useState<CoverageTier | "">("");
-  const [minPrice, setMinPrice] = useState("");
-  const [maxPrice, setMaxPrice] = useState("");
+function buildServicesSearchParams(filters: CoverageFiltersValue): URLSearchParams {
+  const params = new URLSearchParams();
+  if (filters.tier) params.set("tier", filters.tier);
+  if (filters.minPrice) params.set("minPrice", String(Number(filters.minPrice) * 100));
+  if (filters.maxPrice) params.set("maxPrice", String(Number(filters.maxPrice) * 100));
+  return params;
+}
 
-  const { data: servicesData, isLoading } = useSWR<{ services: CoverageService[] }>(
-    buildServicesKey(tierFilter, minPrice, maxPrice),
-    fetcher,
-    {
-      onError(err: unknown) {
-        toast.error(err instanceof ApiError ? err.message : "Failed to load marketplace data.");
-      },
-    }
+function getProviderName(providers: CoverageProvider[], providerId: string): string {
+  const provider = providers.find((p) => p.id === providerId);
+  return provider?.displayName ?? "Unknown Provider";
+}
+
+function formatPrice(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function formatTier(tier: CoverageTier): string {
+  return tier.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function ErrorState({ message }: { message: string }) {
+  return (
+    <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-700 dark:text-red-300">
+      {message}
+    </div>
   );
+}
 
-  const { data: providersData } = useSWR<{ providers: CoverageProvider[] }>(
-    PROVIDERS_KEY,
-    fetcher
-  );
+export default async function CoverageMarketplacePage({
+  searchParams,
+}: CoverageMarketplacePageProps = {}) {
+  const params = searchParams ? await searchParams : {};
+  const filters = readFilters(params);
+  let services: CoverageService[] = [];
+  let providers: CoverageProvider[] = [];
+  let errorMessage: string | null = null;
 
-  const onboardingMarked = useRef(false);
-  useEffect(() => {
-    if (!onboardingMarked.current) {
-      onboardingMarked.current = true;
-      void fetch("/api/v1/onboarding-progress", {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ coverageVisited: true }),
-      });
-    }
-  }, []);
-
-  const services = servicesData?.services ?? [];
-  const providers = providersData?.providers ?? [];
-
-  function getProviderName(providerId: string): string {
-    const provider = providers.find((p) => p.id === providerId);
-    return provider?.displayName ?? "Unknown Provider";
-  }
-
-  function formatPrice(cents: number): string {
-    return `$${(cents / 100).toFixed(2)}`;
-  }
-
-  function formatTier(tier: CoverageTier): string {
-    return tier.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  try {
+    const [servicesData, providersData] = await Promise.all([
+      serverFetch<{ services: CoverageService[] }>(SERVICES_PATH, {
+        searchParams: buildServicesSearchParams(filters),
+      }),
+      serverFetch<{ providers: CoverageProvider[] }>(PROVIDERS_PATH),
+    ]);
+    services = servicesData.services;
+    providers = providersData.providers;
+  } catch (err) {
+    errorMessage = err instanceof ApiError ? err.message : "Failed to load marketplace data.";
   }
 
   return (
     <section className="space-y-4">
+      <OnboardingPing />
       <article className="hero-card hero-card--violet animate-in">
         <p className="eyebrow">Coverage Marketplace</p>
         <h1 className="text-4xl text-foreground">Professional script coverage</h1>
@@ -84,58 +98,12 @@ export default function CoverageMarketplacePage() {
         </p>
       </article>
 
-      <article className="panel stack animate-in animate-in-delay-1">
-        <h2 className="section-title">Filter Services</h2>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-          <label className="stack-tight">
-            <span className="text-sm font-medium text-foreground">Tier</span>
-            <select
-              className="input"
-              value={tierFilter}
-              onChange={(e) => setTierFilter(e.target.value as CoverageTier | "")}
-            >
-              <option value="">All tiers</option>
-              <option value="concept_notes">Concept Notes</option>
-              <option value="early_draft">Early Draft</option>
-              <option value="polish_proofread">Polish Proofread</option>
-              <option value="competition_ready">Competition Ready</option>
-            </select>
-          </label>
-          <label className="stack-tight">
-            <span className="text-sm font-medium text-foreground">Min Price ($)</span>
-            <input
-              type="number"
-              className="input"
-              placeholder="0"
-              min={0}
-              step={1}
-              value={minPrice}
-              onChange={(e) => setMinPrice(e.target.value)}
-            />
-          </label>
-          <label className="stack-tight">
-            <span className="text-sm font-medium text-foreground">Max Price ($)</span>
-            <input
-              type="number"
-              className="input"
-              placeholder="500"
-              min={0}
-              step={1}
-              value={maxPrice}
-              onChange={(e) => setMaxPrice(e.target.value)}
-            />
-          </label>
-        </div>
-      </article>
+      <CoverageFilters tier={filters.tier} minPrice={filters.minPrice} maxPrice={filters.maxPrice} />
 
       <article className="panel stack animate-in animate-in-delay-2">
         <h2 className="section-title">Available Services</h2>
-        {isLoading ? (
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            <SkeletonCard />
-            <SkeletonCard />
-            <SkeletonCard />
-          </div>
+        {errorMessage ? (
+          <ErrorState message={errorMessage} />
         ) : services.length === 0 ? (
           <EmptyState
             illustration={<EmptyIllustration variant="search" className="h-14 w-14 text-foreground" />}
@@ -166,7 +134,7 @@ export default function CoverageMarketplacePage() {
                       href={`/coverage/providers/${encodeURIComponent(service.providerId)}`}
                       className="text-sm text-tide-700 dark:text-tide-500 hover:underline"
                     >
-                      {getProviderName(service.providerId)}
+                      {getProviderName(providers, service.providerId)}
                     </a>
                   </div>
                 </div>

--- a/apps/writer-web/app/leaderboard/filters.tsx
+++ b/apps/writer-web/app/leaderboard/filters.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import type { FormEvent } from "react";
+import type { TierDesignation } from "@script-manifest/contracts";
+
+type FiltersProps = {
+  total: number;
+};
+
+const tierOptions: Array<{ value: TierDesignation | ""; label: string }> = [
+  { value: "", label: "All tiers" },
+  { value: "top_1", label: "Top 1%" },
+  { value: "top_2", label: "Top 2%" },
+  { value: "top_10", label: "Top 10%" },
+  { value: "top_25", label: "Top 25%" }
+];
+
+function filterValue(searchParams: URLSearchParams, key: string): string {
+  return searchParams.get(key) ?? "";
+}
+
+function buildQuery(form: HTMLFormElement): string {
+  const formData = new FormData(form);
+  const query = new URLSearchParams();
+  for (const key of ["format", "genre", "tier"]) {
+    const value = formData.get(key);
+    if (typeof value === "string" && value.trim()) {
+      query.set(key, value.trim());
+    }
+  }
+  if (formData.get("trending") === "true") {
+    query.set("trending", "true");
+  }
+  return query.toString();
+}
+
+export function LeaderboardFilters({ total }: FiltersProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  function pushQuery(form: HTMLFormElement) {
+    const qs = buildQuery(form);
+    router.push(qs ? `/leaderboard?${qs}` : "/leaderboard");
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    pushQuery(event.currentTarget);
+  }
+
+  function handleChange(event: FormEvent<HTMLFormElement>) {
+    pushQuery(event.currentTarget);
+  }
+
+  return (
+    <article className="panel stack animate-in animate-in-delay-1">
+      <form className="stack" onSubmit={handleSubmit} onChange={handleChange} key={searchParams.toString()}>
+        <div className="grid-two">
+          <label className="stack-tight">
+            <span>Format filter</span>
+            <input
+              className="input"
+              name="format"
+              defaultValue={filterValue(searchParams, "format")}
+              placeholder="feature / tv / short"
+            />
+          </label>
+          <label className="stack-tight">
+            <span>Genre filter</span>
+            <input
+              className="input"
+              name="genre"
+              defaultValue={filterValue(searchParams, "genre")}
+              placeholder="drama / comedy"
+            />
+          </label>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <label className="stack-tight">
+            <span>Tier</span>
+            <select className="input" name="tier" defaultValue={filterValue(searchParams, "tier")}>
+              {tierOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center gap-2 self-end pb-1 cursor-pointer">
+            <input
+              type="checkbox"
+              name="trending"
+              value="true"
+              defaultChecked={filterValue(searchParams, "trending") === "true"}
+            />
+            <span className="text-sm font-medium">Trending</span>
+          </label>
+        </div>
+        <div className="inline-form">
+          <button type="submit" className="btn btn-primary">
+            Refresh leaderboard
+          </button>
+          <button type="button" className="btn btn-secondary" onClick={() => router.push("/leaderboard")}>
+            Reset
+          </button>
+          <span className="badge">{total} total</span>
+        </div>
+      </form>
+    </article>
+  );
+}

--- a/apps/writer-web/app/leaderboard/page.test.tsx
+++ b/apps/writer-web/app/leaderboard/page.test.tsx
@@ -1,222 +1,168 @@
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { SWRConfig } from "swr";
-import type { ReactElement } from "react";
+import { ApiError } from "../lib/fetcher";
+import { serverFetch } from "../lib/serverFetch";
 import LeaderboardPage from "./page";
 
-function jsonResponse(payload: unknown, status = 200): Response {
-  return new Response(JSON.stringify(payload), {
-    status,
-    headers: { "content-type": "application/json" }
-  });
+vi.mock("../lib/serverFetch", () => ({
+  serverFetch: vi.fn()
+}));
+
+const pushMock = vi.fn();
+const useSearchParamsMock = vi.fn(() => new URLSearchParams());
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+  useSearchParams: () => useSearchParamsMock()
+}));
+
+const serverFetchMock = vi.mocked(serverFetch);
+
+function leaderboardEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    writerId: "writer_01",
+    rank: 1,
+    totalScore: 9,
+    submissionCount: 3,
+    placementCount: 2,
+    tier: "top_10",
+    badges: ["Finalist - Austin 2025"],
+    scoreChange30d: 2.5,
+    lastUpdatedAt: "2026-02-06T00:00:00.000Z",
+    ...overrides
+  };
 }
 
-function renderWithSWR(ui: ReactElement) {
-  return render(
-    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0, shouldRetryOnError: false }}>
-      {ui}
-    </SWRConfig>
-  );
+async function renderPage(searchParams: Record<string, string | string[] | undefined> = {}) {
+  const element = await LeaderboardPage({ searchParams: Promise.resolve(searchParams) });
+  return render(element);
 }
 
 describe("LeaderboardPage", () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
+    serverFetchMock.mockReset();
+    pushMock.mockReset();
+    useSearchParamsMock.mockReset();
+    useSearchParamsMock.mockReturnValue(new URLSearchParams());
   });
 
   afterEach(() => {
     cleanup();
   });
 
-
-  it("loads leaderboard rows and applies filters", async () => {
-    const fetchMock = vi.fn<typeof fetch>(async (input) => {
-      const url = typeof input === "string" ? input : input.toString();
-      if (url.includes("format=feature") && url.includes("genre=drama")) {
-        return jsonResponse({
-          leaderboard: [
-            {
-              writerId: "writer_01",
-              rank: 1,
-              totalScore: 9,
-              submissionCount: 3,
-              placementCount: 2,
-              tier: "top_10",
-              badges: ["Finalist - Austin 2025"],
-              scoreChange30d: 2.5,
-              lastUpdatedAt: "2026-02-06T00:00:00.000Z"
-            }
-          ],
-          total: 1
-        });
-      }
-      return jsonResponse({ leaderboard: [], total: 0 });
+  it("renders leaderboard rows from serverFetch", async () => {
+    serverFetchMock.mockResolvedValue({
+      leaderboard: [leaderboardEntry()],
+      total: 1
     });
-    vi.stubGlobal("fetch", fetchMock);
 
-    renderWithSWR(<LeaderboardPage />);
-    const user = userEvent.setup();
+    await renderPage({ format: "feature", genre: "drama" });
 
-    // Wait for initial fetch to settle (button leaves "Refreshing..." state)
-    await screen.findByRole("button", { name: "Refresh leaderboard" });
-
-    await user.type(screen.getByLabelText("Format filter"), "feature");
-    await user.type(screen.getByLabelText("Genre filter"), "drama");
-    await user.click(screen.getByRole("button", { name: "Refresh leaderboard" }));
-
-    await screen.findAllByText("writer_01");
+    expect(serverFetchMock).toHaveBeenCalledWith("/api/v1/leaderboard", {
+      searchParams: { format: "feature", genre: "drama" }
+    });
+    expect(screen.getByText("writer_01")).toBeInTheDocument();
     expect(screen.getByText("9.0")).toBeInTheDocument();
     expect(screen.getByText("3 submitted")).toBeInTheDocument();
     expect(screen.getByText("2 placed")).toBeInTheDocument();
   });
 
-  it("renders tier badges", async () => {
-    const fetchMock = vi.fn<typeof fetch>(async () => {
-      return jsonResponse({
-        leaderboard: [
-          {
-            writerId: "writer_01",
-            rank: 1,
-            totalScore: 50,
-            submissionCount: 5,
-            placementCount: 3,
-            tier: "top_1",
-            badges: [],
-            scoreChange30d: 0,
-            lastUpdatedAt: "2026-02-06T00:00:00.000Z"
-          }
-        ],
-        total: 1
-      });
+  it("renders writer and score content in SSR HTML", async () => {
+    serverFetchMock.mockResolvedValue({
+      leaderboard: [leaderboardEntry({ writerId: "writer_server", totalScore: 42 })],
+      total: 1
     });
-    vi.stubGlobal("fetch", fetchMock);
 
-    renderWithSWR(<LeaderboardPage />);
-    await screen.findAllByText("writer_01");
-    // Tier badge is a span with the tier class, distinct from the <option> elements
+    const { container } = await renderPage();
+
+    expect(container.innerHTML).toContain("writer_server");
+    expect(container.innerHTML).toContain("42.0");
+  });
+
+  it("renders tier badges", async () => {
+    serverFetchMock.mockResolvedValue({
+      leaderboard: [leaderboardEntry({ totalScore: 50, submissionCount: 5, placementCount: 3, tier: "top_1", badges: [], scoreChange30d: 0 })],
+      total: 1
+    });
+
+    await renderPage();
+
     const tierBadges = screen.getAllByText("Top 1%");
     const badgeSpan = tierBadges.find((el) => el.tagName === "SPAN" && el.className.includes("rounded-full"));
     expect(badgeSpan).toBeTruthy();
   });
 
   it("renders badge chips", async () => {
-    const fetchMock = vi.fn<typeof fetch>(async () => {
-      return jsonResponse({
-        leaderboard: [
-          {
-            writerId: "writer_01",
-            rank: 1,
-            totalScore: 20,
-            submissionCount: 2,
-            placementCount: 1,
-            tier: null,
-            badges: ["Winner - Sundance 2026"],
-            scoreChange30d: 0,
-            lastUpdatedAt: "2026-02-06T00:00:00.000Z"
-          }
-        ],
-        total: 1
-      });
+    serverFetchMock.mockResolvedValue({
+      leaderboard: [leaderboardEntry({ totalScore: 20, submissionCount: 2, placementCount: 1, tier: null, badges: ["Winner - Sundance 2026"], scoreChange30d: 0 })],
+      total: 1
     });
-    vi.stubGlobal("fetch", fetchMock);
 
-    renderWithSWR(<LeaderboardPage />);
-    await screen.findAllByText("writer_01");
+    await renderPage();
+
     expect(screen.getByText("Winner - Sundance 2026")).toBeInTheDocument();
   });
 
   it("renders trending indicators", async () => {
-    const fetchMock = vi.fn<typeof fetch>(async () => {
-      return jsonResponse({
-        leaderboard: [
-          {
-            writerId: "writer_01",
-            rank: 1,
-            totalScore: 30,
-            submissionCount: 4,
-            placementCount: 2,
-            tier: "top_10",
-            badges: [],
-            scoreChange30d: 5.5,
-            lastUpdatedAt: "2026-02-06T00:00:00.000Z"
-          }
-        ],
-        total: 1
-      });
+    serverFetchMock.mockResolvedValue({
+      leaderboard: [leaderboardEntry({ totalScore: 30, submissionCount: 4, placementCount: 2, scoreChange30d: 5.5 })],
+      total: 1
     });
-    vi.stubGlobal("fetch", fetchMock);
 
-    renderWithSWR(<LeaderboardPage />);
-    await screen.findAllByText("writer_01");
+    await renderPage();
+
     expect(screen.getByText(/5\.5/)).toBeInTheDocument();
   });
 
-  it("initial load renders empty state when no writers", async () => {
-    const fetchMock = vi.fn<typeof fetch>(async () => {
-      return jsonResponse({ leaderboard: [], total: 0 });
-    });
-    vi.stubGlobal("fetch", fetchMock);
+  it("renders empty state when no writers", async () => {
+    serverFetchMock.mockResolvedValue({ leaderboard: [], total: 0 });
 
-    renderWithSWR(<LeaderboardPage />);
+    await renderPage();
 
-    await screen.findByText("The spotlight is waiting");
+    expect(screen.getByText("The spotlight is waiting")).toBeInTheDocument();
     expect(screen.getByText("0 total")).toBeInTheDocument();
   });
 
-  it("changing a filter triggers a new fetch with updated URL", async () => {
-    const fetchMock = vi.fn<typeof fetch>(async (input) => {
-      const url = typeof input === "string" ? input : input.toString();
-      if (url.includes("format=feature")) {
-        return jsonResponse({
-          leaderboard: [
-            {
-              writerId: "writer_feature",
-              rank: 1,
-              totalScore: 15,
-              submissionCount: 5,
-              placementCount: 3,
-              tier: "top_10",
-              badges: [],
-              scoreChange30d: 0,
-              lastUpdatedAt: "2026-02-06T00:00:00.000Z"
-            }
-          ],
-          total: 1
-        });
-      }
-      return jsonResponse({ leaderboard: [], total: 0 });
-    });
-    vi.stubGlobal("fetch", fetchMock);
+  it("renders ApiError messages inline", async () => {
+    serverFetchMock.mockRejectedValue(new ApiError("Forbidden access", { status: 403 }));
 
-    renderWithSWR(<LeaderboardPage />);
-    const user = userEvent.setup();
+    await renderPage();
 
-    // Wait for initial fetch to complete
-    await screen.findByRole("button", { name: "Refresh leaderboard" });
-
-    // Change format filter — SWR auto-refetches because the cache key changes
-    await user.type(screen.getByLabelText("Format filter"), "feature");
-
-    // Wait for writer to appear (confirms the new-key fetch completed)
-    await screen.findByText("writer_feature");
-
-    // Verify a fetch was made with format=feature in the URL
-    const formatCalls = fetchMock.mock.calls.filter((args) => {
-      const url = typeof args[0] === "string" ? args[0] : String(args[0]);
-      return url.includes("format=feature");
-    });
-    expect(formatCalls.length).toBeGreaterThan(0);
+    expect(screen.getByText("Forbidden access")).toBeInTheDocument();
   });
 
-  it("ApiError 4xx renders error message", async () => {
-    const fetchMock = vi.fn<typeof fetch>(async () => {
-      return jsonResponse({ message: "Forbidden access" }, 403);
+  it("filter form pushes query string changes", async () => {
+    serverFetchMock.mockResolvedValue({ leaderboard: [], total: 0 });
+    useSearchParamsMock.mockReturnValue(new URLSearchParams("format=feature&genre=drama&tier=top_10&trending=true"));
+
+    await renderPage({ format: "feature", genre: "drama", tier: "top_10", trending: "true" });
+
+    expect(screen.getByLabelText("Format filter")).toHaveValue("feature");
+    expect(screen.getByLabelText("Genre filter")).toHaveValue("drama");
+    expect(screen.getByLabelText("Tier")).toHaveValue("top_10");
+    expect(screen.getByLabelText("Trending")).toBeChecked();
+
+    const user = userEvent.setup();
+    await user.clear(screen.getByLabelText("Format filter"));
+    await user.type(screen.getByLabelText("Format filter"), "short");
+    await user.selectOptions(screen.getByLabelText("Tier"), "top_25");
+    await user.click(screen.getByLabelText("Trending"));
+    await user.click(screen.getByRole("button", { name: "Refresh leaderboard" }));
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenLastCalledWith("/leaderboard?format=short&genre=drama&tier=top_25");
     });
-    vi.stubGlobal("fetch", fetchMock);
+  });
 
-    renderWithSWR(<LeaderboardPage />);
+  it("reset clears filters", async () => {
+    serverFetchMock.mockResolvedValue({ leaderboard: [], total: 0 });
+    useSearchParamsMock.mockReturnValue(new URLSearchParams("format=feature"));
 
-    await screen.findByText("Forbidden access");
+    await renderPage({ format: "feature" });
+
+    await userEvent.setup().click(screen.getByRole("button", { name: "Reset" }));
+
+    expect(pushMock).toHaveBeenCalledWith("/leaderboard");
   });
 });

--- a/apps/writer-web/app/leaderboard/page.tsx
+++ b/apps/writer-web/app/leaderboard/page.tsx
@@ -1,30 +1,18 @@
-"use client";
-
-import { useMemo, useState, type FormEvent } from "react";
-import useSWR from "swr";
 import type { Route } from "next";
 import type { RankedWriterEntry, TierDesignation } from "@script-manifest/contracts";
 import { EmptyState } from "../components/emptyState";
 import { EmptyIllustration } from "../components/illustrations";
-import { fetcher, ApiError } from "../lib/fetcher";
+import { ApiError } from "../lib/fetcher";
+import { serverFetch } from "../lib/serverFetch";
+import { LeaderboardFilters } from "./filters";
 
 type LeaderboardResponse = {
   leaderboard: RankedWriterEntry[];
   total: number;
 };
 
-type Filters = {
-  format: string;
-  genre: string;
-  tier: TierDesignation | "";
-  trending: boolean;
-};
-
-const initialFilters: Filters = {
-  format: "",
-  genre: "",
-  tier: "",
-  trending: false
+type LeaderboardPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
 const avatarGradients = [
@@ -71,44 +59,51 @@ function scorePercent(score: number, maxScore: number): number {
   return Math.min(100, Math.round((score / maxScore) * 100));
 }
 
-function buildKey(filters: Filters): string {
-  const search = new URLSearchParams();
-  if (filters.format.trim()) {
-    search.set("format", filters.format.trim());
-  }
-  if (filters.genre.trim()) {
-    search.set("genre", filters.genre.trim());
-  }
-  if (filters.tier) {
-    search.set("tier", filters.tier);
-  }
-  if (filters.trending) {
-    search.set("trending", "true");
-  }
-  const qs = search.toString();
-  return qs ? `/api/v1/leaderboard?${qs}` : "/api/v1/leaderboard";
+function stringParam(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
 }
 
-export default function LeaderboardPage() {
-  const [filters, setFilters] = useState<Filters>(initialFilters);
+function buildLeaderboardSearchParams(input: Record<string, string | string[] | undefined>) {
+  const searchParams: Record<string, string | boolean | undefined> = {};
+  const format = stringParam(input.format)?.trim();
+  const genre = stringParam(input.genre)?.trim();
+  const tier = stringParam(input.tier)?.trim();
+  const trending = stringParam(input.trending)?.trim();
 
-  const { data, error, isLoading, mutate } = useSWR<LeaderboardResponse>(
-    buildKey(filters),
-    fetcher
-  );
-
-  const rows = useMemo(() => data?.leaderboard ?? [], [data]);
-  const total = data?.total ?? 0;
-
-  const maxScore = useMemo(() => {
-    if (rows.length === 0) return 1;
-    return Math.max(...rows.map((r) => r.totalScore), 1);
-  }, [rows]);
-
-  function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    void mutate();
+  if (format) {
+    searchParams.format = format;
   }
+  if (genre) {
+    searchParams.genre = genre;
+  }
+  if (tier) {
+    searchParams.tier = tier;
+  }
+  if (trending === "true") {
+    searchParams.trending = true;
+  }
+  return searchParams;
+}
+
+export default async function LeaderboardPage({ searchParams }: LeaderboardPageProps) {
+  let data: LeaderboardResponse = { leaderboard: [], total: 0 };
+  let error: string | null = null;
+  const filters = await searchParams;
+  const leaderboardSearchParams = buildLeaderboardSearchParams(filters);
+
+  try {
+    data = await serverFetch<LeaderboardResponse>("/api/v1/leaderboard", { searchParams: leaderboardSearchParams });
+  } catch (caught) {
+    if (caught instanceof ApiError) {
+      error = caught.message;
+    } else {
+      error = "Leaderboard load failed.";
+    }
+  }
+
+  const rows = data.leaderboard;
+  const total = data.total;
+  const maxScore = rows.length === 0 ? 1 : Math.max(...rows.map((r) => r.totalScore), 1);
 
   return (
     <section className="space-y-4">
@@ -121,72 +116,7 @@ export default function LeaderboardPage() {
         </p>
       </article>
 
-      <article className="panel stack animate-in animate-in-delay-1">
-        <form className="stack" onSubmit={handleSubmit}>
-          <div className="grid-two">
-            <label className="stack-tight">
-              <span>Format filter</span>
-              <input
-                className="input"
-                value={filters.format}
-                onChange={(event) => setFilters((current) => ({ ...current, format: event.target.value }))}
-                placeholder="feature / tv / short"
-              />
-            </label>
-            <label className="stack-tight">
-              <span>Genre filter</span>
-              <input
-                className="input"
-                value={filters.genre}
-                onChange={(event) => setFilters((current) => ({ ...current, genre: event.target.value }))}
-                placeholder="drama / comedy"
-              />
-            </label>
-          </div>
-          <div className="flex flex-wrap items-center gap-3">
-            <label className="stack-tight">
-              <span>Tier</span>
-              <select
-                className="input"
-                value={filters.tier}
-                onChange={(event) =>
-                  setFilters((current) => ({ ...current, tier: event.target.value as TierDesignation | "" }))
-                }
-              >
-                <option value="">All tiers</option>
-                <option value="top_1">Top 1%</option>
-                <option value="top_2">Top 2%</option>
-                <option value="top_10">Top 10%</option>
-                <option value="top_25">Top 25%</option>
-              </select>
-            </label>
-            <label className="flex items-center gap-2 self-end pb-1 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={filters.trending}
-                onChange={(event) => setFilters((current) => ({ ...current, trending: event.target.checked }))}
-              />
-              <span className="text-sm font-medium">Trending</span>
-            </label>
-          </div>
-          <div className="inline-form">
-            <button type="submit" className="btn btn-primary" disabled={isLoading}>
-              {isLoading ? "Refreshing..." : "Refresh leaderboard"}
-            </button>
-            <button
-              type="button"
-              className="btn btn-secondary"
-              onClick={() => {
-                setFilters(initialFilters);
-              }}
-              disabled={isLoading}
-            >
-              Reset
-            </button>
-            <span className="badge">{total} total</span>
-          </div>
-        </form>
-      </article>
+      <LeaderboardFilters total={total} />
 
       <article className="panel stack">
         <div className="subcard-header">
@@ -268,7 +198,7 @@ export default function LeaderboardPage() {
 
       {error ? (
         <p className="status-error">
-          {error instanceof ApiError ? error.message : "Leaderboard load failed."}
+          {error}
         </p>
       ) : null}
     </section>

--- a/apps/writer-web/app/lib/serverFetch.ts
+++ b/apps/writer-web/app/lib/serverFetch.ts
@@ -1,0 +1,103 @@
+import { cookies } from "next/headers";
+import { ApiError } from "./fetcher";
+
+const DEFAULT_GATEWAY_BASE = "http://localhost:4000";
+
+function getApiGatewayBase(): string {
+  return process.env.API_GATEWAY_URL ?? DEFAULT_GATEWAY_BASE;
+}
+
+export type ServerFetchInit = Omit<RequestInit, "headers"> & {
+  headers?: HeadersInit;
+  searchParams?: URLSearchParams | Record<string, string | number | boolean | undefined>;
+};
+
+function buildSearchParams(
+  input: ServerFetchInit["searchParams"],
+): URLSearchParams | null {
+  if (!input) {
+    return null;
+  }
+  if (input instanceof URLSearchParams) {
+    return input;
+  }
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(input)) {
+    if (value === undefined || value === "") {
+      continue;
+    }
+    params.set(key, String(value));
+  }
+  return params;
+}
+
+async function buildAuthorizedHeaders(caller?: HeadersInit): Promise<Headers> {
+  const headers = new Headers({ Accept: "application/json" });
+  if (caller) {
+    new Headers(caller).forEach((value, key) => headers.set(key, value));
+  }
+  const cookieStore = await cookies();
+  const token = cookieStore.get("sm_session")?.value;
+  if (token) {
+    headers.set("authorization", `Bearer ${token}`);
+  }
+  return headers;
+}
+
+export async function serverFetch<T>(
+  path: string,
+  init: ServerFetchInit = {},
+): Promise<T> {
+  const { headers, searchParams, ...rest } = init;
+  const url = new URL(path, getApiGatewayBase());
+  const params = buildSearchParams(searchParams);
+  if (params) {
+    for (const [key, value] of params.entries()) {
+      url.searchParams.append(key, value);
+    }
+  }
+
+  const response = await fetch(url, {
+    cache: "no-store",
+    ...rest,
+    headers: await buildAuthorizedHeaders(headers),
+  });
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  if (!response.ok) {
+    const rawText = await response.text();
+    let body: unknown = rawText;
+    let code: string | undefined;
+    try {
+      const parsed = JSON.parse(rawText) as unknown;
+      body = parsed;
+      if (
+        parsed !== null &&
+        typeof parsed === "object" &&
+        "code" in parsed &&
+        typeof (parsed as Record<string, unknown>).code === "string"
+      ) {
+        code = (parsed as Record<string, unknown>).code as string;
+      }
+    } catch {
+      // body remains rawText
+    }
+    const message =
+      body !== null &&
+      typeof body === "object" &&
+      "message" in body &&
+      typeof (body as Record<string, unknown>).message === "string"
+        ? ((body as Record<string, unknown>).message as string)
+        : `HTTP ${response.status}`;
+    throw new ApiError(message, { status: response.status, code, body });
+  }
+
+  return (await response.json()) as T;
+}
+
+export function isApiError(value: unknown): value is ApiError {
+  return value instanceof ApiError;
+}

--- a/apps/writer-web/next-env.d.ts
+++ b/apps/writer-web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Phase 4 of CHAOS-1514 (Modernize writer-web data fetching architecture). Converts two public read-only pages from client-side \`useSWR\` to **Next.js App Router Server Components**, with small Client Component islands for filter forms.

- **\`app/lib/serverFetch.ts\`** — new server-side fetch helper. Reads the \`sm_session\` HttpOnly cookie via \`next/headers\`, forwards \`Authorization\` to the API gateway, throws \`ApiError\` on non-2xx (same shape as the client \`fetcher\`).
- **\`app/leaderboard/page.tsx\`** — now a Server Component. Reads filters from \`searchParams\`, calls \`serverFetch(\"/api/v1/leaderboard\")\`, renders the full table as static HTML. Filter form extracted into \`app/leaderboard/filters.tsx\` (client island) which pushes filter state into URL search params via \`useRouter().push()\`.
- **\`app/coverage/page.tsx\`** — now a Server Component. Parallel \`Promise.all\` fetches services + providers via \`serverFetch\`. Filter form extracted into \`app/coverage/filters.tsx\` (client island) with the same URL-search-params pattern. The \`onboarding-progress\` PATCH is now a small \`OnboardingPing\` client island.

## Build verification

Production build confirms both routes ship as dynamic SSR (\`ƒ\`):

\`\`\`
├ ƒ /coverage
├ ƒ /leaderboard
\`\`\`

No \`useSWR\` remains in either page. Filters are URL-driven, so navigating back/forward replays the exact rendered state from cache.

## Tests

- \`app/leaderboard/page.test.tsx\` and \`app/coverage/page.test.tsx\` rewritten to test SSR output directly: \`await LeaderboardPage({ searchParams: ... })\` then \`render(...)\` on the returned element. \`serverFetch\` is mocked via \`vi.mock(\"../lib/serverFetch\", ...)\`.
- New explicit cases: filter values from URL are sent to \`serverFetch\` with the correct cents-conversion for prices; empty / error states render server-side; SSR HTML contains expected writer/score content.

## Verification

\`\`\`
pnpm --filter @script-manifest/writer-web typecheck   # clean
pnpm --filter @script-manifest/writer-web lint        # 0 errors (27 pre-existing warnings)
pnpm --filter @script-manifest/writer-web test        # 492/492 passing
pnpm --filter @script-manifest/writer-web build       # clean, /coverage + /leaderboard rendered as ƒ
\`\`\`

## Out of scope

- \`app/competitions/page.tsx\` (the public list) still uses \`useSWR\`. It mixes interactive modals + URL filters; per the issue boundary that one is a follow-up if needed. ≥2 pages converted as Phase 4 requires.
- \`app/coverage/providers/[id]/page.tsx\` and admin pages remain client-rendered; out of scope per CHAOS-1519.
- No middleware or edge-runtime changes.
- Phase 5 (cleanup + custom ESLint rule) tracked in CHAOS-1520, queued next.

Closes CHAOS-1519.