### PR TITLE
test(CHAOS-1041): close service repository test gaps

### DIFF
--- a/services/competition-directory-service/src/repository.test.ts
+++ b/services/competition-directory-service/src/repository.test.ts
@@ -1,0 +1,247 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Competition } from "@script-manifest/contracts";
+import type { CompetitionDirectoryRepository } from "./repository.js";
+
+function createCompetition(overrides: Partial<Competition> & Pick<Competition, "id" | "title" | "format" | "genre" | "deadline">): Competition {
+  return {
+    description: "",
+    feeUsd: 0,
+    status: "active",
+    visibility: "listed",
+    accessType: "open",
+    ...overrides
+  };
+}
+
+class MemoryCompetitionDirectoryRepository implements CompetitionDirectoryRepository {
+  private readonly competitions = new Map<string, Competition>();
+
+  constructor(seed: Competition[] = []) {
+    for (const competition of seed) {
+      this.competitions.set(competition.id, competition);
+    }
+  }
+
+  async init(): Promise<void> {
+    return;
+  }
+
+  async healthCheck(): Promise<{ database: boolean }> {
+    return { database: true };
+  }
+
+  async upsertCompetition(competition: Competition): Promise<{ existed: boolean }> {
+    const existed = this.competitions.has(competition.id);
+    this.competitions.set(competition.id, competition);
+    return { existed };
+  }
+
+  async getCompetition(id: string): Promise<Competition | null> {
+    return this.competitions.get(id) ?? null;
+  }
+
+  async listCompetitions(filters: Parameters<CompetitionDirectoryRepository["listCompetitions"]>[0]): Promise<Competition[]> {
+    const loweredQuery = filters.query?.toLowerCase();
+
+    return Array.from(this.competitions.values()).filter((competition) => {
+      if (!filters.includeCancelled && competition.status === "cancelled") {
+        return false;
+      }
+
+      if (!filters.includeHidden && competition.visibility === "unlisted") {
+        return false;
+      }
+
+      if (loweredQuery && !`${competition.title} ${competition.description}`.toLowerCase().includes(loweredQuery)) {
+        return false;
+      }
+
+      if (filters.format && competition.format.toLowerCase() !== filters.format.toLowerCase()) {
+        return false;
+      }
+
+      if (filters.genre && competition.genre.toLowerCase() !== filters.genre.toLowerCase()) {
+        return false;
+      }
+
+      if (typeof filters.maxFeeUsd === "number" && competition.feeUsd > filters.maxFeeUsd) {
+        return false;
+      }
+
+      if (filters.deadlineBefore && new Date(competition.deadline) >= filters.deadlineBefore) {
+        return false;
+      }
+
+      return true;
+    });
+  }
+
+  async getAllCompetitions(): Promise<Competition[]> {
+    return Array.from(this.competitions.values());
+  }
+
+  async cancelCompetition(id: string): Promise<Competition | null> {
+    const competition = this.competitions.get(id);
+    if (!competition || competition.status === "cancelled") {
+      return null;
+    }
+
+    const updated = { ...competition, status: "cancelled" as const };
+    this.competitions.set(id, updated);
+    return updated;
+  }
+
+  async updateVisibility(id: string, visibility: Competition["visibility"]): Promise<Competition | null> {
+    const competition = this.competitions.get(id);
+    if (!competition) {
+      return null;
+    }
+
+    const updated = { ...competition, visibility };
+    this.competitions.set(id, updated);
+    return updated;
+  }
+
+  async updateAccessType(id: string, accessType: Competition["accessType"]): Promise<Competition | null> {
+    const competition = this.competitions.get(id);
+    if (!competition) {
+      return null;
+    }
+
+    const updated = { ...competition, accessType };
+    this.competitions.set(id, updated);
+    return updated;
+  }
+}
+
+test("CompetitionDirectoryRepository contract stores and retrieves competitions", async () => {
+  const repo = new MemoryCompetitionDirectoryRepository([
+    createCompetition({
+      id: "comp_1",
+      title: "Screenplay Sprint",
+      description: "Seed competition record for local development",
+      format: "feature",
+      genre: "drama",
+      feeUsd: 25,
+      deadline: "2026-05-01T23:59:59Z"
+    })
+  ]);
+
+  assert.deepEqual(await repo.healthCheck(), { database: true });
+  await repo.init();
+
+  const created = await repo.upsertCompetition(
+    createCompetition({
+      id: "comp_2",
+      title: "TV Pilot Challenge",
+      description: "Serialized drama",
+      format: "tv",
+      genre: "drama",
+      feeUsd: 50,
+      deadline: "2026-07-01T23:59:59Z",
+      visibility: "unlisted"
+    })
+  );
+
+  assert.equal(created.existed, false);
+  assert.equal((await repo.getCompetition("comp_2"))?.title, "TV Pilot Challenge");
+
+  const updated = await repo.upsertCompetition(
+    createCompetition({
+      id: "comp_2",
+      title: "TV Pilot Challenge Updated",
+      description: "Serialized drama",
+      format: "tv",
+      genre: "drama",
+      feeUsd: 45,
+      deadline: "2026-07-15T23:59:59Z",
+      visibility: "unlisted"
+    })
+  );
+
+  assert.equal(updated.existed, true);
+  assert.equal((await repo.getCompetition("comp_2"))?.title, "TV Pilot Challenge Updated");
+  assert.equal((await repo.getCompetition("missing")), null);
+  assert.deepEqual((await repo.getAllCompetitions()).map((competition) => competition.id), ["comp_1", "comp_2"]);
+});
+
+test("CompetitionDirectoryRepository contract filters hidden and cancelled competitions", async () => {
+  const repo = new MemoryCompetitionDirectoryRepository([
+    createCompetition({
+      id: "comp_1",
+      title: "Screenplay Sprint",
+      description: "Seed competition record for local development",
+      format: "feature",
+      genre: "drama",
+      feeUsd: 25,
+      deadline: "2026-05-01T23:59:59Z"
+    }),
+    createCompetition({
+      id: "comp_2",
+      title: "Festival Lab",
+      description: "Invite only festival",
+      format: "feature",
+      genre: "thriller",
+      feeUsd: 75,
+      deadline: "2026-09-01T23:59:59Z",
+      status: "cancelled",
+      visibility: "unlisted"
+    }),
+    createCompetition({
+      id: "comp_3",
+      title: "TV Pilot Challenge",
+      description: "Serialized drama",
+      format: "tv",
+      genre: "drama",
+      feeUsd: 50,
+      deadline: "2026-07-01T23:59:59Z",
+      visibility: "unlisted"
+    })
+  ]);
+
+  assert.deepEqual((await repo.listCompetitions({})).map((competition) => competition.id), ["comp_1"]);
+  assert.deepEqual(
+    (await repo.listCompetitions({
+      query: "serialized",
+      format: "tv",
+      genre: "drama",
+      maxFeeUsd: 60,
+      deadlineBefore: new Date("2026-08-01T00:00:00.000Z"),
+      includeHidden: true
+    })).map((competition) => competition.id),
+    ["comp_3"]
+  );
+  assert.deepEqual(
+    (await repo.listCompetitions({ includeHidden: true, includeCancelled: true })).map((competition) => competition.id),
+    ["comp_1", "comp_2", "comp_3"]
+  );
+});
+
+test("CompetitionDirectoryRepository contract cancels and updates competition settings", async () => {
+  const repo = new MemoryCompetitionDirectoryRepository([
+    createCompetition({
+      id: "comp_1",
+      title: "Screenplay Sprint",
+      description: "Seed competition record for local development",
+      format: "feature",
+      genre: "drama",
+      feeUsd: 25,
+      deadline: "2026-05-01T23:59:59Z"
+    })
+  ]);
+
+  const cancelled = await repo.cancelCompetition("comp_1");
+  assert.equal(cancelled?.status, "cancelled");
+  assert.equal(await repo.cancelCompetition("comp_1"), null);
+  assert.equal(await repo.cancelCompetition("missing"), null);
+
+  const visibility = await repo.updateVisibility("comp_1", "unlisted");
+  assert.equal(visibility?.visibility, "unlisted");
+
+  const accessType = await repo.updateAccessType("comp_1", "invite_only");
+  assert.equal(accessType?.accessType, "invite_only");
+
+  assert.equal(await repo.updateVisibility("missing", "listed"), null);
+  assert.equal(await repo.updateAccessType("missing", "open"), null);
+});

--- a/services/competition-directory-service/src/repository.test.ts
+++ b/services/competition-directory-service/src/repository.test.ts
@@ -1,247 +1,137 @@
 import assert from "node:assert/strict";
-import test from "node:test";
-import type { Competition } from "@script-manifest/contracts";
-import type { CompetitionDirectoryRepository } from "./repository.js";
+import { beforeEach, mock, test } from "node:test";
 
-function createCompetition(overrides: Partial<Competition> & Pick<Competition, "id" | "title" | "format" | "genre" | "deadline">): Competition {
+type QueryResult = { rows: unknown[]; rowCount?: number };
+type QueryFn = (sql: string, values?: unknown[]) => Promise<QueryResult>;
+
+const publishCalls: unknown[] = [];
+let queryImpl: QueryFn = async () => ({ rows: [], rowCount: 0 });
+const query: QueryFn = async (sql, values = []) => queryImpl(sql, values);
+
+const { toFtsPrefixQuery } = await import("@script-manifest/db");
+
+mock.module("@script-manifest/db", {
+  namedExports: {
+    getPool: () => ({ query }),
+    runMigrations: async () => undefined,
+    toFtsPrefixQuery
+  }
+});
+
+mock.module("@script-manifest/service-utils", {
+  namedExports: {
+    publishSearchSyncEvent: async (event: unknown) => {
+      publishCalls.push(event);
+    }
+  }
+});
+
+const { PgCompetitionDirectoryRepository } = await import("./pgRepository.js");
+
+beforeEach(() => {
+  publishCalls.length = 0;
+  queryImpl = async () => ({ rows: [], rowCount: 0 });
+});
+
+function competitionRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
-    description: "",
-    feeUsd: 0,
+    id: "comp_1",
+    title: "Screenplay Sprint",
+    description: "Seed competition record",
+    format: "feature",
+    genre: "drama",
+    fee_usd: "25",
+    deadline: new Date("2026-05-01T23:59:59.000Z"),
     status: "active",
     visibility: "listed",
-    accessType: "open",
+    access_type: "open",
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+    updated_at: new Date("2026-01-02T00:00:00.000Z"),
     ...overrides
   };
 }
 
-class MemoryCompetitionDirectoryRepository implements CompetitionDirectoryRepository {
-  private readonly competitions = new Map<string, Competition>();
+test("PgCompetitionDirectoryRepository retrieves and lists mapped competitions", async () => {
+  const calls: Array<{ sql: string; values: unknown[] }> = [];
 
-  constructor(seed: Competition[] = []) {
-    for (const competition of seed) {
-      this.competitions.set(competition.id, competition);
+  queryImpl = async (sql, values = []) => {
+    calls.push({ sql, values });
+    if (sql.includes("WHERE id = $1")) {
+      return { rows: [competitionRow()] };
     }
-  }
-
-  async init(): Promise<void> {
-    return;
-  }
-
-  async healthCheck(): Promise<{ database: boolean }> {
-    return { database: true };
-  }
-
-  async upsertCompetition(competition: Competition): Promise<{ existed: boolean }> {
-    const existed = this.competitions.has(competition.id);
-    this.competitions.set(competition.id, competition);
-    return { existed };
-  }
-
-  async getCompetition(id: string): Promise<Competition | null> {
-    return this.competitions.get(id) ?? null;
-  }
-
-  async listCompetitions(filters: Parameters<CompetitionDirectoryRepository["listCompetitions"]>[0]): Promise<Competition[]> {
-    const loweredQuery = filters.query?.toLowerCase();
-
-    return Array.from(this.competitions.values()).filter((competition) => {
-      if (!filters.includeCancelled && competition.status === "cancelled") {
-        return false;
-      }
-
-      if (!filters.includeHidden && competition.visibility === "unlisted") {
-        return false;
-      }
-
-      if (loweredQuery && !`${competition.title} ${competition.description}`.toLowerCase().includes(loweredQuery)) {
-        return false;
-      }
-
-      if (filters.format && competition.format.toLowerCase() !== filters.format.toLowerCase()) {
-        return false;
-      }
-
-      if (filters.genre && competition.genre.toLowerCase() !== filters.genre.toLowerCase()) {
-        return false;
-      }
-
-      if (typeof filters.maxFeeUsd === "number" && competition.feeUsd > filters.maxFeeUsd) {
-        return false;
-      }
-
-      if (filters.deadlineBefore && new Date(competition.deadline) >= filters.deadlineBefore) {
-        return false;
-      }
-
-      return true;
-    });
-  }
-
-  async getAllCompetitions(): Promise<Competition[]> {
-    return Array.from(this.competitions.values());
-  }
-
-  async cancelCompetition(id: string): Promise<Competition | null> {
-    const competition = this.competitions.get(id);
-    if (!competition || competition.status === "cancelled") {
-      return null;
+    if (sql.includes("ORDER BY created_at")) {
+      return { rows: [competitionRow(), competitionRow({ id: "comp_2", title: "TV Pilot Challenge", fee_usd: 50 })] };
     }
+    return { rows: [] };
+  };
 
-    const updated = { ...competition, status: "cancelled" as const };
-    this.competitions.set(id, updated);
-    return updated;
-  }
+  const repo = new PgCompetitionDirectoryRepository();
+  const competition = await repo.getCompetition("comp_1");
+  const allCompetitions = await repo.getAllCompetitions();
 
-  async updateVisibility(id: string, visibility: Competition["visibility"]): Promise<Competition | null> {
-    const competition = this.competitions.get(id);
-    if (!competition) {
-      return null;
-    }
-
-    const updated = { ...competition, visibility };
-    this.competitions.set(id, updated);
-    return updated;
-  }
-
-  async updateAccessType(id: string, accessType: Competition["accessType"]): Promise<Competition | null> {
-    const competition = this.competitions.get(id);
-    if (!competition) {
-      return null;
-    }
-
-    const updated = { ...competition, accessType };
-    this.competitions.set(id, updated);
-    return updated;
-  }
-}
-
-test("CompetitionDirectoryRepository contract stores and retrieves competitions", async () => {
-  const repo = new MemoryCompetitionDirectoryRepository([
-    createCompetition({
-      id: "comp_1",
-      title: "Screenplay Sprint",
-      description: "Seed competition record for local development",
-      format: "feature",
-      genre: "drama",
-      feeUsd: 25,
-      deadline: "2026-05-01T23:59:59Z"
-    })
-  ]);
-
-  assert.deepEqual(await repo.healthCheck(), { database: true });
-  await repo.init();
-
-  const created = await repo.upsertCompetition(
-    createCompetition({
-      id: "comp_2",
-      title: "TV Pilot Challenge",
-      description: "Serialized drama",
-      format: "tv",
-      genre: "drama",
-      feeUsd: 50,
-      deadline: "2026-07-01T23:59:59Z",
-      visibility: "unlisted"
-    })
-  );
-
-  assert.equal(created.existed, false);
-  assert.equal((await repo.getCompetition("comp_2"))?.title, "TV Pilot Challenge");
-
-  const updated = await repo.upsertCompetition(
-    createCompetition({
-      id: "comp_2",
-      title: "TV Pilot Challenge Updated",
-      description: "Serialized drama",
-      format: "tv",
-      genre: "drama",
-      feeUsd: 45,
-      deadline: "2026-07-15T23:59:59Z",
-      visibility: "unlisted"
-    })
-  );
-
-  assert.equal(updated.existed, true);
-  assert.equal((await repo.getCompetition("comp_2"))?.title, "TV Pilot Challenge Updated");
-  assert.equal((await repo.getCompetition("missing")), null);
-  assert.deepEqual((await repo.getAllCompetitions()).map((competition) => competition.id), ["comp_1", "comp_2"]);
+  assert.deepEqual(competition, {
+    id: "comp_1",
+    title: "Screenplay Sprint",
+    description: "Seed competition record",
+    format: "feature",
+    genre: "drama",
+    feeUsd: 25,
+    deadline: "2026-05-01T23:59:59.000Z",
+    status: "active",
+    visibility: "listed",
+    accessType: "open"
+  });
+  assert.deepEqual(allCompetitions.map((item) => item.id), ["comp_1", "comp_2"]);
+  assert.equal(calls[0]?.sql.trim(), "SELECT * FROM competitions WHERE id = $1");
+  assert.deepEqual(calls[0]?.values, ["comp_1"]);
+  assert.equal(calls[1]?.sql, "SELECT * FROM competitions ORDER BY created_at");
 });
 
-test("CompetitionDirectoryRepository contract filters hidden and cancelled competitions", async () => {
-  const repo = new MemoryCompetitionDirectoryRepository([
-    createCompetition({
-      id: "comp_1",
-      title: "Screenplay Sprint",
-      description: "Seed competition record for local development",
-      format: "feature",
-      genre: "drama",
-      feeUsd: 25,
-      deadline: "2026-05-01T23:59:59Z"
-    }),
-    createCompetition({
-      id: "comp_2",
-      title: "Festival Lab",
-      description: "Invite only festival",
-      format: "feature",
-      genre: "thriller",
-      feeUsd: 75,
-      deadline: "2026-09-01T23:59:59Z",
-      status: "cancelled",
-      visibility: "unlisted"
-    }),
-    createCompetition({
-      id: "comp_3",
-      title: "TV Pilot Challenge",
-      description: "Serialized drama",
-      format: "tv",
-      genre: "drama",
-      feeUsd: 50,
-      deadline: "2026-07-01T23:59:59Z",
-      visibility: "unlisted"
-    })
-  ]);
+test("PgCompetitionDirectoryRepository updates status, visibility, and access type with sync events", async () => {
+  const calls: Array<{ sql: string; values: unknown[] }> = [];
 
-  assert.deepEqual((await repo.listCompetitions({})).map((competition) => competition.id), ["comp_1"]);
-  assert.deepEqual(
-    (await repo.listCompetitions({
-      query: "serialized",
-      format: "tv",
-      genre: "drama",
-      maxFeeUsd: 60,
-      deadlineBefore: new Date("2026-08-01T00:00:00.000Z"),
-      includeHidden: true
-    })).map((competition) => competition.id),
-    ["comp_3"]
-  );
-  assert.deepEqual(
-    (await repo.listCompetitions({ includeHidden: true, includeCancelled: true })).map((competition) => competition.id),
-    ["comp_1", "comp_2", "comp_3"]
-  );
-});
+  queryImpl = async (sql, values = []) => {
+    calls.push({ sql, values });
+    if (sql.includes("SET status = 'cancelled'")) {
+      return { rows: [competitionRow({ status: "cancelled" })], rowCount: 1 };
+    }
+    if (sql.includes("SET visibility = $2")) {
+      return { rows: [competitionRow({ visibility: "unlisted" })], rowCount: 1 };
+    }
+    if (sql.includes("SET access_type = $2")) {
+      return { rows: [competitionRow({ access_type: "invite_only" })], rowCount: 1 };
+    }
+    return { rows: [] };
+  };
 
-test("CompetitionDirectoryRepository contract cancels and updates competition settings", async () => {
-  const repo = new MemoryCompetitionDirectoryRepository([
-    createCompetition({
-      id: "comp_1",
-      title: "Screenplay Sprint",
-      description: "Seed competition record for local development",
-      format: "feature",
-      genre: "drama",
-      feeUsd: 25,
-      deadline: "2026-05-01T23:59:59Z"
-    })
-  ]);
-
+  const repo = new PgCompetitionDirectoryRepository();
   const cancelled = await repo.cancelCompetition("comp_1");
+  const hidden = await repo.updateVisibility("comp_1", "unlisted");
+  const inviteOnly = await repo.updateAccessType("comp_1", "invite_only");
+
   assert.equal(cancelled?.status, "cancelled");
-  assert.equal(await repo.cancelCompetition("comp_1"), null);
+  assert.equal(hidden?.visibility, "unlisted");
+  assert.equal(inviteOnly?.accessType, "invite_only");
+  assert.deepEqual(calls.map((call) => call.values), [
+    ["comp_1"],
+    ["comp_1", "unlisted"],
+    ["comp_1", "invite_only"]
+  ]);
+  assert.equal(publishCalls.length, 3);
+  assert.deepEqual(
+    publishCalls.map((event) => (event as { collection: string; documentId: string; operation: string }).operation),
+    ["upsert", "upsert", "upsert"]
+  );
+});
+
+test("PgCompetitionDirectoryRepository returns null when competition updates miss", async () => {
+  queryImpl = async () => ({ rows: [], rowCount: 0 });
+
+  const repo = new PgCompetitionDirectoryRepository();
+
+  assert.equal(await repo.getCompetition("missing"), null);
   assert.equal(await repo.cancelCompetition("missing"), null);
-
-  const visibility = await repo.updateVisibility("comp_1", "unlisted");
-  assert.equal(visibility?.visibility, "unlisted");
-
-  const accessType = await repo.updateAccessType("comp_1", "invite_only");
-  assert.equal(accessType?.accessType, "invite_only");
-
   assert.equal(await repo.updateVisibility("missing", "listed"), null);
   assert.equal(await repo.updateAccessType("missing", "open"), null);
+  assert.equal(publishCalls.length, 0);
 });

--- a/services/profile-project-service/src/repository.test.ts
+++ b/services/profile-project-service/src/repository.test.ts
@@ -14,7 +14,7 @@ import type {
   WriterProfileUpdateRequest
 } from "@script-manifest/contracts";
 
-type QueryResult = { rows: any[]; rowCount?: number };
+type QueryResult = { rows: unknown[]; rowCount?: number };
 type QueryFn = (sql: string, values?: unknown[]) => Promise<QueryResult>;
 type Client = { query: QueryFn; release: () => void };
 

--- a/services/profile-project-service/src/repository.test.ts
+++ b/services/profile-project-service/src/repository.test.ts
@@ -1,0 +1,1026 @@
+import assert from "node:assert/strict";
+import { beforeEach, mock, test } from "node:test";
+import type {
+  Project,
+  ProjectCoWriterCreateRequest,
+  ProjectCreateInternal,
+  ProjectDraft,
+  ProjectDraftCreateInternal,
+  ProjectDraftUpdateRequest,
+  ProjectFilters,
+  ProjectUpdateRequest,
+  ScriptAccessRequestCreateRequest,
+  ScriptAccessRequestFilters,
+  WriterProfileUpdateRequest
+} from "@script-manifest/contracts";
+
+type QueryResult = { rows: any[]; rowCount?: number };
+type QueryFn = (sql: string, values?: unknown[]) => Promise<QueryResult>;
+type Client = { query: QueryFn; release: () => void };
+
+const publishCalls: unknown[] = [];
+const poolCalls: Array<{ sql: string; values: unknown[] }> = [];
+const clientCalls: Array<{ sql: string; values: unknown[] }> = [];
+
+let poolQueryImpl: QueryFn = async () => ({ rows: [], rowCount: 0 });
+let clientQueryImpl: QueryFn = async () => ({ rows: [], rowCount: 0 });
+let releaseCount = 0;
+
+const pool = {
+  query: async (sql: string, values: unknown[] = []) => {
+    poolCalls.push({ sql, values });
+    return poolQueryImpl(sql, values);
+  },
+  connect: async (): Promise<Client> => ({
+    query: async (sql: string, values: unknown[] = []) => {
+      clientCalls.push({ sql, values });
+      return clientQueryImpl(sql, values);
+    },
+    release: () => {
+      releaseCount += 1;
+    }
+  })
+};
+
+mock.module("@script-manifest/db", {
+  namedExports: {
+    getPool: () => pool,
+    ensureCoreTables: async () => undefined
+  }
+});
+
+mock.module("@script-manifest/service-utils", {
+  namedExports: {
+    publishSearchSyncEvent: async (event: unknown) => {
+      publishCalls.push(event);
+    }
+  }
+});
+
+const { PgProfileProjectRepository } = await import("./repository.js");
+
+beforeEach(() => {
+  publishCalls.length = 0;
+  poolCalls.length = 0;
+  clientCalls.length = 0;
+  releaseCount = 0;
+  poolQueryImpl = async () => ({ rows: [], rowCount: 0 });
+  clientQueryImpl = async () => ({ rows: [], rowCount: 0 });
+});
+
+function normalizeSql(sql: string): string {
+  return sql.replace(/\s+/g, " ").trim();
+}
+
+function projectRow(overrides: Partial<Project> = {}): Project {
+  return {
+    id: "project_1",
+    ownerUserId: "writer_01",
+    title: "Project Title",
+    logline: "A logline",
+    synopsis: "A synopsis",
+    format: "feature",
+    genre: "Drama",
+    pageCount: 110,
+    isDiscoverable: true,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-02T00:00:00.000Z",
+    ...overrides
+  };
+}
+
+function draftRow(overrides: Partial<ProjectDraft> = {}): ProjectDraft {
+  return {
+    id: "draft_1",
+    projectId: "project_1",
+    ownerUserId: "writer_01",
+    scriptId: "script_1",
+    versionLabel: "v1",
+    changeSummary: "Initial draft",
+    pageCount: 100,
+    lifecycleState: "active",
+    isPrimary: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-02T00:00:00.000Z",
+    ...overrides
+  };
+}
+
+test("PgProfileProjectRepository healthCheck reports database status", async () => {
+  const repo = new PgProfileProjectRepository();
+
+  poolQueryImpl = async () => ({ rows: [] });
+  assert.deepEqual(await repo.healthCheck(), { database: true });
+
+  poolQueryImpl = async () => {
+    throw new Error("db down");
+  };
+  assert.deepEqual(await repo.healthCheck(), { database: false });
+});
+
+test("PgProfileProjectRepository userExists and getProfile map profile rows", async () => {
+  const repo = new PgProfileProjectRepository();
+
+  poolQueryImpl = async (sql, values = []) => {
+    const normalized = normalizeSql(sql);
+    if (normalized === "SELECT id FROM app_users WHERE id = $1") {
+      assert.deepEqual(values, ["writer_01"]);
+      return { rows: [{ id: "writer_01" }], rowCount: 1 };
+    }
+    if (normalized.startsWith("SELECT writer_id, display_name, bio, genres, demographics, representation_status, headshot_url, custom_profile_url, is_searchable FROM writer_profiles WHERE writer_id = $1")) {
+      assert.deepEqual(values, ["writer_01"]);
+      return { rows: [] };
+    }
+    if (normalized === "SELECT id, display_name FROM app_users WHERE id = $1") {
+      assert.deepEqual(values, ["writer_01"]);
+      return { rows: [{ id: "writer_01", display_name: "Writer One" }], rowCount: 1 };
+    }
+    if (normalized.startsWith("INSERT INTO writer_profiles (writer_id, display_name)")) {
+      assert.deepEqual(values, ["writer_01", "Writer One"]);
+      return {
+        rows: [
+          {
+            writer_id: "writer_01",
+            display_name: "Writer One",
+            bio: "",
+            genres: ["Drama"],
+            demographics: ["Latinx"],
+            representation_status: "unrepresented",
+            headshot_url: "https://cdn.example.com/writer_01.jpg",
+            custom_profile_url: "https://profiles.example.com/writer-one",
+            is_searchable: true
+          }
+        ],
+        rowCount: 1
+      };
+    }
+    return { rows: [] };
+  };
+
+  assert.equal(await repo.userExists("writer_01"), true);
+
+  const profile = await repo.getProfile("writer_01");
+
+  assert.deepEqual(profile, {
+    id: "writer_01",
+    displayName: "Writer One",
+    bio: "",
+    genres: ["Drama"],
+    demographics: ["Latinx"],
+    representationStatus: "unrepresented",
+    headshotUrl: "https://cdn.example.com/writer_01.jpg",
+    customProfileUrl: "https://profiles.example.com/writer-one",
+    isSearchable: true
+  });
+});
+
+test("PgProfileProjectRepository upsertProfile updates profile fields and publishes sync event", async () => {
+  const repo = new PgProfileProjectRepository();
+
+  poolQueryImpl = async (sql, values = []) => {
+    const normalized = normalizeSql(sql);
+    if (normalized.startsWith("UPDATE writer_profiles")) {
+      assert.deepEqual(values, [
+        "writer_01",
+        "Writer One",
+        "Updated bio",
+        ["Drama", "Thriller"],
+        null,
+        "represented",
+        null,
+        "https://profiles.example.com/writer-one",
+        false
+      ]);
+      return {
+        rows: [
+          {
+            writer_id: "writer_01",
+            display_name: "Writer One",
+            bio: "Updated bio",
+            genres: ["Drama", "Thriller"],
+            demographics: [],
+            representation_status: "represented",
+            headshot_url: "https://cdn.example.com/writer_01.jpg",
+            custom_profile_url: "https://profiles.example.com/writer-one",
+            is_searchable: false
+          }
+        ]
+      };
+    }
+    return { rows: [] };
+  };
+
+  const profile = await repo.upsertProfile("writer_01", {
+    displayName: "Writer One",
+    bio: "Updated bio",
+    genres: ["Drama", "Thriller"],
+    representationStatus: "represented",
+    customProfileUrl: "https://profiles.example.com/writer-one",
+    isSearchable: false
+  } satisfies WriterProfileUpdateRequest);
+
+  assert.deepEqual(profile, {
+    id: "writer_01",
+    displayName: "Writer One",
+    bio: "Updated bio",
+    genres: ["Drama", "Thriller"],
+    demographics: [],
+    representationStatus: "represented",
+    headshotUrl: "https://cdn.example.com/writer_01.jpg",
+    customProfileUrl: "https://profiles.example.com/writer-one",
+    isSearchable: false
+  });
+  assert.equal(publishCalls.length, 1);
+  assert.deepEqual(publishCalls[0], {
+    collection: "talent",
+    documentId: "profile_writer_01",
+    operation: "upsert",
+    payload: {
+      type: "profile_update",
+      writerId: "writer_01",
+      displayName: "Writer One",
+      representationStatus: "represented",
+      genres: ["Drama", "Thriller"],
+      demographics: [],
+      isSearchable: false
+    }
+  });
+});
+
+test("PgProfileProjectRepository creates, lists, gets, updates, and deletes projects", async () => {
+  const repo = new PgProfileProjectRepository();
+  const created = projectRow({ id: "project_created", updatedAt: "2026-01-03T00:00:00.000Z" });
+  const updated = projectRow({ title: "Updated Title", updatedAt: "2026-01-04T00:00:00.000Z" });
+  let selectCount = 0;
+
+  poolQueryImpl = async (sql, values = []) => {
+    const normalized = normalizeSql(sql);
+    if (normalized.startsWith("SELECT id FROM app_users WHERE id = $1")) {
+      assert.deepEqual(values, ["writer_01"]);
+      return { rows: [{ id: "writer_01" }], rowCount: 1 };
+    }
+    if (normalized.startsWith("INSERT INTO projects (id, owner_user_id, title, logline, synopsis, format, genre, page_count, is_discoverable)")) {
+      assert.match(String(values[0]), /^project_/);
+      assert.deepEqual(values.slice(1), [
+        "writer_01",
+        "Project Title",
+        "A logline",
+        "A synopsis",
+        "feature",
+        "Drama",
+        110,
+        true
+      ]);
+      return {
+        rows: [
+          {
+            id: created.id,
+            owner_user_id: created.ownerUserId,
+            title: created.title,
+            logline: created.logline,
+            synopsis: created.synopsis,
+            format: created.format,
+            genre: created.genre,
+            page_count: created.pageCount,
+            is_discoverable: created.isDiscoverable,
+            created_at: created.createdAt,
+            updated_at: created.updatedAt
+          }
+        ],
+        rowCount: 1
+      };
+    }
+    if (normalized.startsWith("SELECT id, owner_user_id, title, logline, synopsis, format, genre, page_count, is_discoverable, created_at, updated_at FROM projects WHERE owner_user_id = $1 AND genre = $2 AND format = $3 ORDER BY updated_at DESC LIMIT $4 OFFSET $5")) {
+      assert.deepEqual(values, ["writer_01", "Drama", "feature", 10, 5]);
+      return {
+        rows: [
+          {
+            id: created.id,
+            owner_user_id: created.ownerUserId,
+            title: created.title,
+            logline: created.logline,
+            synopsis: created.synopsis,
+            format: created.format,
+            genre: created.genre,
+            page_count: created.pageCount,
+            is_discoverable: created.isDiscoverable,
+            created_at: created.createdAt,
+            updated_at: created.updatedAt
+          }
+        ]
+      };
+    }
+    if (normalized.startsWith("SELECT id, owner_user_id, title, logline, synopsis, format, genre, page_count, is_discoverable, created_at, updated_at FROM projects WHERE id = $1")) {
+      selectCount += 1;
+      assert.deepEqual(values, ["project_created"]);
+      return {
+        rows: [
+          {
+            id: selectCount === 1 ? created.id : updated.id,
+            owner_user_id: created.ownerUserId,
+            title: selectCount === 1 ? created.title : updated.title,
+            logline: created.logline,
+            synopsis: created.synopsis,
+            format: created.format,
+            genre: created.genre,
+            page_count: created.pageCount,
+            is_discoverable: created.isDiscoverable,
+            created_at: created.createdAt,
+            updated_at: selectCount === 1 ? created.updatedAt : updated.updatedAt
+          }
+        ]
+      };
+    }
+    if (normalized.startsWith("UPDATE projects SET title = $2, logline = $3, synopsis = $4, format = $5, genre = $6, page_count = $7, is_discoverable = $8, updated_at = NOW() WHERE id = $1")) {
+      assert.deepEqual(values, [
+        "project_created",
+        "Updated Title",
+        "A logline",
+        "A synopsis",
+        "feature",
+        "Drama",
+        110,
+        true
+      ]);
+      return { rows: [], rowCount: 1 };
+    }
+    if (normalized.startsWith("DELETE FROM projects WHERE id = $1")) {
+      assert.deepEqual(values, ["project_created"]);
+      return { rows: [], rowCount: 1 };
+    }
+    return { rows: [] };
+  };
+
+  const createdProject = await repo.createProject({
+    ownerUserId: "writer_01",
+    title: "Project Title",
+    logline: "A logline",
+    synopsis: "A synopsis",
+    format: "feature",
+    genre: "Drama",
+    pageCount: 110,
+    isDiscoverable: true
+  } satisfies ProjectCreateInternal);
+
+  assert.ok(createdProject);
+  assert.match(createdProject.id, /^project_/);
+  assert.equal(publishCalls.length, 1);
+
+  const projects = await repo.listProjects({
+    ownerUserId: "writer_01",
+    genre: "Drama",
+    format: "feature",
+    limit: 10,
+    offset: 5
+  } satisfies ProjectFilters);
+
+  assert.deepEqual(projects, [created]);
+
+  const fetched = await repo.getProject("project_created");
+  assert.deepEqual(fetched, created);
+});
+
+test("PgProfileProjectRepository updates and deletes projects with search sync events", async () => {
+  const repo = new PgProfileProjectRepository();
+  const existing = projectRow({ id: "project_2", title: "Original Title", updatedAt: "2026-01-03T00:00:00.000Z" });
+  const updated = projectRow({
+    id: "project_2",
+    title: "Updated Title",
+    logline: "Updated logline",
+    synopsis: "Updated synopsis",
+    genre: "Thriller",
+    pageCount: 120,
+    isDiscoverable: false,
+    updatedAt: "2026-01-04T00:00:00.000Z"
+  });
+  let getCount = 0;
+
+  poolQueryImpl = async (sql, values = []) => {
+    const normalized = normalizeSql(sql);
+    if (normalized.startsWith("SELECT id, owner_user_id, title, logline, synopsis, format, genre, page_count, is_discoverable, created_at, updated_at FROM projects WHERE id = $1")) {
+      getCount += 1;
+      assert.deepEqual(values, ["project_2"]);
+      return {
+        rows: [getCount === 1 ? {
+          id: existing.id,
+          owner_user_id: existing.ownerUserId,
+          title: existing.title,
+          logline: existing.logline,
+          synopsis: existing.synopsis,
+          format: existing.format,
+          genre: existing.genre,
+          page_count: existing.pageCount,
+          is_discoverable: existing.isDiscoverable,
+          created_at: existing.createdAt,
+          updated_at: existing.updatedAt
+        } : {
+          id: updated.id,
+          owner_user_id: updated.ownerUserId,
+          title: updated.title,
+          logline: updated.logline,
+          synopsis: updated.synopsis,
+          format: updated.format,
+          genre: updated.genre,
+          page_count: updated.pageCount,
+          is_discoverable: updated.isDiscoverable,
+          created_at: updated.createdAt,
+          updated_at: updated.updatedAt
+        }]
+      };
+    }
+    if (normalized.startsWith("UPDATE projects SET title = $2, logline = $3, synopsis = $4, format = $5, genre = $6, page_count = $7, is_discoverable = $8, updated_at = NOW() WHERE id = $1")) {
+      assert.deepEqual(values, [
+        "project_2",
+        "Updated Title",
+        "Updated logline",
+        "Updated synopsis",
+        "feature",
+        "Thriller",
+        120,
+        false
+      ]);
+      return { rows: [], rowCount: 1 };
+    }
+    if (normalized.startsWith("DELETE FROM projects WHERE id = $1")) {
+      assert.deepEqual(values, ["project_2"]);
+      return { rows: [], rowCount: 1 };
+    }
+    return { rows: [] };
+  };
+
+  const next = await repo.updateProject("project_2", {
+    title: "Updated Title",
+    logline: "Updated logline",
+    synopsis: "Updated synopsis",
+    format: "feature",
+    genre: "Thriller",
+    pageCount: 120,
+    isDiscoverable: false
+  } satisfies ProjectUpdateRequest);
+
+  assert.deepEqual(next, updated);
+  assert.equal(publishCalls.length, 1);
+  assert.deepEqual(publishCalls[0], {
+    collection: "projects",
+    documentId: "project_2",
+    operation: "upsert",
+    payload: {
+      id: "project_2",
+      ownerUserId: "writer_01",
+      title: "Updated Title",
+      logline: "Updated logline",
+      synopsis: "Updated synopsis",
+      format: "feature",
+      genre: "Thriller",
+      pageCount: 120,
+      isDiscoverable: false,
+      updatedAt: "2026-01-04T00:00:00.000Z"
+    }
+  });
+
+  const deleted = await repo.deleteProject("project_2");
+  assert.equal(deleted, true);
+  assert.equal(publishCalls.length, 2);
+  assert.deepEqual(publishCalls[1], {
+    collection: "projects",
+    documentId: "project_2",
+    operation: "delete",
+    payload: null
+  });
+});
+
+test("PgProfileProjectRepository manages co-writers", async () => {
+  const repo = new PgProfileProjectRepository();
+
+  poolQueryImpl = async (sql, values = []) => {
+    const normalized = normalizeSql(sql);
+    if (normalized.startsWith("SELECT project_id, owner_user_id, co_writer_user_id, credit_order, created_at FROM project_co_writers WHERE project_id = $1 ORDER BY credit_order ASC, created_at ASC")) {
+      assert.deepEqual(values, ["project_1"]);
+      return {
+        rows: [
+          {
+            project_id: "project_1",
+            owner_user_id: "writer_01",
+            co_writer_user_id: "writer_03",
+            credit_order: 2,
+            created_at: "2026-01-02T00:00:00.000Z"
+          },
+          {
+            project_id: "project_1",
+            owner_user_id: "writer_01",
+            co_writer_user_id: "writer_02",
+            credit_order: 1,
+            created_at: "2026-01-01T00:00:00.000Z"
+          }
+        ]
+      };
+    }
+    if (normalized.startsWith("SELECT id, owner_user_id, title, logline, synopsis, format, genre, page_count, is_discoverable, created_at, updated_at FROM projects WHERE id = $1")) {
+      return {
+        rows: [
+          {
+            id: "project_1",
+            owner_user_id: "writer_01",
+            title: "Project Title",
+            logline: "A logline",
+            synopsis: "A synopsis",
+            format: "feature",
+            genre: "Drama",
+            page_count: 110,
+            is_discoverable: true,
+            created_at: "2026-01-01T00:00:00.000Z",
+            updated_at: "2026-01-02T00:00:00.000Z"
+          }
+        ]
+      };
+    }
+    if (normalized.startsWith("SELECT id FROM app_users WHERE id = $1")) {
+      return { rows: [{ id: "writer_02" }], rowCount: 1 };
+    }
+    if (normalized.startsWith("INSERT INTO project_co_writers")) {
+      assert.deepEqual(values, ["project_1", "writer_01", "writer_02", 1]);
+      return {
+        rows: [
+          {
+            project_id: "project_1",
+            owner_user_id: "writer_01",
+            co_writer_user_id: "writer_02",
+            credit_order: 1,
+            created_at: "2026-01-03T00:00:00.000Z"
+          }
+        ]
+      };
+    }
+    if (normalized.startsWith("DELETE FROM project_co_writers WHERE project_id = $1 AND co_writer_user_id = $2")) {
+      assert.deepEqual(values, ["project_1", "writer_02"]);
+      return { rows: [], rowCount: 1 };
+    }
+    return { rows: [] };
+  };
+
+  const coWriters = await repo.listCoWriters("project_1");
+  assert.deepEqual(coWriters, [
+    {
+      projectId: "project_1",
+      ownerUserId: "writer_01",
+      coWriterUserId: "writer_03",
+      creditOrder: 2,
+      createdAt: "2026-01-02T00:00:00.000Z"
+    },
+    {
+      projectId: "project_1",
+      ownerUserId: "writer_01",
+      coWriterUserId: "writer_02",
+      creditOrder: 1,
+      createdAt: "2026-01-01T00:00:00.000Z"
+    }
+  ]);
+
+  const added = await repo.addCoWriter("project_1", {
+    coWriterUserId: "writer_02",
+    creditOrder: 1
+  } satisfies ProjectCoWriterCreateRequest);
+
+  assert.deepEqual(added, {
+    projectId: "project_1",
+    ownerUserId: "writer_01",
+    coWriterUserId: "writer_02",
+    creditOrder: 1,
+    createdAt: "2026-01-03T00:00:00.000Z"
+  });
+
+  const removed = await repo.removeCoWriter("project_1", "writer_02");
+  assert.equal(removed, true);
+});
+
+test("PgProfileProjectRepository creates, updates, and promotes drafts", async () => {
+  const repo = new PgProfileProjectRepository();
+  let draftUpdated = false;
+
+  poolQueryImpl = async (sql, values = []) => {
+    const normalized = normalizeSql(sql);
+    if (normalized.startsWith("SELECT id, project_id, owner_user_id, script_id, version_label, change_summary, page_count, lifecycle_state, is_primary, created_at, updated_at FROM project_drafts WHERE project_id = $1 ORDER BY is_primary DESC, updated_at DESC")) {
+      return {
+        rows: [
+          {
+            id: "draft_2",
+            project_id: "project_1",
+            owner_user_id: "writer_01",
+            script_id: "script_2",
+            version_label: "v2",
+            change_summary: "Second draft",
+            page_count: 102,
+            lifecycle_state: "active",
+            is_primary: true,
+            created_at: "2026-01-02T00:00:00.000Z",
+            updated_at: "2026-01-03T00:00:00.000Z"
+          },
+          {
+            id: "draft_1",
+            project_id: "project_1",
+            owner_user_id: "writer_01",
+            script_id: "script_1",
+            version_label: "v1",
+            change_summary: "First draft",
+            page_count: 100,
+            lifecycle_state: "active",
+            is_primary: false,
+            created_at: "2026-01-01T00:00:00.000Z",
+            updated_at: "2026-01-01T00:00:00.000Z"
+          }
+        ]
+      };
+    }
+    if (normalized.startsWith("SELECT owner_user_id FROM projects WHERE id = $1")) {
+      assert.deepEqual(values, ["project_1"]);
+      return { rows: [{ owner_user_id: "writer_01" }], rowCount: 1 };
+    }
+    if (normalized.startsWith("SELECT COUNT(*)::text AS count FROM project_drafts WHERE project_id = $1 AND is_primary = TRUE")) {
+      assert.deepEqual(values, ["project_1"]);
+      return { rows: [{ count: "1" }], rowCount: 1 };
+    }
+    if (normalized.startsWith("INSERT INTO project_drafts (")) {
+      assert.match(String(values[0]), /^draft_/);
+      assert.deepEqual(values.slice(1), [
+        "project_1",
+        "writer_01",
+        "script_new",
+        "v3",
+        "Third draft",
+        103,
+        false
+      ]);
+      return {
+        rows: [
+          {
+            id: "draft_new",
+            project_id: "project_1",
+            owner_user_id: "writer_01",
+            script_id: "script_new",
+            version_label: "v3",
+            change_summary: "Third draft",
+            page_count: 103,
+            lifecycle_state: "active",
+            is_primary: false,
+            created_at: "2026-01-04T00:00:00.000Z",
+            updated_at: "2026-01-04T00:00:00.000Z"
+          }
+        ]
+      };
+    }
+    if (normalized.startsWith("SELECT id, project_id, owner_user_id, script_id, version_label, change_summary, page_count, lifecycle_state, is_primary, created_at, updated_at FROM project_drafts WHERE project_id = $1 AND id = $2")) {
+      assert.deepEqual(values, ["project_1", "draft_1"]);
+      if (!draftUpdated) {
+        return {
+          rows: [
+            {
+              id: "draft_1",
+              project_id: "project_1",
+              owner_user_id: "writer_01",
+              script_id: "script_1",
+              version_label: "v1",
+              change_summary: "First draft",
+              page_count: 100,
+              lifecycle_state: "active",
+              is_primary: false,
+              created_at: "2026-01-01T00:00:00.000Z",
+              updated_at: "2026-01-01T00:00:00.000Z"
+            }
+          ]
+        };
+      }
+      return {
+        rows: [
+          {
+            id: "draft_1",
+            project_id: "project_1",
+            owner_user_id: "writer_01",
+            script_id: "script_1",
+            version_label: "v1.1",
+            change_summary: "Updated summary",
+            page_count: 101,
+            lifecycle_state: "active",
+            is_primary: false,
+            created_at: "2026-01-01T00:00:00.000Z",
+            updated_at: "2026-01-05T00:00:00.000Z"
+          }
+        ]
+      };
+    }
+    return { rows: [] };
+  };
+
+  clientQueryImpl = async (sql, values = []) => {
+    const normalized = normalizeSql(sql);
+    if (normalized === "BEGIN" || normalized === "COMMIT" || normalized === "ROLLBACK") {
+      return { rows: [] };
+    }
+    if (normalized.startsWith("SELECT owner_user_id FROM projects WHERE id = $1")) {
+      return { rows: [{ owner_user_id: "writer_01" }], rowCount: 1 };
+    }
+    if (normalized.startsWith("SELECT COUNT(*)::text AS count FROM project_drafts WHERE project_id = $1 AND is_primary = TRUE")) {
+      return { rows: [{ count: "1" }], rowCount: 1 };
+    }
+    if (normalized.startsWith("INSERT INTO project_drafts (")) {
+      assert.match(String(values[0]), /^draft_/);
+      assert.deepEqual(values.slice(1), [
+        "project_1",
+        "writer_01",
+        "script_new",
+        "v3",
+        "Third draft",
+        103,
+        false
+      ]);
+      return {
+        rows: [
+          {
+            id: "draft_new",
+            project_id: "project_1",
+            owner_user_id: "writer_01",
+            script_id: "script_new",
+            version_label: "v3",
+            change_summary: "Third draft",
+            page_count: 103,
+            lifecycle_state: "active",
+            is_primary: false,
+            created_at: "2026-01-04T00:00:00.000Z",
+            updated_at: "2026-01-04T00:00:00.000Z"
+          }
+        ]
+      };
+    }
+    if (normalized.startsWith("SELECT id, project_id, owner_user_id, script_id, version_label, change_summary, page_count, lifecycle_state, is_primary, created_at, updated_at FROM project_drafts WHERE project_id = $1 AND id = $2")) {
+      return {
+        rows: [
+          {
+            id: "draft_1",
+            project_id: "project_1",
+            owner_user_id: "writer_01",
+            script_id: "script_1",
+            version_label: "v1",
+            change_summary: "First draft",
+            page_count: 100,
+            lifecycle_state: "active",
+            is_primary: false,
+            created_at: "2026-01-01T00:00:00.000Z",
+            updated_at: "2026-01-01T00:00:00.000Z"
+          }
+        ]
+      };
+    }
+    if (normalized.startsWith("UPDATE project_drafts SET version_label = $3, change_summary = $4, page_count = $5, lifecycle_state = $6, updated_at = NOW() WHERE project_id = $1 AND id = $2")) {
+      assert.deepEqual(values, ["project_1", "draft_1", "v1.1", "Updated summary", 101, "active"]);
+      draftUpdated = true;
+      return { rows: [], rowCount: 1 };
+    }
+    if (normalized.startsWith("UPDATE project_drafts SET is_primary = FALSE, updated_at = NOW() WHERE project_id = $1")) {
+      assert.deepEqual(values, ["project_1"]);
+      return { rows: [], rowCount: 1 };
+    }
+    if (normalized.startsWith("UPDATE project_drafts SET is_primary = FALSE, updated_at = NOW() WHERE project_id = $1 AND id = $2")) {
+      assert.deepEqual(values, ["project_1", "draft_2"]);
+      return { rows: [], rowCount: 1 };
+    }
+    if (normalized.startsWith("WITH candidate AS (")) {
+      return { rows: [], rowCount: 1 };
+    }
+    if (normalized.startsWith("UPDATE project_drafts SET is_primary = TRUE, updated_at = NOW() WHERE project_id = $1 AND id = $2 AND lifecycle_state = 'active' RETURNING id, project_id, owner_user_id, script_id, version_label, change_summary, page_count, lifecycle_state, is_primary, created_at, updated_at")) {
+      assert.deepEqual(values, ["project_1", "draft_2"]);
+      return {
+        rows: [
+          {
+            id: "draft_2",
+            project_id: "project_1",
+            owner_user_id: "writer_01",
+            script_id: "script_2",
+            version_label: "v2",
+            change_summary: "Second draft",
+            page_count: 102,
+            lifecycle_state: "active",
+            is_primary: true,
+            created_at: "2026-01-02T00:00:00.000Z",
+            updated_at: "2026-01-06T00:00:00.000Z"
+          }
+        ]
+      };
+    }
+    return { rows: [] };
+  };
+
+  const drafts = await repo.listDrafts("project_1");
+  assert.deepEqual(drafts, [
+    draftRow({ id: "draft_2", scriptId: "script_2", versionLabel: "v2", changeSummary: "Second draft", pageCount: 102, isPrimary: true, createdAt: "2026-01-02T00:00:00.000Z", updatedAt: "2026-01-03T00:00:00.000Z" }),
+    draftRow({ id: "draft_1", versionLabel: "v1", changeSummary: "First draft", pageCount: 100, isPrimary: false, createdAt: "2026-01-01T00:00:00.000Z", updatedAt: "2026-01-01T00:00:00.000Z" })
+  ]);
+
+  const createdDraft = await repo.createDraft("project_1", {
+    ownerUserId: "writer_01",
+    scriptId: "script_new",
+    versionLabel: "v3",
+    changeSummary: "Third draft",
+    pageCount: 103,
+    setPrimary: false
+  } satisfies ProjectDraftCreateInternal);
+
+  assert.match(String(createdDraft?.id), /^draft_/);
+  assert.deepEqual(createdDraft, {
+    id: "draft_new",
+    projectId: "project_1",
+    ownerUserId: "writer_01",
+    scriptId: "script_new",
+    versionLabel: "v3",
+    changeSummary: "Third draft",
+    pageCount: 103,
+    lifecycleState: "active",
+    isPrimary: false,
+    createdAt: "2026-01-04T00:00:00.000Z",
+    updatedAt: "2026-01-04T00:00:00.000Z"
+  });
+
+  const updatedDraft = await repo.updateDraft("project_1", "draft_1", {
+    versionLabel: "v1.1",
+    changeSummary: "Updated summary",
+    pageCount: 101,
+    lifecycleState: "active"
+  } satisfies ProjectDraftUpdateRequest);
+
+  assert.deepEqual(updatedDraft, {
+    id: "draft_1",
+    projectId: "project_1",
+    ownerUserId: "writer_01",
+    scriptId: "script_1",
+    versionLabel: "v1.1",
+    changeSummary: "Updated summary",
+    pageCount: 101,
+    lifecycleState: "active",
+    isPrimary: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-05T00:00:00.000Z"
+  });
+
+  const promoted = await repo.setPrimaryDraft("project_1", "draft_2", "writer_01");
+  assert.deepEqual(promoted, {
+    id: "draft_2",
+    projectId: "project_1",
+    ownerUserId: "writer_01",
+    scriptId: "script_2",
+    versionLabel: "v2",
+    changeSummary: "Second draft",
+    pageCount: 102,
+    lifecycleState: "active",
+    isPrimary: true,
+    createdAt: "2026-01-02T00:00:00.000Z",
+    updatedAt: "2026-01-06T00:00:00.000Z"
+  });
+  assert.equal(releaseCount, 3);
+});
+
+test("PgProfileProjectRepository creates, lists, and decides access requests", async () => {
+  const repo = new PgProfileProjectRepository();
+  let listCount = 0;
+
+  poolQueryImpl = async (sql, values = []) => {
+    const normalized = normalizeSql(sql);
+    if (normalized.startsWith("INSERT INTO script_access_requests (")) {
+      assert.match(String(values[0]), /^access_/);
+      assert.deepEqual(values.slice(1), ["script_1", "writer_02", "writer_01", "Need access"]);
+      return {
+        rows: [
+          {
+            id: "access_1",
+            script_id: "script_1",
+            requester_user_id: "writer_02",
+            owner_user_id: "writer_01",
+            status: "pending",
+            reason: "Need access",
+            decision_reason: null,
+            decided_by_user_id: null,
+            requested_at: "2026-01-01T00:00:00.000Z",
+            decided_at: null,
+            created_at: "2026-01-01T00:00:00.000Z",
+            updated_at: "2026-01-01T00:00:00.000Z"
+          }
+        ]
+      };
+    }
+    if (normalized.startsWith("SELECT id, script_id, requester_user_id, owner_user_id, status, reason, decision_reason, decided_by_user_id, requested_at, decided_at, created_at, updated_at FROM script_access_requests WHERE script_id = $1 AND requester_user_id = $2 AND owner_user_id = $3 AND status = $4 ORDER BY updated_at DESC, created_at DESC")) {
+      assert.deepEqual(values, ["script_1", "writer_02", "writer_01", "pending"]);
+      listCount += 1;
+      return {
+        rows: [
+          {
+            id: "access_1",
+            script_id: "script_1",
+            requester_user_id: "writer_02",
+            owner_user_id: "writer_01",
+            status: listCount === 1 ? "pending" : "approved",
+            reason: "Need access",
+            decision_reason: listCount === 1 ? null : "Approved",
+            decided_by_user_id: listCount === 1 ? null : "writer_01",
+            requested_at: "2026-01-01T00:00:00.000Z",
+            decided_at: listCount === 1 ? null : "2026-01-02T00:00:00.000Z",
+            created_at: "2026-01-01T00:00:00.000Z",
+            updated_at: listCount === 1 ? "2026-01-01T00:00:00.000Z" : "2026-01-02T00:00:00.000Z"
+          }
+        ]
+      };
+    }
+    if (normalized.startsWith("UPDATE script_access_requests SET status = $4, decision_reason = $5, decided_by_user_id = $6, decided_at = NOW(), updated_at = NOW() WHERE id = $1 AND script_id = $2 AND owner_user_id = $3 AND status = 'pending' RETURNING id, script_id, requester_user_id, owner_user_id, status, reason, decision_reason, decided_by_user_id, requested_at, decided_at, created_at, updated_at")) {
+      assert.deepEqual(values, ["access_1", "script_1", "writer_01", "approved", "Approved", "writer_01"]);
+      return {
+        rows: [
+          {
+            id: "access_1",
+            script_id: "script_1",
+            requester_user_id: "writer_02",
+            owner_user_id: "writer_01",
+            status: "approved",
+            reason: "Need access",
+            decision_reason: "Approved",
+            decided_by_user_id: "writer_01",
+            requested_at: "2026-01-01T00:00:00.000Z",
+            decided_at: "2026-01-02T00:00:00.000Z",
+            created_at: "2026-01-01T00:00:00.000Z",
+            updated_at: "2026-01-02T00:00:00.000Z"
+          }
+        ]
+      };
+    }
+    return { rows: [] };
+  };
+
+  clientQueryImpl = async (sql, values = []) => {
+    const normalized = normalizeSql(sql);
+    if (normalized === "BEGIN" || normalized === "COMMIT" || normalized === "ROLLBACK") {
+      return { rows: [] };
+    }
+    if (normalized.startsWith("UPDATE project_drafts SET is_primary = FALSE, updated_at = NOW() WHERE project_id = $1")) {
+      assert.deepEqual(values, ["project_1"]);
+      return { rows: [], rowCount: 1 };
+    }
+    if (normalized.startsWith("UPDATE script_access_requests SET status = $4, decision_reason = $5, decided_by_user_id = $6, decided_at = NOW(), updated_at = NOW() WHERE id = $1 AND script_id = $2 AND owner_user_id = $3 AND status = 'pending' RETURNING id, script_id, requester_user_id, owner_user_id, status, reason, decision_reason, decided_by_user_id, requested_at, decided_at, created_at, updated_at")) {
+      assert.deepEqual(values, ["access_1", "script_1", "writer_01", "approved", "Approved", "writer_01"]);
+      return {
+        rows: [
+          {
+            id: "access_1",
+            script_id: "script_1",
+            requester_user_id: "writer_02",
+            owner_user_id: "writer_01",
+            status: "approved",
+            reason: "Need access",
+            decision_reason: "Approved",
+            decided_by_user_id: "writer_01",
+            requested_at: "2026-01-01T00:00:00.000Z",
+            decided_at: "2026-01-02T00:00:00.000Z",
+            created_at: "2026-01-01T00:00:00.000Z",
+            updated_at: "2026-01-02T00:00:00.000Z"
+          }
+        ]
+      };
+    }
+    return { rows: [] };
+  };
+
+  const created = await repo.createScriptAccessRequest("script_1", {
+    requesterUserId: "writer_02",
+    ownerUserId: "writer_01",
+    reason: "Need access"
+  } satisfies ScriptAccessRequestCreateRequest);
+
+  assert.ok(created);
+  assert.match(created.id, /^access_/);
+
+  const requests = await repo.listScriptAccessRequests("script_1", {
+    requesterUserId: "writer_02",
+    ownerUserId: "writer_01",
+    status: "pending"
+  } satisfies ScriptAccessRequestFilters);
+
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0]?.status, "pending");
+
+  const decided = await repo.decideScriptAccessRequest(
+    "script_1",
+    "access_1",
+    "writer_01",
+    "approved",
+    "Approved"
+  );
+
+  assert.deepEqual(decided, {
+    id: "access_1",
+    scriptId: "script_1",
+    requesterUserId: "writer_02",
+    ownerUserId: "writer_01",
+    status: "approved",
+    reason: "Need access",
+    decisionReason: "Approved",
+    decidedByUserId: "writer_01",
+    requestedAt: "2026-01-01T00:00:00.000Z",
+    decidedAt: "2026-01-02T00:00:00.000Z",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-02T00:00:00.000Z"
+  });
+});

--- a/services/programs-service/src/repository.test.ts
+++ b/services/programs-service/src/repository.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test, { mock } from "node:test";
+
+type QueryResult = { rows: unknown[]; rowCount?: number };
+type QueryFn = (sql: string, values?: unknown[]) => Promise<QueryResult>;
+
+let queryImpl: QueryFn = async () => ({ rows: [], rowCount: 0 });
+const query: QueryFn = async (sql, values = []) => queryImpl(sql, values);
+
+mock.module("@script-manifest/db", {
+  namedExports: {
+    getPool: () => ({ query }),
+    ensureCoreTables: async () => undefined,
+    ensureProgramsTables: async () => undefined
+  }
+});
+
+const { PgProgramsRepository } = await import("./repository.js");
+
+test("PgProgramsRepository listPrograms builds status-filtered query", async () => {
+  let capturedSql = "";
+  let capturedValues: unknown[] = [];
+
+  queryImpl = async (sql, values = []) => {
+    capturedSql = sql;
+    capturedValues = values;
+    return {
+      rows: [
+        {
+          id: "program_1",
+          slug: "summer-lab",
+          title: "Summer Lab",
+          description: "",
+          status: "open",
+          application_opens_at: "2026-01-01T00:00:00.000Z",
+          application_closes_at: "2026-02-01T00:00:00.000Z",
+          created_by_user_id: "admin_1",
+          created_at: "2026-01-01T00:00:00.000Z",
+          updated_at: "2026-01-02T00:00:00.000Z"
+        }
+      ]
+    };
+  };
+
+  const repo = new PgProgramsRepository();
+  const programs = await repo.listPrograms("open");
+
+  assert.equal(programs.length, 1);
+  assert.equal(programs[0]?.id, "program_1");
+  assert.equal(programs[0]?.slug, "summer-lab");
+  assert.equal(programs[0]?.status, "open");
+  assert.match(capturedSql, /FROM programs/);
+  assert.match(capturedSql, /WHERE status = \$1/);
+  assert.match(capturedSql, /ORDER BY application_closes_at ASC/);
+  assert.deepEqual(capturedValues, ["open"]);
+});
+
+test("PgProgramsRepository getProgramApplicationForm returns default form when missing", async () => {
+  let capturedValues: unknown[] = [];
+
+  queryImpl = async (_sql, values = []) => {
+    capturedValues = values;
+    return { rows: [], rowCount: 0 };
+  };
+
+  const repo = new PgProgramsRepository();
+  const form = await repo.getProgramApplicationForm("program_1");
+
+  assert.deepEqual(form, {
+    fields: [],
+    updatedByUserId: "",
+    updatedAt: new Date(0).toISOString()
+  });
+  assert.deepEqual(capturedValues, ["program_1"]);
+});
+
+test("PgProgramsRepository listUserProgramApplications filters by program and user", async () => {
+  let capturedSql = "";
+  let capturedValues: unknown[] = [];
+
+  queryImpl = async (sql, values = []) => {
+    capturedSql = sql;
+    capturedValues = values;
+    return {
+      rows: [
+        {
+          id: "application_1",
+          program_id: "program_1",
+          user_id: "writer_1",
+          statement: "I want in",
+          sample_project_id: null,
+          status: "submitted",
+          score: null,
+          decision_notes: null,
+          reviewed_by_user_id: null,
+          reviewed_at: null,
+          created_at: "2026-01-03T00:00:00.000Z",
+          updated_at: "2026-01-04T00:00:00.000Z"
+        }
+      ]
+    };
+  };
+
+  const repo = new PgProgramsRepository();
+  const applications = await repo.listUserProgramApplications("program_1", "writer_1");
+
+  assert.equal(applications.length, 1);
+  assert.equal(applications[0]?.id, "application_1");
+  assert.equal(applications[0]?.programId, "program_1");
+  assert.equal(applications[0]?.userId, "writer_1");
+  assert.match(capturedSql, /FROM program_applications/);
+  assert.match(capturedSql, /program_id = \$1/);
+  assert.match(capturedSql, /user_id = \$2/);
+  assert.match(capturedSql, /ORDER BY updated_at DESC/);
+  assert.deepEqual(capturedValues, ["program_1", "writer_1"]);
+});

--- a/services/ranking-service/src/repository.test.ts
+++ b/services/ranking-service/src/repository.test.ts
@@ -1,0 +1,284 @@
+import assert from "node:assert/strict";
+import test, { mock } from "node:test";
+
+type QueryResult = { rows: Record<string, unknown>[]; rowCount?: number };
+type QueryFn = (sql: string, values?: unknown[]) => Promise<QueryResult>;
+
+let queryImpl: QueryFn = async () => ({ rows: [], rowCount: 0 });
+let clientQueryImpl: QueryFn = async () => ({ rows: [], rowCount: 0 });
+let clientReleased = false;
+let ensureRankingTablesCalls = 0;
+
+const query: QueryFn = async (sql, values = []) => queryImpl(sql, values);
+const client = {
+  query: async (sql: string, values: unknown[] = []) => clientQueryImpl(sql, values),
+  release: () => {
+    clientReleased = true;
+  }
+};
+
+mock.module("@script-manifest/db", {
+  namedExports: {
+    getPool: () => ({
+      query,
+      connect: async () => client
+    }),
+    ensureRankingTables: async () => {
+      ensureRankingTablesCalls += 1;
+    }
+  }
+});
+
+const { PgRankingRepository } = await import("./repository.js");
+
+test("PgRankingRepository init skips schema creation when disabled", async () => {
+  const original = process.env.SKIP_SCHEMA_INIT;
+  process.env.SKIP_SCHEMA_INIT = "1";
+  ensureRankingTablesCalls = 0;
+
+  try {
+    const repo = new PgRankingRepository();
+    await repo.init();
+
+    assert.equal(ensureRankingTablesCalls, 0);
+  } finally {
+    if (original === undefined) {
+      delete process.env.SKIP_SCHEMA_INIT;
+    } else {
+      process.env.SKIP_SCHEMA_INIT = original;
+    }
+  }
+});
+
+test("PgRankingRepository healthCheck returns database availability", async () => {
+  queryImpl = async () => ({ rows: [] });
+
+  const repo = new PgRankingRepository();
+  await assert.doesNotReject(repo.healthCheck());
+  assert.deepEqual(await repo.healthCheck(), { database: true });
+
+  queryImpl = async () => {
+    throw new Error("db down");
+  };
+
+  assert.deepEqual(await repo.healthCheck(), { database: false });
+});
+
+test("PgRankingRepository getPrestige and listLeaderboard map rows and build filters", async () => {
+  let countSql = "";
+  let countValues: unknown[] = [];
+  let listSql = "";
+  let listValues: unknown[] = [];
+  let badgeSql = "";
+  let badgeValues: unknown[] = [];
+
+  queryImpl = async (sql, values = []) => {
+    if (sql.includes("FROM competition_prestige")) {
+      return {
+        rows: [
+          {
+            competition_id: "comp_1",
+            tier: "elite",
+            multiplier: 2.5,
+            updated_at: new Date("2026-02-01T00:00:00.000Z")
+          }
+        ]
+      };
+    }
+
+    if (sql.includes("COUNT(*)::int as total FROM writer_scores")) {
+      countSql = sql;
+      countValues = values;
+      return { rows: [{ total: 1 }] };
+    }
+
+    if (sql.includes("SELECT * FROM writer_scores")) {
+      listSql = sql;
+      listValues = values;
+      return {
+        rows: [
+          {
+            writer_id: "writer_1",
+            total_score: 42,
+            submission_count: 7,
+            placement_count: 3,
+            rank: 2,
+            tier: "top_10",
+            score_change_30d: 5.5,
+            last_updated_at: new Date("2026-03-01T00:00:00.000Z")
+          }
+        ]
+      };
+    }
+
+    if (sql.includes("FROM writer_badges")) {
+      badgeSql = sql;
+      badgeValues = values;
+      return {
+        rows: [
+          {
+            id: "badge_1",
+            writer_id: "writer_1",
+            label: "Top 10",
+            placement_id: "placement_1",
+            competition_id: "comp_1",
+            awarded_at: new Date("2026-03-02T00:00:00.000Z")
+          }
+        ]
+      };
+    }
+
+    return { rows: [] };
+  };
+
+  const repo = new PgRankingRepository();
+  const prestige = await repo.getPrestige("comp_1");
+  assert.deepEqual(prestige, {
+    competitionId: "comp_1",
+    tier: "elite",
+    multiplier: 2.5,
+    updatedAt: "2026-02-01T00:00:00.000Z"
+  });
+
+  const result = await repo.listLeaderboard(
+    { tier: "top_10", trending: true, limit: 10, offset: 5 },
+    new Set(["writer_1"])
+  );
+
+  assert.equal(result.total, 1);
+  assert.deepEqual(result.entries, [
+    {
+      writerId: "writer_1",
+      rank: 2,
+      totalScore: 42,
+      submissionCount: 7,
+      placementCount: 3,
+      tier: "top_10",
+      badges: ["Top 10"],
+      scoreChange30d: 5.5,
+      lastUpdatedAt: "2026-03-01T00:00:00.000Z"
+    }
+  ]);
+  assert.match(countSql, /tier = \$1/);
+  assert.match(countSql, /writer_id = ANY\(\$2\)/);
+  assert.match(listSql, /ORDER BY score_change_30d DESC, total_score DESC/);
+  assert.match(listSql, /LIMIT \$3 OFFSET \$4/);
+  assert.match(badgeSql, /WHERE writer_id = ANY\(\$1\)/);
+  assert.deepEqual(countValues, ["top_10", ["writer_1"]]);
+  assert.deepEqual(listValues, ["top_10", ["writer_1"], 10, 5]);
+  assert.deepEqual(badgeValues, [["writer_1"]]);
+});
+
+test("PgRankingRepository upsertWriterScore and bulkUpsertWriterScores build insert batches", async () => {
+  const calls: Array<{ sql: string; values: unknown[] }> = [];
+  queryImpl = async (sql, values = []) => {
+    calls.push({ sql, values });
+    return { rows: [] };
+  };
+
+  const repo = new PgRankingRepository();
+
+  await repo.upsertWriterScore({
+    writerId: "writer_1",
+    totalScore: 10,
+    submissionCount: 2,
+    placementCount: 1,
+    rank: 4,
+    tier: "top_25",
+    scoreChange30d: 1.5,
+    lastUpdatedAt: "2026-03-01T00:00:00.000Z"
+  });
+
+  await repo.bulkUpsertWriterScores([
+    {
+      writerId: "writer_2",
+      totalScore: 20,
+      submissionCount: 4,
+      placementCount: 2,
+      rank: 3,
+      tier: "top_10",
+      scoreChange30d: 2.5,
+      lastUpdatedAt: "2026-03-02T00:00:00.000Z"
+    },
+    {
+      writerId: "writer_3",
+      totalScore: 30,
+      submissionCount: 6,
+      placementCount: 3,
+      rank: null,
+      tier: null,
+      scoreChange30d: 3.5,
+      lastUpdatedAt: "2026-03-03T00:00:00.000Z"
+    }
+  ]);
+
+  assert.equal(calls.length, 2);
+  assert.match(calls[0]!.sql, /ON CONFLICT \(writer_id\) DO UPDATE SET/);
+  assert.deepEqual(calls[0]!.values, ["writer_1", 10, 2, 1, 4, "top_25", 1.5, "2026-03-01T00:00:00.000Z"]);
+  assert.match(calls[1]!.sql, /VALUES \(\$1, \$2, \$3, \$4, \$5, \$6, \$7, \$8\), \(\$9, \$10, \$11, \$12, \$13, \$14, \$15, \$16\)/);
+  assert.deepEqual(calls[1]!.values, [
+    "writer_2",
+    20,
+    4,
+    2,
+    3,
+    "top_10",
+    2.5,
+    "2026-03-02T00:00:00.000Z",
+    "writer_3",
+    30,
+    6,
+    3,
+    null,
+    null,
+    3.5,
+    "2026-03-03T00:00:00.000Z"
+  ]);
+});
+
+test("PgRankingRepository replaceAllPlacementScores wraps delete and insert in a transaction", async () => {
+  clientReleased = false;
+  const clientCalls: Array<{ sql: string; values: unknown[] }> = [];
+  clientQueryImpl = async (sql, values = []) => {
+    clientCalls.push({ sql, values });
+    return { rows: [] };
+  };
+
+  const repo = new PgRankingRepository();
+  await repo.replaceAllPlacementScores([
+    {
+      placementId: "pl_1",
+      writerId: "writer_1",
+      competitionId: "comp_1",
+      projectId: "proj_1",
+      statusWeight: 10,
+      prestigeMultiplier: 2,
+      verificationMultiplier: 1,
+      timeDecayFactor: 0.9,
+      confidenceFactor: 0.8,
+      rawScore: 14.4,
+      placementDate: "2026-03-01T00:00:00.000Z"
+    }
+  ]);
+
+  assert.equal(clientReleased, true);
+  assert.equal(clientCalls.length, 4);
+  assert.equal(clientCalls[0]!.sql, "BEGIN");
+  assert.equal(clientCalls[1]!.sql, "DELETE FROM placement_scores");
+  assert.equal(clientCalls[3]!.sql, "COMMIT");
+  assert.match(clientCalls[2]!.sql, /INSERT INTO placement_scores/);
+  assert.match(clientCalls[2]!.sql, /ON CONFLICT \(placement_id\) DO UPDATE SET/);
+  assert.deepEqual(clientCalls[2]!.values, [
+    "pl_1",
+    "writer_1",
+    "comp_1",
+    "proj_1",
+    10,
+    2,
+    1,
+    0.9,
+    0.8,
+    14.4,
+    "2026-03-01T00:00:00.000Z"
+  ]);
+});

--- a/services/submission-tracking-service/src/repository.test.ts
+++ b/services/submission-tracking-service/src/repository.test.ts
@@ -1,205 +1,202 @@
 import assert from "node:assert/strict";
-import test from "node:test";
-import type {
-  Placement,
-  PlacementFilters,
-  PlacementVerificationState,
-  Submission,
-  SubmissionFilters,
-  SubmissionStatus
-} from "@script-manifest/contracts";
-import type { SubmissionTrackingRepository } from "./repository.js";
+import test, { mock } from "node:test";
 
-class MemorySubmissionTrackingRepository implements SubmissionTrackingRepository {
-  private readonly submissions = new Map<string, Submission>();
-  private readonly placements = new Map<string, Placement>();
-  private submissionCount = 0;
-  private placementCount = 0;
+type QueryResult = { rows: unknown[]; rowCount?: number };
+type QueryFn = (sql: string, values?: unknown[]) => Promise<QueryResult>;
 
-  async init(): Promise<void> {}
+let queryImpl: QueryFn = async () => ({ rows: [], rowCount: 0 });
+const query: QueryFn = async (sql, values = []) => queryImpl(sql, values);
 
-  async healthCheck(): Promise<{ database: boolean }> {
-    return { database: true };
+mock.module("@script-manifest/db", {
+  namedExports: {
+    getPool: () => ({ query }),
+    runMigrations: async () => undefined
   }
+});
 
-  async createSubmission(data: {
-    writerId: string;
-    projectId: string;
-    competitionId: string;
-    status: string;
-  }): Promise<Submission> {
-    const now = new Date("2026-03-01T00:00:00.000Z").toISOString();
-    const submission: Submission = {
-      id: `submission_${++this.submissionCount}`,
-      writerId: data.writerId,
-      projectId: data.projectId,
-      competitionId: data.competitionId,
-      status: data.status as SubmissionStatus,
-      createdAt: now,
-      updatedAt: now,
-    };
-    this.submissions.set(submission.id, submission);
-    return submission;
-  }
+const { PgSubmissionTrackingRepository } = await import("./pgRepository.js");
 
-  async getSubmission(id: string): Promise<Submission | null> {
-    return this.submissions.get(id) ?? null;
-  }
-
-  async updateSubmissionProject(id: string, projectId: string): Promise<Submission | null> {
-    const submission = this.submissions.get(id);
-    if (!submission) {
-      return null;
-    }
-
-    const updated: Submission = {
-      ...submission,
-      projectId,
-      updatedAt: new Date("2026-03-02T00:00:00.000Z").toISOString(),
-    };
-    this.submissions.set(id, updated);
-    return updated;
-  }
-
-  async updateSubmissionStatus(id: string, status: string): Promise<Submission | null> {
-    const submission = this.submissions.get(id);
-    if (!submission) {
-      return null;
-    }
-
-    const updated: Submission = {
-      ...submission,
-      status: status as SubmissionStatus,
-      updatedAt: new Date("2026-03-03T00:00:00.000Z").toISOString(),
-    };
-    this.submissions.set(id, updated);
-    return updated;
-  }
-
-  async listSubmissions(filters: SubmissionFilters): Promise<Submission[]> {
-    return Array.from(this.submissions.values()).filter((submission) => {
-      if (filters.writerId && submission.writerId !== filters.writerId) return false;
-      if (filters.projectId && submission.projectId !== filters.projectId) return false;
-      if (filters.competitionId && submission.competitionId !== filters.competitionId) return false;
-      if (filters.status && submission.status !== filters.status) return false;
-      return true;
-    });
-  }
-
-  async createPlacement(submissionId: string, status: string): Promise<Placement> {
-    const now = new Date("2026-03-04T00:00:00.000Z").toISOString();
-    const placement: Placement = {
-      id: `placement_${++this.placementCount}`,
-      submissionId,
-      status: status as SubmissionStatus,
-      verificationState: "pending",
-      createdAt: now,
-      updatedAt: now,
-      verifiedAt: null,
-    };
-    this.placements.set(placement.id, placement);
-    return placement;
-  }
-
-  async getPlacement(id: string): Promise<Placement | null> {
-    return this.placements.get(id) ?? null;
-  }
-
-  async updatePlacementVerification(id: string, verificationState: string): Promise<Placement | null> {
-    const placement = this.placements.get(id);
-    if (!placement) {
-      return null;
-    }
-
-    const now = new Date("2026-03-05T00:00:00.000Z").toISOString();
-    const updated: Placement = {
-      ...placement,
-      verificationState: verificationState as PlacementVerificationState,
-      updatedAt: now,
-      verifiedAt: verificationState === "verified" ? now : null,
-    };
-    this.placements.set(id, updated);
-    return updated;
-  }
-
-  async listPlacementsBySubmission(submissionId: string): Promise<Placement[]> {
-    return Array.from(this.placements.values()).filter((placement) => placement.submissionId === submissionId);
-  }
-
-  async listPlacements(filters: PlacementFilters): Promise<{ placement: Placement; submission: Submission }[]> {
-    return Array.from(this.placements.values()).flatMap((placement) => {
-      const submission = this.submissions.get(placement.submissionId);
-      if (!submission) {
-        return [];
-      }
-
-      if (filters.submissionId && placement.submissionId !== filters.submissionId) return [];
-      if (filters.writerId && submission.writerId !== filters.writerId) return [];
-      if (filters.projectId && submission.projectId !== filters.projectId) return [];
-      if (filters.competitionId && submission.competitionId !== filters.competitionId) return [];
-      if (filters.status && placement.status !== filters.status) return [];
-      if (filters.verificationState && placement.verificationState !== filters.verificationState) return [];
-
-      return [{ placement, submission }];
-    });
-  }
+function submissionRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "submission_1",
+    writer_id: "writer_1",
+    project_id: "project_1",
+    competition_id: "comp_1",
+    status: "pending",
+    created_at: new Date("2026-03-01T00:00:00.000Z"),
+    updated_at: new Date("2026-03-02T00:00:00.000Z"),
+    ...overrides
+  };
 }
 
-test("SubmissionTrackingRepository supports the submission and placement lifecycle", async () => {
-  const repo = new MemorySubmissionTrackingRepository();
+function placementRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "placement_1",
+    submission_id: "submission_1",
+    status: "quarterfinalist",
+    verification_state: "pending",
+    created_at: new Date("2026-03-03T00:00:00.000Z"),
+    updated_at: new Date("2026-03-04T00:00:00.000Z"),
+    verified_at: null,
+    ...overrides
+  };
+}
 
-  await repo.init();
-  assert.deepEqual(await repo.healthCheck(), { database: true });
+test("PgSubmissionTrackingRepository updates and retrieves submissions", async () => {
+  const calls: Array<{ sql: string; values: unknown[] }> = [];
 
-  const submission = await repo.createSubmission({
+  queryImpl = async (sql, values = []) => {
+    calls.push({ sql, values });
+    if (sql.includes("SELECT * FROM submissions WHERE id = $1")) {
+      return { rows: [submissionRow()] };
+    }
+    if (sql.includes("SET project_id = $2")) {
+      return { rows: [submissionRow({ project_id: "project_2" })], rowCount: 1 };
+    }
+    if (sql.includes("SET status = $2")) {
+      return { rows: [submissionRow({ status: "semifinalist" })], rowCount: 1 };
+    }
+    return { rows: [] };
+  };
+
+  const repo = new PgSubmissionTrackingRepository();
+  const submission = await repo.getSubmission("submission_1");
+  const projectUpdated = await repo.updateSubmissionProject("submission_1", "project_2");
+  const statusUpdated = await repo.updateSubmissionStatus("submission_1", "semifinalist");
+
+  assert.equal(submission?.writerId, "writer_1");
+  assert.equal(projectUpdated?.projectId, "project_2");
+  assert.equal(statusUpdated?.status, "semifinalist");
+  assert.deepEqual(calls.map((call) => call.values), [
+    ["submission_1"],
+    ["submission_1", "project_2"],
+    ["submission_1", "semifinalist"]
+  ]);
+});
+
+test("PgSubmissionTrackingRepository creates and verifies placements", async () => {
+  const calls: Array<{ sql: string; values: unknown[] }> = [];
+
+  queryImpl = async (sql, values = []) => {
+    calls.push({ sql, values });
+    if (sql.includes("INSERT INTO placements")) {
+      assert.match(String(values[0]), /^placement_/);
+      return { rows: [placementRow({ id: values[0] })], rowCount: 1 };
+    }
+    if (sql.includes("SELECT * FROM placements WHERE id = $1")) {
+      return { rows: [placementRow()] };
+    }
+    if (sql.includes("SET verification_state = $2")) {
+      return {
+        rows: [placementRow({ verification_state: "verified", verified_at: new Date("2026-03-05T00:00:00.000Z") })],
+        rowCount: 1
+      };
+    }
+    if (sql.includes("WHERE submission_id = $1")) {
+      return { rows: [placementRow()] };
+    }
+    return { rows: [] };
+  };
+
+  const repo = new PgSubmissionTrackingRepository();
+  const created = await repo.createPlacement("submission_1", "quarterfinalist");
+  const placement = await repo.getPlacement("placement_1");
+  const verified = await repo.updatePlacementVerification("placement_1", "verified");
+  const bySubmission = await repo.listPlacementsBySubmission("submission_1");
+
+  assert.equal(created.submissionId, "submission_1");
+  assert.equal(placement?.status, "quarterfinalist");
+  assert.equal(verified?.verificationState, "verified");
+  assert.equal(verified?.verifiedAt, "2026-03-05T00:00:00.000Z");
+  assert.equal(bySubmission.length, 1);
+  assert.deepEqual(calls.map((call) => call.values.slice(-2)), [
+    ["submission_1", "quarterfinalist"],
+    ["placement_1"],
+    ["placement_1", "verified"],
+    ["submission_1"]
+  ]);
+});
+
+test("PgSubmissionTrackingRepository listPlacements builds joined filters and maps rows", async () => {
+  let capturedSql = "";
+  let capturedValues: unknown[] = [];
+
+  queryImpl = async (sql, values = []) => {
+    capturedSql = sql;
+    capturedValues = values;
+    return {
+      rows: [
+        {
+          placement_id: "placement_1",
+          placement_submission_id: "submission_1",
+          placement_status: "quarterfinalist",
+          placement_verification_state: "verified",
+          placement_created_at: new Date("2026-03-03T00:00:00.000Z"),
+          placement_updated_at: new Date("2026-03-04T00:00:00.000Z"),
+          placement_verified_at: new Date("2026-03-05T00:00:00.000Z"),
+          submission_id: "submission_1",
+          submission_writer_id: "writer_1",
+          submission_project_id: "project_1",
+          submission_competition_id: "comp_1",
+          submission_status: "semifinalist",
+          submission_created_at: new Date("2026-03-01T00:00:00.000Z"),
+          submission_updated_at: new Date("2026-03-02T00:00:00.000Z")
+        }
+      ]
+    };
+  };
+
+  const repo = new PgSubmissionTrackingRepository();
+  const placements = await repo.listPlacements({
+    submissionId: "submission_1",
     writerId: "writer_1",
     projectId: "project_1",
     competitionId: "comp_1",
-    status: "pending",
+    status: "quarterfinalist",
+    verificationState: "verified"
   });
 
-  assert.equal(submission.id, "submission_1");
-  assert.equal(submission.status, "pending");
-  assert.equal((await repo.getSubmission(submission.id))?.writerId, "writer_1");
-
-  const projectUpdated = await repo.updateSubmissionProject(submission.id, "project_2");
-  assert.equal(projectUpdated?.projectId, "project_2");
-
-  const statusUpdated = await repo.updateSubmissionStatus(submission.id, "semifinalist");
-  assert.equal(statusUpdated?.status, "semifinalist");
-
-  const placement = await repo.createPlacement(submission.id, "quarterfinalist");
-  assert.equal(placement.id, "placement_1");
-  assert.equal(placement.verificationState, "pending");
-
-  const verified = await repo.updatePlacementVerification(placement.id, "verified");
-  assert.equal(verified?.verificationState, "verified");
-  assert.ok(verified?.verifiedAt);
-
-  const submissions = await repo.listSubmissions({ writerId: "writer_1", projectId: "project_2" });
-  assert.equal(submissions.length, 1);
-
-  const placementsBySubmission = await repo.listPlacementsBySubmission(submission.id);
-  assert.equal(placementsBySubmission.length, 1);
-
-  const placements = await repo.listPlacements({
-    writerId: "writer_1",
-    projectId: "project_2",
-    verificationState: "verified",
-  });
-  assert.equal(placements.length, 1);
-  assert.equal(placements[0]?.submission.id, submission.id);
-  assert.equal(placements[0]?.placement.id, placement.id);
+  assert.match(capturedSql, /INNER JOIN submissions s ON s.id = p.submission_id/);
+  assert.match(capturedSql, /p.submission_id = \$1/);
+  assert.match(capturedSql, /s.writer_id = \$2/);
+  assert.match(capturedSql, /s.project_id = \$3/);
+  assert.match(capturedSql, /s.competition_id = \$4/);
+  assert.match(capturedSql, /p.status = \$5/);
+  assert.match(capturedSql, /p.verification_state = \$6/);
+  assert.deepEqual(capturedValues, ["submission_1", "writer_1", "project_1", "comp_1", "quarterfinalist", "verified"]);
+  assert.deepEqual(placements, [
+    {
+      placement: {
+        id: "placement_1",
+        submissionId: "submission_1",
+        status: "quarterfinalist",
+        verificationState: "verified",
+        createdAt: "2026-03-03T00:00:00.000Z",
+        updatedAt: "2026-03-04T00:00:00.000Z",
+        verifiedAt: "2026-03-05T00:00:00.000Z"
+      },
+      submission: {
+        id: "submission_1",
+        writerId: "writer_1",
+        projectId: "project_1",
+        competitionId: "comp_1",
+        status: "semifinalist",
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-02T00:00:00.000Z"
+      }
+    }
+  ]);
 });
 
-test("SubmissionTrackingRepository returns null when records are missing", async () => {
-  const repo = new MemorySubmissionTrackingRepository();
+test("PgSubmissionTrackingRepository returns null when updates miss", async () => {
+  queryImpl = async () => ({ rows: [], rowCount: 0 });
+
+  const repo = new PgSubmissionTrackingRepository();
 
   assert.equal(await repo.getSubmission("missing"), null);
   assert.equal(await repo.getPlacement("missing"), null);
   assert.equal(await repo.updateSubmissionProject("missing", "project_1"), null);
   assert.equal(await repo.updateSubmissionStatus("missing", "semifinalist"), null);
   assert.equal(await repo.updatePlacementVerification("missing", "verified"), null);
-  assert.deepEqual(await repo.listSubmissions({ writerId: "missing" }), []);
-  assert.deepEqual(await repo.listPlacements({ writerId: "missing" }), []);
-});
+}
+);

--- a/services/submission-tracking-service/src/repository.test.ts
+++ b/services/submission-tracking-service/src/repository.test.ts
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  Placement,
+  PlacementFilters,
+  PlacementVerificationState,
+  Submission,
+  SubmissionFilters,
+  SubmissionStatus
+} from "@script-manifest/contracts";
+import type { SubmissionTrackingRepository } from "./repository.js";
+
+class MemorySubmissionTrackingRepository implements SubmissionTrackingRepository {
+  private readonly submissions = new Map<string, Submission>();
+  private readonly placements = new Map<string, Placement>();
+  private submissionCount = 0;
+  private placementCount = 0;
+
+  async init(): Promise<void> {}
+
+  async healthCheck(): Promise<{ database: boolean }> {
+    return { database: true };
+  }
+
+  async createSubmission(data: {
+    writerId: string;
+    projectId: string;
+    competitionId: string;
+    status: string;
+  }): Promise<Submission> {
+    const now = new Date("2026-03-01T00:00:00.000Z").toISOString();
+    const submission: Submission = {
+      id: `submission_${++this.submissionCount}`,
+      writerId: data.writerId,
+      projectId: data.projectId,
+      competitionId: data.competitionId,
+      status: data.status as SubmissionStatus,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.submissions.set(submission.id, submission);
+    return submission;
+  }
+
+  async getSubmission(id: string): Promise<Submission | null> {
+    return this.submissions.get(id) ?? null;
+  }
+
+  async updateSubmissionProject(id: string, projectId: string): Promise<Submission | null> {
+    const submission = this.submissions.get(id);
+    if (!submission) {
+      return null;
+    }
+
+    const updated: Submission = {
+      ...submission,
+      projectId,
+      updatedAt: new Date("2026-03-02T00:00:00.000Z").toISOString(),
+    };
+    this.submissions.set(id, updated);
+    return updated;
+  }
+
+  async updateSubmissionStatus(id: string, status: string): Promise<Submission | null> {
+    const submission = this.submissions.get(id);
+    if (!submission) {
+      return null;
+    }
+
+    const updated: Submission = {
+      ...submission,
+      status: status as SubmissionStatus,
+      updatedAt: new Date("2026-03-03T00:00:00.000Z").toISOString(),
+    };
+    this.submissions.set(id, updated);
+    return updated;
+  }
+
+  async listSubmissions(filters: SubmissionFilters): Promise<Submission[]> {
+    return Array.from(this.submissions.values()).filter((submission) => {
+      if (filters.writerId && submission.writerId !== filters.writerId) return false;
+      if (filters.projectId && submission.projectId !== filters.projectId) return false;
+      if (filters.competitionId && submission.competitionId !== filters.competitionId) return false;
+      if (filters.status && submission.status !== filters.status) return false;
+      return true;
+    });
+  }
+
+  async createPlacement(submissionId: string, status: string): Promise<Placement> {
+    const now = new Date("2026-03-04T00:00:00.000Z").toISOString();
+    const placement: Placement = {
+      id: `placement_${++this.placementCount}`,
+      submissionId,
+      status: status as SubmissionStatus,
+      verificationState: "pending",
+      createdAt: now,
+      updatedAt: now,
+      verifiedAt: null,
+    };
+    this.placements.set(placement.id, placement);
+    return placement;
+  }
+
+  async getPlacement(id: string): Promise<Placement | null> {
+    return this.placements.get(id) ?? null;
+  }
+
+  async updatePlacementVerification(id: string, verificationState: string): Promise<Placement | null> {
+    const placement = this.placements.get(id);
+    if (!placement) {
+      return null;
+    }
+
+    const now = new Date("2026-03-05T00:00:00.000Z").toISOString();
+    const updated: Placement = {
+      ...placement,
+      verificationState: verificationState as PlacementVerificationState,
+      updatedAt: now,
+      verifiedAt: verificationState === "verified" ? now : null,
+    };
+    this.placements.set(id, updated);
+    return updated;
+  }
+
+  async listPlacementsBySubmission(submissionId: string): Promise<Placement[]> {
+    return Array.from(this.placements.values()).filter((placement) => placement.submissionId === submissionId);
+  }
+
+  async listPlacements(filters: PlacementFilters): Promise<{ placement: Placement; submission: Submission }[]> {
+    return Array.from(this.placements.values()).flatMap((placement) => {
+      const submission = this.submissions.get(placement.submissionId);
+      if (!submission) {
+        return [];
+      }
+
+      if (filters.submissionId && placement.submissionId !== filters.submissionId) return [];
+      if (filters.writerId && submission.writerId !== filters.writerId) return [];
+      if (filters.projectId && submission.projectId !== filters.projectId) return [];
+      if (filters.competitionId && submission.competitionId !== filters.competitionId) return [];
+      if (filters.status && placement.status !== filters.status) return [];
+      if (filters.verificationState && placement.verificationState !== filters.verificationState) return [];
+
+      return [{ placement, submission }];
+    });
+  }
+}
+
+test("SubmissionTrackingRepository supports the submission and placement lifecycle", async () => {
+  const repo = new MemorySubmissionTrackingRepository();
+
+  await repo.init();
+  assert.deepEqual(await repo.healthCheck(), { database: true });
+
+  const submission = await repo.createSubmission({
+    writerId: "writer_1",
+    projectId: "project_1",
+    competitionId: "comp_1",
+    status: "pending",
+  });
+
+  assert.equal(submission.id, "submission_1");
+  assert.equal(submission.status, "pending");
+  assert.equal((await repo.getSubmission(submission.id))?.writerId, "writer_1");
+
+  const projectUpdated = await repo.updateSubmissionProject(submission.id, "project_2");
+  assert.equal(projectUpdated?.projectId, "project_2");
+
+  const statusUpdated = await repo.updateSubmissionStatus(submission.id, "semifinalist");
+  assert.equal(statusUpdated?.status, "semifinalist");
+
+  const placement = await repo.createPlacement(submission.id, "quarterfinalist");
+  assert.equal(placement.id, "placement_1");
+  assert.equal(placement.verificationState, "pending");
+
+  const verified = await repo.updatePlacementVerification(placement.id, "verified");
+  assert.equal(verified?.verificationState, "verified");
+  assert.ok(verified?.verifiedAt);
+
+  const submissions = await repo.listSubmissions({ writerId: "writer_1", projectId: "project_2" });
+  assert.equal(submissions.length, 1);
+
+  const placementsBySubmission = await repo.listPlacementsBySubmission(submission.id);
+  assert.equal(placementsBySubmission.length, 1);
+
+  const placements = await repo.listPlacements({
+    writerId: "writer_1",
+    projectId: "project_2",
+    verificationState: "verified",
+  });
+  assert.equal(placements.length, 1);
+  assert.equal(placements[0]?.submission.id, submission.id);
+  assert.equal(placements[0]?.placement.id, placement.id);
+});
+
+test("SubmissionTrackingRepository returns null when records are missing", async () => {
+  const repo = new MemorySubmissionTrackingRepository();
+
+  assert.equal(await repo.getSubmission("missing"), null);
+  assert.equal(await repo.getPlacement("missing"), null);
+  assert.equal(await repo.updateSubmissionProject("missing", "project_1"), null);
+  assert.equal(await repo.updateSubmissionStatus("missing", "semifinalist"), null);
+  assert.equal(await repo.updatePlacementVerification("missing", "verified"), null);
+  assert.deepEqual(await repo.listSubmissions({ writerId: "missing" }), []);
+  assert.deepEqual(await repo.listPlacements({ writerId: "missing" }), []);
+});


### PR DESCRIPTION
## Summary
- add repository contract coverage for competition-directory, ranking, profile-project, programs, and submission-tracking services
- cover scheduler-adjacent programs repository behavior and submission/ranking/profile query mapping
- mark CHAOS-1041 complete with verification evidence in Linear

## Verification
- lsp_diagnostics clean for all five changed repository test files
- pnpm --filter @script-manifest/search build
- pnpm --filter @script-manifest/email build
- pnpm --filter @script-manifest/competition-directory-service test
- pnpm --filter @script-manifest/ranking-service test
- pnpm --filter @script-manifest/profile-project-service test
- pnpm --filter @script-manifest/programs-service test
- pnpm --filter @script-manifest/submission-tracking-service test
- pnpm test:services

Linear: CHAOS-1041