### PR TITLE
feat(writer-web): phase 5 cleanup - custom ESLint rule + final SWR migration (CHAOS-1520)

### DIFF
--- a/apps/writer-web/app/admin/page.tsx
+++ b/apps/writer-web/app/admin/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import useSWR from "swr";
 import Link from "next/link";
 import type { Route } from "next";
 import { Users, Shield, Trophy } from "lucide-react";
 import { SkeletonCard } from "../components/skeleton";
 import { useToast } from "../components/toast";
+import { fetcher, ApiError } from "../lib/fetcher";
 
 type PlatformMetrics = {
   totalUsers: number;
@@ -70,32 +71,17 @@ const quickActions: QuickAction[] = [
 
 export default function AdminDashboardPage() {
   const toast = useToast();
-  const [metrics, setMetrics] = useState<PlatformMetrics | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    async function loadMetrics() {
-      try {
-        const response = await fetch("/api/v1/admin/metrics", {
-          headers: {}
-        });
-        if (!response.ok) {
-          const body = (await response.json().catch(() => ({}))) as { error?: string };
-          toast.error(body.error ?? "Failed to load admin metrics.");
-          return;
-        }
-        const body = (await response.json()) as { metrics: PlatformMetrics };
-        setMetrics(body.metrics);
-      } catch (error) {
-        toast.error(error instanceof Error ? error.message : "Failed to load admin metrics.");
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    void loadMetrics();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const { data, isLoading: loading } = useSWR<{ metrics: PlatformMetrics }>(
+    "/api/v1/admin/metrics",
+    fetcher,
+    {
+      shouldRetryOnError: false,
+      onError(err: unknown) {
+        toast.error(err instanceof ApiError ? (err.message ?? "Failed to load admin metrics.") : "Failed to load admin metrics.");
+      },
+    },
+  );
+  const metrics = data?.metrics ?? null;
 
   const statCards = metrics ? formatStatCards(metrics) : [];
 

--- a/apps/writer-web/app/competitions/page.tsx
+++ b/apps/writer-web/app/competitions/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState, type FormEvent } from "react";
 import useSWR from "swr";
+import useSWRMutation from "swr/mutation";
 import type { Competition } from "@script-manifest/contracts";
 import { Modal } from "../components/modal";
 import { EmptyState } from "../components/emptyState";
@@ -99,15 +100,20 @@ export default function CompetitionsPage() {
 
   const now = useClock(60_000);
 
-  // Fire-and-forget onboarding progress when logged-in user visits
+  const { trigger: pingOnboarding } = useSWRMutation(
+    "/api/v1/onboarding-progress",
+    async (url: string) => {
+      await fetch(url, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ competitionsVisited: true }),
+      });
+    },
+  );
   useEffect(() => {
     if (!user) return;
-    void fetch("/api/v1/onboarding-progress", {
-      method: "PATCH",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ competitionsVisited: true }),
-    });
-  }, [user]);
+    void pingOnboarding();
+  }, [user, pingOnboarding]);
 
   const { data, isLoading: loading } = useSWR<CompetitionsResponse>(
     buildKey(committedFilters),

--- a/apps/writer-web/app/components/OnboardingChecklist.test.tsx
+++ b/apps/writer-web/app/components/OnboardingChecklist.test.tsx
@@ -1,7 +1,21 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { render as rtlRender, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+import { SWRConfig } from "swr";
 import { mockUseAuth } from "../../vitest.setup";
 import { OnboardingChecklist } from "./OnboardingChecklist";
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0, shouldRetryOnError: false }}>
+      {children}
+    </SWRConfig>
+  );
+}
+
+function render(ui: ReactElement) {
+  return rtlRender(ui, { wrapper: Wrapper });
+}
 
 function mockFetchStatus(status: Record<string, boolean>) {
   vi.spyOn(globalThis, "fetch").mockResolvedValue({

--- a/apps/writer-web/app/components/OnboardingChecklist.tsx
+++ b/apps/writer-web/app/components/OnboardingChecklist.tsx
@@ -1,72 +1,46 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import useSWR from "swr";
 import Link from "next/link";
 import type { Route } from "next";
 import { CheckCircle2, Circle, X } from "lucide-react";
 import type { OnboardingStatus } from "@script-manifest/contracts";
+import { fetcher } from "../lib/fetcher";
 
 const ONBOARDING_DISMISSED_KEY = "onboarding-dismissed";
 
-type ChecklistState = {
-  mounted: boolean;
-  dismissed: boolean;
-  status: OnboardingStatus | null;
-};
 
 export function OnboardingChecklist() {
-  const [state, setState] = useState<ChecklistState>({
-    mounted: false,
-    dismissed: true,
-    status: null,
-  });
+  const [dismissed, setDismissed] = useState<boolean>(true);
+  const [mounted, setMounted] = useState<boolean>(false);
 
   useEffect(() => {
     const isDismissed = window.localStorage.getItem(ONBOARDING_DISMISSED_KEY) === "true";
-
-    if (isDismissed) {
-      queueMicrotask(() => setState({ mounted: true, dismissed: true, status: null }));
-      return;
-    }
-
-    let cancelled = false;
-
-    async function fetchStatus() {
-      try {
-        const response = await fetch("/api/v1/onboarding-status", { cache: "no-store" });
-        if (!response.ok || cancelled) return;
-        const body = (await response.json()) as { status?: OnboardingStatus };
-        if (cancelled) return;
-        setState({
-          mounted: true,
-          dismissed: false,
-          status: body.status ?? null,
-        });
-      } catch {
-        if (!cancelled) {
-          setState({ mounted: true, dismissed: false, status: null });
-        }
-      }
-    }
-
-    queueMicrotask(() => setState((prev) => ({ ...prev, mounted: true, dismissed: false })));
-    void fetchStatus();
-
-    return () => {
-      cancelled = true;
-    };
+    // non-data-fetch: defer setState past effect body to satisfy react-hooks/set-state-in-effect
+    queueMicrotask(() => {
+      setDismissed(isDismissed);
+      setMounted(true);
+    });
   }, []);
 
-  if (!state.mounted || state.dismissed) {
+  const { data } = useSWR<{ status?: OnboardingStatus }>(
+    mounted && !dismissed ? "/api/v1/onboarding-status" : null,
+    fetcher,
+    { shouldRetryOnError: false },
+  );
+  const status: OnboardingStatus | null = data?.status ?? null;
+
+  if (!mounted || dismissed) {
     return null;
   }
 
   const handleDismiss = () => {
     window.localStorage.setItem(ONBOARDING_DISMISSED_KEY, "true");
-    setState((prev) => ({ ...prev, dismissed: true }));
+    setDismissed(true);
   };
 
-  const s = state.status;
+  const s = status;
 
   const checklistItems = [
     {

--- a/apps/writer-web/app/coverage/filters.tsx
+++ b/apps/writer-web/app/coverage/filters.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import useSWRMutation from "swr/mutation";
 import type { CoverageTier } from "@script-manifest/contracts";
 import { useRouter, useSearchParams } from "next/navigation";
 
@@ -93,19 +94,24 @@ export function CoverageFilters({ tier, minPrice, maxPrice }: CoverageFiltersPro
   );
 }
 
+async function patchOnboarding(url: string, { arg }: { arg: Record<string, boolean> }): Promise<void> {
+  await fetch(url, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(arg),
+  });
+}
+
 export function OnboardingPing() {
   const onboardingMarked = useRef(false);
+  const { trigger } = useSWRMutation("/api/v1/onboarding-progress", patchOnboarding);
 
   useEffect(() => {
     if (!onboardingMarked.current) {
       onboardingMarked.current = true;
-      void fetch("/api/v1/onboarding-progress", {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ coverageVisited: true }),
-      });
+      void trigger({ coverageVisited: true });
     }
-  }, []);
+  }, [trigger]);
 
   return null;
 }

--- a/apps/writer-web/app/lib/useFeatureFlag.ts
+++ b/apps/writer-web/app/lib/useFeatureFlag.ts
@@ -1,15 +1,13 @@
 "use client";
-import { useEffect, useState } from "react";
+
+import useSWR from "swr";
+import { fetcher } from "./fetcher";
+
+type FeatureFlagsResponse = { flags?: Record<string, boolean> };
 
 export function useFeatureFlag(key: string): boolean {
-  const [enabled, setEnabled] = useState(false);
-  useEffect(() => {
-    fetch("/api/v1/feature-flags", { headers: {} })
-      .then(r => r.json())
-      .then((data: { flags?: Record<string, boolean> }) => {
-        setEnabled(data.flags?.[key] ?? false);
-      })
-      .catch(() => setEnabled(false));
-  }, [key]);
-  return enabled;
+  const { data } = useSWR<FeatureFlagsResponse>("/api/v1/feature-flags", fetcher, {
+    shouldRetryOnError: false,
+  });
+  return data?.flags?.[key] ?? false;
 }

--- a/apps/writer-web/app/projects/[scriptId]/viewer/page.tsx
+++ b/apps/writer-web/app/projects/[scriptId]/viewer/page.tsx
@@ -3,76 +3,29 @@
 import type { ScriptViewResponse } from "@script-manifest/contracts";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { useEffect, useState } from "react";
-
-type ViewState = {
-  loading: boolean;
-  viewer: ScriptViewResponse | null;
-  error: string | null;
-};
-
-const initialState: ViewState = {
-  loading: true,
-  viewer: null,
-  error: null
-};
+import useSWR from "swr";
+import { fetcher, ApiError } from "../../../lib/fetcher";
 
 export default function ScriptViewerPage() {
   const params = useParams<{ scriptId: string }>();
   const scriptId = Array.isArray(params.scriptId) ? params.scriptId[0] : params.scriptId;
-  const [viewState, setViewState] = useState<ViewState>(() =>
-    scriptId ? initialState : { loading: false, viewer: null, error: "missing_script_id" }
+  const viewerKey = scriptId ? `/api/v1/scripts/${encodeURIComponent(scriptId)}/view` : null;
+
+  const { data: viewer, error, isLoading } = useSWR<ScriptViewResponse>(
+    viewerKey,
+    fetcher,
+    { shouldRetryOnError: false },
   );
 
-  useEffect(() => {
-    if (!scriptId) {
-      return;
-    }
-
-    const controller = new AbortController();
-    const loadViewer = async () => {
-      try {
-        setViewState(initialState);
-        const response = await fetch(`/api/v1/scripts/${encodeURIComponent(scriptId)}/view`, {
-          signal: controller.signal,
-          headers: {}
-        });
-        const body = (await response.json()) as {
-          error?: string;
-          detail?: string;
-        } & Partial<ScriptViewResponse>;
-
-        if (!response.ok) {
-          const message = body.error ?? `viewer_request_failed_${response.status}`;
-          setViewState({
-            loading: false,
-            viewer: null,
-            error: body.detail ? `${message}: ${body.detail}` : message
-          });
-          return;
-        }
-
-        setViewState({
-          loading: false,
-          viewer: body as ScriptViewResponse,
-          error: null
-        });
-      } catch (error) {
-        if ((error as Error).name === "AbortError") {
-          return;
-        }
-
-        setViewState({
-          loading: false,
-          viewer: null,
-          error: error instanceof Error ? error.message : "unexpected_viewer_error"
-        });
-      }
-    };
-
-    void loadViewer();
-    return () => controller.abort();
-  }, [scriptId]);
+  const loading = scriptId ? isLoading : false;
+  const missingId = !scriptId;
+  const errorMessage = missingId
+    ? "missing_script_id"
+    : error instanceof ApiError
+      ? error.message
+      : error instanceof Error
+        ? error.message
+        : null;
 
   return (
     <section className="card">
@@ -84,37 +37,37 @@ export default function ScriptViewerPage() {
         <Link href="/projects">Back to projects</Link>
       </p>
 
-      {viewState.loading ? <p>Loading viewer payload...</p> : null}
-      {viewState.error ? <p className="status-error">Viewer unavailable: {viewState.error}</p> : null}
+      {loading ? <p>Loading viewer payload...</p> : null}
+      {errorMessage ? <p className="status-error">Viewer unavailable: {errorMessage}</p> : null}
 
-      {!viewState.loading && viewState.viewer ? (
+      {!loading && viewer ? (
         <>
           <div className="card viewer-meta">
             <p>
-              <strong>File:</strong> {viewState.viewer.filename}
+              <strong>File:</strong> {viewer.filename}
             </p>
             <p>
-              <strong>Object:</strong> {viewState.viewer.viewerPath}
+              <strong>Object:</strong> {viewer.viewerPath}
             </p>
             <p>
               <strong>Access:</strong>{" "}
-              {viewState.viewer.access.canView ? "view allowed" : "view denied (request needed)"}
+              {viewer.access.canView ? "view allowed" : "view denied (request needed)"}
             </p>
             <p>
-              <strong>Expires:</strong> {viewState.viewer.expiresAt}
+              <strong>Expires:</strong> {viewer.expiresAt}
             </p>
           </div>
 
-          {viewState.viewer.access.canView ? (
+          {viewer.access.canView ? (
             <div className="viewer-shell">
               <object
                 className="viewer-frame"
-                data={viewState.viewer.viewerUrl}
-                type={viewState.viewer.contentType}
+                data={viewer.viewerUrl}
+                type={viewer.contentType}
               >
                 <p>
                   PDF embed placeholder.{" "}
-                  <a href={viewState.viewer.viewerUrl} target="_blank" rel="noreferrer">
+                  <a href={viewer.viewerUrl} target="_blank" rel="noreferrer">
                     Open in new tab
                   </a>
                   .

--- a/apps/writer-web/app/rankings/methodology/page.test.tsx
+++ b/apps/writer-web/app/rankings/methodology/page.test.tsx
@@ -1,5 +1,7 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render as rtlRender, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactElement, ReactNode } from "react";
+import { SWRConfig } from "swr";
 import MethodologyPage from "./page";
 
 const SAMPLE_METHODOLOGY = {
@@ -25,6 +27,18 @@ const SAMPLE_METHODOLOGY = {
     top_50_pct: 0.5
   }
 };
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0, shouldRetryOnError: false }}>
+      {children}
+    </SWRConfig>
+  );
+}
+
+function render(ui: ReactElement) {
+  return rtlRender(ui, { wrapper: Wrapper });
+}
 
 describe("MethodologyPage", () => {
   beforeEach(() => {

--- a/apps/writer-web/app/rankings/methodology/page.tsx
+++ b/apps/writer-web/app/rankings/methodology/page.tsx
@@ -1,28 +1,22 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import useSWR from "swr";
 import type { ScoringMethodology } from "@script-manifest/contracts";
+import { fetcher, ApiError } from "../../lib/fetcher";
 
 export default function MethodologyPage() {
-  const [methodology, setMethodology] = useState<ScoringMethodology | null>(null);
-  const [error, setError] = useState("");
+  const { data: methodology, error } = useSWR<ScoringMethodology>(
+    "/api/v1/rankings/methodology",
+    fetcher,
+    { shouldRetryOnError: false },
+  );
 
-  useEffect(() => {
-    async function load() {
-      try {
-        const response = await fetch("/api/v1/rankings/methodology", { cache: "no-store" });
-        if (!response.ok) {
-          setError("Failed to load methodology.");
-          return;
-        }
-        const body = (await response.json()) as ScoringMethodology;
-        setMethodology(body);
-      } catch {
-        setError("Unable to reach the rankings service.");
-      }
-    }
-    void load();
-  }, []);
+  const errorMessage =
+    error instanceof ApiError
+      ? "Failed to load methodology."
+      : error
+        ? "Unable to reach the rankings service."
+        : "";
 
   return (
     <section className="space-y-4">
@@ -34,7 +28,7 @@ export default function MethodologyPage() {
         </p>
       </article>
 
-      {error ? <p className="status-error">{error}</p> : null}
+      {errorMessage ? <p className="status-error">{errorMessage}</p> : null}
 
       {methodology ? (
         <>

--- a/apps/writer-web/app/reset-password/page.tsx
+++ b/apps/writer-web/app/reset-password/page.tsx
@@ -41,6 +41,7 @@ export default function ResetPasswordPage() {
   const [success, setSuccess] = useState(false);
 
   useEffect(() => {
+    // non-data-fetch: defer setToken past effect body to satisfy react-hooks/set-state-in-effect
     queueMicrotask(() => {
       const params = new URLSearchParams(window.location.search);
       const t = params.get("token");

--- a/apps/writer-web/eslint-rules/no-fetch-in-effect.cjs
+++ b/apps/writer-web/eslint-rules/no-fetch-in-effect.cjs
@@ -1,0 +1,100 @@
+"use strict";
+
+const EFFECT_HOOKS = new Set(["useEffect", "useLayoutEffect", "useInsertionEffect"]);
+
+function isEffectCall(node) {
+  if (!node || node.type !== "CallExpression") return false;
+  const callee = node.callee;
+  if (callee.type === "Identifier") return EFFECT_HOOKS.has(callee.name);
+  if (callee.type === "MemberExpression" && callee.property?.type === "Identifier") {
+    return EFFECT_HOOKS.has(callee.property.name);
+  }
+  return false;
+}
+
+function isFetchCall(node) {
+  if (!node || node.type !== "CallExpression") return false;
+  const callee = node.callee;
+  if (callee.type === "Identifier" && callee.name === "fetch") return true;
+  if (
+    callee.type === "MemberExpression" &&
+    callee.property?.type === "Identifier" &&
+    callee.property.name === "fetch"
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function walkForFetch(node, onFetch, depth = 0) {
+  if (!node || typeof node !== "object" || depth > 60) return;
+  if (isFetchCall(node)) {
+    onFetch(node);
+    return;
+  }
+  for (const key of Object.keys(node)) {
+    if (key === "parent" || key === "loc" || key === "range") continue;
+    const value = node[key];
+    if (Array.isArray(value)) {
+      for (const child of value) walkForFetch(child, onFetch, depth + 1);
+    } else if (value && typeof value === "object" && typeof value.type === "string") {
+      walkForFetch(value, onFetch, depth + 1);
+    }
+  }
+}
+
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow `fetch()` inside React effect hooks. Use SWR (useSWR / useSWRMutation) or a Server Component instead.",
+      recommended: false,
+    },
+    hasSuggestions: true,
+    schema: [],
+    messages: {
+      noFetchInEffect:
+        "Avoid calling fetch() inside {{hook}}. Use useSWR for reads, useSWRMutation for writes, or convert this page to a Server Component. See docs/frontend/data-fetching.md.",
+      suggestUseSwr: "Replace this useEffect+fetch with useSWR (see docs/frontend/data-fetching.md).",
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (!isEffectCall(node)) return;
+        const callback = node.arguments[0];
+        if (!callback) return;
+        if (
+          callback.type !== "ArrowFunctionExpression" &&
+          callback.type !== "FunctionExpression"
+        ) {
+          return;
+        }
+        walkForFetch(callback, (fetchNode) => {
+          const hookName =
+            node.callee.type === "Identifier"
+              ? node.callee.name
+              : node.callee.property?.name ?? "useEffect";
+          context.report({
+            node: fetchNode,
+            messageId: "noFetchInEffect",
+            data: { hook: hookName },
+            suggest: [
+              {
+                messageId: "suggestUseSwr",
+                fix: () => null,
+              },
+            ],
+          });
+        });
+      },
+    };
+  },
+};
+
+module.exports = {
+  rules: {
+    "no-fetch-in-effect": rule,
+  },
+};

--- a/apps/writer-web/eslint-rules/no-fetch-in-effect.test.cjs
+++ b/apps/writer-web/eslint-rules/no-fetch-in-effect.test.cjs
@@ -1,0 +1,51 @@
+"use strict";
+
+const { RuleTester } = require("eslint");
+const plugin = require("./no-fetch-in-effect.cjs");
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    parserOptions: { ecmaFeatures: { jsx: true } },
+  },
+});
+
+ruleTester.run("no-fetch-in-effect", plugin.rules["no-fetch-in-effect"], {
+  valid: [
+    { code: "useEffect(() => { setX(1); }, []);" },
+    { code: "useEffect(() => { void mutate('/key'); }, []);" },
+    { code: "useSWR('/key', fetcher);" },
+    {
+      code: "useEffect(() => { void trigger({ id: 1 }); }, [trigger]);",
+    },
+    {
+      code: "async function load() { await fetch('/x'); } load();",
+    },
+    { code: "useLayoutEffect(() => { document.title = 'x'; }, []);" },
+  ],
+  invalid: [
+    {
+      code: "useEffect(() => { void fetch('/api/v1/x'); }, []);",
+      errors: [{ messageId: "noFetchInEffect" }],
+    },
+    {
+      code: "useEffect(() => { fetch('/api/v1/x').then(r => r.json()); }, []);",
+      errors: [{ messageId: "noFetchInEffect" }],
+    },
+    {
+      code: "useLayoutEffect(() => { fetch('/api/v1/x'); }, []);",
+      errors: [{ messageId: "noFetchInEffect" }],
+    },
+    {
+      code: "useEffect(() => { queueMicrotask(() => { void fetch('/api/v1/x'); }); }, []);",
+      errors: [{ messageId: "noFetchInEffect" }],
+    },
+    {
+      code: "React.useEffect(() => { fetch('/api/v1/x'); }, []);",
+      errors: [{ messageId: "noFetchInEffect" }],
+    },
+  ],
+});
+
+console.log("no-fetch-in-effect: all rule cases passed");

--- a/apps/writer-web/eslint.config.mjs
+++ b/apps/writer-web/eslint.config.mjs
@@ -1,11 +1,23 @@
 import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
 import nextTypescript from "eslint-config-next/typescript";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const dataFetchingPlugin = require("./eslint-rules/no-fetch-in-effect.cjs");
 
 const eslintConfig = [
   ...nextCoreWebVitals,
   ...nextTypescript,
   {
-    ignores: [".next/**", "node_modules/**", "out/**", "build/**", "next-env.d.ts"]
+    plugins: {
+      "script-manifest-data-fetching": dataFetchingPlugin
+    },
+    rules: {
+      "script-manifest-data-fetching/no-fetch-in-effect": "error"
+    }
+  },
+  {
+    ignores: [".next/**", "node_modules/**", "out/**", "build/**", "next-env.d.ts", "eslint-rules/**"]
   }
 ];
 

--- a/docs/frontend/data-fetching.md
+++ b/docs/frontend/data-fetching.md
@@ -1,234 +1,256 @@
-# Data Fetching Migration Guide (CHAOS-1523)
+# Data Fetching Guide (writer-web)
 
-## 1) Why this exists
+Authoritative reference for fetching, caching, and mutating data in `apps/writer-web`. Originally drafted as a migration guide in CHAOS-1523; finalized in CHAOS-1520 once the migration from `useEffect + fetch` to SWR + Server Components was complete.
 
-CHAOS-1512 removed direct lint violations by wrapping mount-time fetches in `queueMicrotask(...)`. That unblocked CI, but it preserved the same failure modes: duplicate requests, no cache reuse, bespoke loading/error branches, and brittle polling.
+## 1) Architecture
 
-CHAOS-1514 documented the cost-of-pain table (duplicate requests, stale re-entry, inconsistent UX, and foot-gun patterns). This guide standardizes Phase 1+ migrations so we stop creating one-off fetch/state stacks per page.
+```mermaid
+flowchart TD
+  user[User] --> page[Next.js App Router page]
+  page -->|"Server Component"| sf[serverFetch (lib)]
+  sf --> gw[API Gateway]
+  page -->|"Client Component"| swr[useSWR / useSWRMutation]
+  swr --> fetcher[fetcher (lib)]
+  fetcher --> bff[/api/v1/* route proxy/]
+  bff --> gw
+  gw --> svc[Backend services]
+  swr -->|"refreshAuth, mutate(key)"| swr
+```
 
-## 2) The new stack
+Four layers:
 
-Use this stack in order:
+1. **Typed fetcher** — `apps/writer-web/app/lib/fetcher.ts`. Wraps `fetch`, returns parsed JSON typed via generics, throws `ApiError(status, code, body)` on non-2xx.
+2. **SWR (client)** — `useSWR` for reads, `useSWRMutation` for writes. Cache, dedupe, focus/visibility/reconnect revalidation, polling come for free.
+3. **Server Component reads** — `apps/writer-web/app/lib/serverFetch.ts`. Reads `sm_session` cookie, forwards Authorization to the gateway, returns parsed JSON or throws `ApiError`.
+4. **Server Actions / route handlers** — for mutations originating from RSC pages.
 
-1. Typed fetcher: `apps/writer-web/app/lib/fetcher.ts`
-   - `fetcher<T>(input, init)`
-   - `ApiError` with `status`, `code`, `body`
-2. SWR in client surfaces: `useSWR` / `useSWRMutation`
-3. RSC + Server Actions for read-heavy flows where client interactivity is not required for initial data read.
+## 2) Decision tree
 
-## 3) Decision tree: which tool for which case?
+| Surface | Recommended primitive |
+| --- | --- |
+| Public, read-mostly page | Server Component + `serverFetch` |
+| Auth-bound page, interactive UI | Client `useSWR` with the typed `fetcher` |
+| Mutation from client UI (forms, buttons) | `useSWRMutation` + `mutate(key)` |
+| Mutation from RSC page | Server Action + `revalidatePath` / `revalidateTag` |
+| Polling (e.g. unread badge) | `useSWR(key, { refreshInterval })` |
+| Auth-gated resource where user may be unknown | Pause SWR with `null` key until `useAuth().loading === false` |
+| One-shot fire-and-forget side effect on mount | `useSWRMutation` triggered from `useEffect` |
+| Filter / search state that should survive navigation | URL `searchParams` driving a Server Component re-render |
 
-- Mostly-static reads on a public page (no auth)
-  - Use RSC + cached fetch.
-- Auth-bound reads in a client page
-  - Use `useSWR` with the typed fetcher.
-- Mutations from interactive client UI
-  - Use `useSWRMutation` and invalidate with `mutate(key)`.
-- Mutations from RSC pages
-  - Use Server Action + `revalidatePath`/`revalidateTag`.
-- Polling (for example NotificationBell)
-  - Use `useSWR` with `refreshInterval`.
-- Auth-gated resource where user may be unknown
-  - Pause SWR until auth resolves (`null` key / `isPaused` gate until `useAuth().loading === false`).
+## 3) Pattern catalogue
 
-## 4) Before / after recipes
-
-### A. Admin CRUD page (`admin/competitions`)
-
-Source: `apps/writer-web/app/admin/competitions/page.tsx` (see around lines 49-72)
-
-**Before (current bespoke pattern)**
+### 3.1 Auth-bound read (`useSWR`)
 
 ```tsx
-async function loadCompetitions() {
-  setLoading(true);
-  setStatus("");
-  try {
-    const response = await fetch("/api/v1/competitions?includeHidden=true&includeCancelled=true", { cache: "no-store" });
-    const body = (await response.json()) as { competitions?: Competition[]; error?: string };
-    if (!response.ok) {
-      setStatus(body.error ? `Error: ${body.error}` : "Unable to load competitions.");
-      return;
-    }
-    setRows(body.competitions ?? []);
-  } finally {
-    setLoading(false);
-  }
+const { user, loading: authLoading } = useAuth();
+const profileKey = authLoading || !user ? null : `/api/v1/profiles/${encodeURIComponent(user.id)}`;
+const { data, isLoading, mutate } = useSWR<{ profile: WriterProfile }>(profileKey, {
+  onError(err) {
+    toast.error(err instanceof ApiError ? err.message : "Failed to load profile.");
+  },
+});
+```
+
+Reference implementations:
+- `apps/writer-web/app/profile/page.tsx`
+- `apps/writer-web/app/coverage/dashboard/page.tsx`
+
+### 3.2 Mutation (`useSWRMutation`)
+
+```tsx
+async function putProfile(url: string, { arg }: { arg: WriterProfileDraft }) {
+  return fetcher(url, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(arg),
+  });
 }
 
-useEffect(() => {
-  queueMicrotask(() => { void loadCompetitions(); });
-}, []);
+const { trigger, isMutating } = useSWRMutation(profileKey, putProfile, {
+  populateCache: true,
+  revalidate: false,
+  onSuccess() {
+    toast.success("Profile saved.");
+  },
+});
 ```
 
-**After (Phase 1 target: CHAOS-1524)**
+Reference: `apps/writer-web/app/profile/page.tsx`.
+
+### 3.3 Polling
 
 ```tsx
-// TODO(CHAOS-1524): migrate to useSWR + useSWRMutation
-// key: '/api/v1/admin/competitions'
-// FILL IN AT PHASE 1
+const { data } = useSWR<UnreadCountResponse>(
+  "/api/v1/notifications/unread-count",
+  fetcher,
+  { refreshInterval: 30_000, shouldRetryOnError: false },
+);
 ```
 
-### B. Public read-only list (`leaderboard`)
+Reference: `apps/writer-web/app/components/notificationBell.tsx`.
 
-Source: `apps/writer-web/app/leaderboard/page.tsx` (see around lines 84-128)
-
-**Before (current bespoke pattern)**
+### 3.4 Server Component read
 
 ```tsx
-const runLeaderboardQuery = useCallback(async (activeFilters: Filters) => {
-  setLoading(true);
-  setStatus("");
-  const search = new URLSearchParams();
-  // ...manual query param construction...
-  const response = await fetch(`/api/v1/leaderboard?${search.toString()}`, { cache: "no-store" });
-  // ...manual response/error branches...
-  setLoading(false);
-}, []);
+// app/leaderboard/page.tsx — Server Component, no "use client"
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
 
-useEffect(() => {
-  queueMicrotask(() => { void runLeaderboardQuery(initialFilters); });
-}, [runLeaderboardQuery]);
+export default async function LeaderboardPage({ searchParams }: { searchParams?: SearchParams }) {
+  const params = searchParams ? await searchParams : {};
+  let data: LeaderboardResponse | null = null;
+  let errorMessage: string | null = null;
+  try {
+    data = await serverFetch<LeaderboardResponse>("/api/v1/leaderboard", {
+      searchParams: { format: firstParam(params.format), genre: firstParam(params.genre) },
+    });
+  } catch (err) {
+    errorMessage = err instanceof ApiError ? err.message : "Failed to load leaderboard.";
+  }
+  return <LeaderboardView data={data} errorMessage={errorMessage} />;
+}
 ```
 
-**After option 1 (client SWR, Phase 1 target: CHAOS-1525)**
+The interactive filter form lives in a sibling client island (`app/leaderboard/filters.tsx`) that uses `useRouter()` + `useSearchParams()` to push new filter state into the URL.
+
+### 3.5 Client island that re-renders the Server Component
 
 ```tsx
-// TODO(CHAOS-1525): migrate to client useSWR
-// FILL IN AT PHASE 1
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+export function LeaderboardFilters(/* ... */) {
+  const router = useRouter();
+  const params = useSearchParams();
+  function handleSubmit(form: HTMLFormElement) {
+    const next = new URLSearchParams(params);
+    next.set("format", new FormData(form).get("format")?.toString() ?? "");
+    router.push(`/leaderboard?${next.toString()}`);
+  }
+  // ...
+}
 ```
 
-**After option 2 (RSC for mostly-static reads, Phase 1 target: CHAOS-1525)**
+### 3.6 Auth session (`AuthProvider`)
+
+`AuthProvider` is itself a thin wrapper around `useSWR("/api/v1/auth/me")`. To trigger revalidation imperatively (after login/logout/email-verification), import `refreshAuth` from `app/lib/AuthProvider`:
 
 ```tsx
-// TODO(CHAOS-1525): migrate to Server Component read path
-// FILL IN AT PHASE 1
+import { refreshAuth } from "../lib/AuthProvider";
+refreshAuth(); // → mutate("/api/v1/auth/me")
 ```
 
-Tradeoff summary:
-- Client SWR: easier filter interactivity + built-in revalidation.
-- RSC: better initial payload characteristics for mostly-static/public reads.
+The legacy `AUTH_CHANGED_EVENT` window event is still honored for back-compat.
 
-### C. Owner-bound mutation (`profile`)
+## 4) When NOT to use SWR
 
-Source: `apps/writer-web/app/profile/page.tsx` (see around lines 52-111)
-
-**Before (current bespoke pattern)**
-
-```tsx
-const loadProfile = useCallback(async (explicitWriterId?: string) => {
-  const targetWriterId = explicitWriterId ?? writerId;
-  if (!targetWriterId.trim()) return;
-  setLoading(true);
-  const response = await fetch(`/api/v1/profiles/${encodeURIComponent(targetWriterId)}`, {
-    cache: "no-store",
-    headers: {}
-  });
-  // ...manual parse + state fanout + toast branches...
-  setLoading(false);
-}, [writerId]);
-
-useEffect(() => {
-  if (writerId) queueMicrotask(() => { void loadProfile(writerId); });
-}, [loadProfile, writerId]);
-```
-
-**After (Phase 1 target: CHAOS-1526)**
-
-```tsx
-// TODO(CHAOS-1526): migrate to auth-paused useSWR + useSWRMutation save path
-// FILL IN AT PHASE 1
-```
+- **Form input state** — drive with `useState` / a form library. SWR is a data cache, not form state.
+- **One-shot user actions that show a modal / navigate** — call the fetcher directly inside an event handler. Wrapping a single button-click in `useSWRMutation` is overkill.
+- **Long-running uploads with progress** — use `fetch` + `XMLHttpRequest`-style progress; SWR has no progress primitive.
+- **Push channels (WebSocket / SSE)** — use a dedicated subscription hook; SWR can hold the latest snapshot but should not own the transport.
+- **Server Component data** — call `serverFetch` directly. Never import SWR in a Server Component.
 
 ## 5) Cache-key conventions
 
-- Use API URL strings as keys (example: `'/api/v1/admin/competitions'`).
-- If key composition depends on auth/params, return `null` while unresolved.
-- Do not use object keys.
+- Keys are API URL strings (`/api/v1/admin/competitions`).
+- If the key depends on async-resolved data (auth, route params), return `null` until resolved.
+- Do not use object keys. Always stringify query parameters into the URL.
 
 ```ts
 const { user, loading } = useAuth();
 const key = loading || !user ? null : `/api/v1/me/projects?writerId=${encodeURIComponent(user.id)}`;
 ```
 
-## 6) Invalidating cache after a mutation
-
-Use one of:
+## 6) Invalidating after a mutation
 
 ```ts
+// Single key
 const { mutate } = useSWRConfig();
-await mutate('/api/v1/admin/competitions');
+await mutate("/api/v1/admin/competitions");
 ```
 
 ```ts
-// via useSWRMutation options
-// revalidate: true
+// useSWRMutation auto-revalidate
+useSWRMutation(key, fetcher, { revalidate: true });
 ```
 
 ```ts
-const { mutate } = useSWRConfig();
-await mutate((key) => typeof key === 'string' && key.startsWith('/api/v1/admin/'));
+// Pattern match
+await mutate((key) => typeof key === "string" && key.startsWith("/api/v1/admin/"));
 ```
 
-## 7) Standard loading / error / empty-state UI
+## 7) Standard UI primitives
 
-Existing references:
-
-- Skeleton primitives: `apps/writer-web/app/components/skeleton.tsx`
+- Skeleton placeholders: `apps/writer-web/app/components/skeleton.tsx`
 - Empty state: `apps/writer-web/app/components/emptyState.tsx`
 - Toast surface: `apps/writer-web/app/components/toast.tsx`
 
-Missing standardized inline error surface:
+Show skeletons during initial `isLoading === true`, switch to empty state when data resolves to `[]`, raise toasts only for non-blocking failures. Render blocking errors inline.
 
-```ts
-// TODO Phase 1 — add Skeleton/ErrorInline/Empty components (or wrapper conventions)
-// Follow-up: CHAOS-1528
+## 8) Error handling
+
+Catch `ApiError` from `apps/writer-web/app/lib/fetcher.ts`:
+
+- `status` — HTTP branch handling (401/403/404/5xx).
+- `code` — API-level classification (e.g. `email_not_verified`).
+- `body` — safe diagnostics for logs / dev tooling.
+
+The global `SWRProvider` (`app/lib/SWRProvider.tsx`) is configured to:
+- Skip retries on 4xx, retry on 5xx.
+- Call `refreshAuth()` on any 401 (force a re-check of the session).
+
+## 9) Lint enforcement
+
+A custom ESLint rule prevents regressions:
+
+```
+script-manifest-data-fetching/no-fetch-in-effect (error)
 ```
 
-## 8) Polling
+Flags any `fetch()` call inside a `useEffect`, `useLayoutEffect`, or `useInsertionEffect` body — including transitively through `queueMicrotask`, `setTimeout`, etc. Rule source: `apps/writer-web/eslint-rules/no-fetch-in-effect.cjs`. Wired in `apps/writer-web/eslint.config.mjs`.
 
-```ts
-useSWR(key, { refreshInterval: 30_000, refreshWhenHidden: false });
-```
+`queueMicrotask` may still appear in client components, but only for **non-data-fetch** state initialization (e.g. reading `localStorage` or `window.location.search` and deferring `setState` past the effect body to satisfy `react-hooks/set-state-in-effect`). Each remaining occurrence must carry a `// non-data-fetch: …` comment explaining why.
 
-Set `refreshWhenHidden: false` so polling pauses while tab is hidden.
+## 10) Migration cookbook
 
-## 9) Auth-bound resources
+| Phase | Linear | What landed |
+| --- | --- | --- |
+| 0 — Foundation | CHAOS-1515 | swr dep, `SWRProvider`, typed `fetcher` + `ApiError`, this guide. |
+| 1 — Pilot | CHAOS-1516 | profile + leaderboard (initial) + admin/competitions converted; pattern proven. |
+| 2 — Bulk client | CHAOS-1517 (1529–1532) | ~26 pages migrated across admin / coverage / user-content / misc batches. |
+| 3 — Special cases | CHAOS-1518 | AuthProvider on SWR, NotificationBell polling, `useClock`, signin OAuth via `useSWRMutation`. |
+| 4 — RSC | CHAOS-1519 | leaderboard + coverage marketplace converted to Server Components; `serverFetch` helper. |
+| 5 — Cleanup | CHAOS-1520 | Final 7 stragglers (admin metrics, methodology, feature flags, script viewer, onboarding ping x2, OnboardingChecklist) migrated; custom ESLint rule landed; docs finalized. |
 
-```ts
-const { user, loading } = useAuth();
-const { data } = useSWR(loading || !user ? null : '/api/v1/me/projects');
-```
-
-## 10) Error handling
-
-Handle `ApiError` from `apps/writer-web/app/lib/fetcher.ts`.
-
-- `status` for HTTP branch handling (401/403/404/5xx)
-- `code` for API-level classification
-- `body` for safe diagnostics
-
-Render blocking failures inline; use `Toast` for non-blocking failures.
-
-## 11) Migration cookbook
-
-Phase 2 PRs append entries here. Each entry: title, link to PR, what pattern was migrated, anything surprising.
-
-- 
-
-## 12) Forbidden patterns (will fail lint once CHAOS-1520 lands)
-
-Do not introduce these patterns in new code:
-
-- `useEffect(() => { fetch(...) }, [])`
-- `queueMicrotask(() => fetch(...))`
+## 11) Forbidden patterns
 
 ```tsx
-// ❌ forbidden
+// ❌ fetch inside useEffect — lint will fail
+useEffect(() => {
+  fetch("/api/v1/something").then(r => r.json()).then(setData);
+}, []);
+```
+
+```tsx
+// ❌ queueMicrotask wrapping a fetch — lint will fail
 useEffect(() => {
   queueMicrotask(async () => {
-    const res = await fetch('/api/v1/something');
+    const res = await fetch("/api/v1/something");
     setData(await res.json());
   });
 }, []);
+```
+
+```tsx
+// ❌ useState + manual loading + fetch triple — lint will fail (no-fetch-in-effect)
+const [data, setData] = useState(null);
+const [loading, setLoading] = useState(true);
+useEffect(() => {
+  fetch("/api/v1/something").then(/* ... */).finally(() => setLoading(false));
+}, []);
+```
+
+```tsx
+// ✅ replace with useSWR
+const { data, isLoading } = useSWR<Payload>("/api/v1/something", fetcher);
 ```


### PR DESCRIPTION
## Summary

Closes out the writer-web data-fetching modernization (CHAOS-1514). Builds on Phase 4 (#478, merged).

### Custom ESLint rule

- **\`script-manifest-data-fetching/no-fetch-in-effect\`** at \`error\` severity. Flags \`fetch()\` inside \`useEffect\` / \`useLayoutEffect\` / \`useInsertionEffect\`, including transitively through \`queueMicrotask\` and \`setTimeout\` wrappers. Suggestion message points at \`useSWR\`.
- Rule source: \`apps/writer-web/eslint-rules/no-fetch-in-effect.cjs\`. Unit tests: \`apps/writer-web/eslint-rules/no-fetch-in-effect.test.cjs\` (6 valid + 5 invalid cases).
- Wired in \`apps/writer-web/eslint.config.mjs\`.

### Final SWR migrations (7 offenders the rule surfaced)

The rule caught 7 \`useEffect + fetch\` triples still in the codebase that prior batches missed. All migrated:

| File | Migration |
| --- | --- |
| \`app/admin/page.tsx\` | admin metrics → \`useSWR\` |
| \`app/lib/useFeatureFlag.ts\` | feature flag → \`useSWR\` |
| \`app/rankings/methodology/page.tsx\` | scoring methodology → \`useSWR\` |
| \`app/projects/[scriptId]/viewer/page.tsx\` | script viewer → \`useSWR\` |
| \`app/components/OnboardingChecklist.tsx\` | onboarding status → \`useSWR\` with conditional key |
| \`app/competitions/page.tsx\` | onboarding-progress PATCH → \`useSWRMutation\` |
| \`app/coverage/filters.tsx\` (\`OnboardingPing\`) | onboarding-progress PATCH → \`useSWRMutation\` |

### queueMicrotask audit

\`\`\`
$ grep -rE "queueMicrotask\(" apps/writer-web/app --include="*.tsx" --include="*.ts"
apps/writer-web/app/components/OnboardingChecklist.tsx:26
apps/writer-web/app/reset-password/page.tsx:45
\`\`\`

Both remaining occurrences are pure state-init defers (no \`fetch\`), each annotated with \`// non-data-fetch: defer setState past effect body to satisfy react-hooks/set-state-in-effect\`. Satisfies the CHAOS-1520 success criterion (every match must be annotated or removed).

### Tests

- All **492 writer-web tests pass**.
- \`OnboardingChecklist\` + \`methodology\` tests now wrap renders in an isolated \`SWRConfig\` provider to prevent cache leakage across tests.
- ESLint rule unit tests pass: \`node apps/writer-web/eslint-rules/no-fetch-in-effect.test.cjs\`.

### Docs

\`docs/frontend/data-fetching.md\` finalized:
- Mermaid architecture diagram
- Pattern catalogue (read / mutation / polling / RSC / client island / auth session)
- Decision tree for which primitive to use
- **When NOT to use SWR** section
- Cache-key + invalidation conventions
- Lint-enforcement section pointing at the new rule
- Migration cookbook covering all 5 phases (CHAOS-1515 → CHAOS-1520)
- Forbidden-patterns examples

## Verification

\`\`\`
pnpm --filter @script-manifest/writer-web typecheck   # clean
pnpm --filter @script-manifest/writer-web lint        # 0 errors (28 pre-existing warnings)
pnpm --filter @script-manifest/writer-web test        # 492/492 passing
pnpm --filter @script-manifest/writer-web build       # clean
node apps/writer-web/eslint-rules/no-fetch-in-effect.test.cjs   # all rule cases pass
\`\`\`

Closes CHAOS-1520. With this merged, **CHAOS-1514 epic is done**.