### PR TITLE
sec(CHAOS-1006): block worktree feature branches from pushing to origin/main

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,70 @@
+#!/bin/sh
+# pre-push: refuse to push the current branch onto a protected remote branch
+# when the local branch name does not match the remote branch name.
+#
+# This protects against the worktree-from-origin/main hazard described in
+# CHAOS-1006: `git worktree add -b <feature> origin/main` leaves <feature>
+# tracking origin/main, so a plain `git push` (with push.default=upstream or
+# similar) would update origin/main from a feature checkout.
+#
+# Bypass intentionally with: git push --no-verify (NOT RECOMMENDED).
+#
+# Activation:
+#   git config core.hooksPath .githooks
+# (run scripts/setup-hooks.sh once after cloning or adding a worktree).
+
+set -eu
+
+PROTECTED_BRANCHES="main master"
+remote_name="$1"
+# $2 is remote_url, unused
+
+z40="0000000000000000000000000000000000000000"
+exit_code=0
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+    # Skip delete pushes
+    if [ "$local_sha" = "$z40" ]; then
+        continue
+    fi
+
+    # remote_ref looks like refs/heads/<branch> for branch updates.
+    case "$remote_ref" in
+        refs/heads/*) remote_branch="${remote_ref#refs/heads/}" ;;
+        *) continue ;;
+    esac
+
+    # Identify the local branch we are pushing from. If local_ref is a
+    # symbolic-style HEAD push (`git push origin HEAD`), resolve it.
+    case "$local_ref" in
+        refs/heads/*) local_branch="${local_ref#refs/heads/}" ;;
+        HEAD)
+            local_branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || echo "")"
+            ;;
+        *) local_branch="$local_ref" ;;
+    esac
+
+    for protected in $PROTECTED_BRANCHES; do
+        if [ "$remote_branch" = "$protected" ] && [ "$local_branch" != "$protected" ]; then
+            cat >&2 <<EOF
+[pre-push] BLOCKED: refusing to push '$local_branch' to '$remote_name/$remote_branch'.
+
+This usually happens when a worktree was created with:
+    git worktree add ../path -b <feature> origin/main
+which leaves <feature> tracking origin/main. A plain \`git push\` then
+targets origin/main, not your feature branch.
+
+Push your feature branch explicitly instead:
+    git push $remote_name HEAD:refs/heads/$local_branch
+Or open the PR (which pushes the branch as a side-effect):
+    gh pr create --head $local_branch --base $protected --title "..." --body "..."
+
+To bypass (NOT RECOMMENDED, requires admin override on protected branches):
+    git push --no-verify
+EOF
+            exit_code=1
+        fi
+    done
+done
+
+exit "$exit_code"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,15 +62,23 @@ linear i create "[Subtask] <subtask title>" \
 - Add every mirrored issue to the `Script Manifest` project in Linear.
 - **NEVER commit or push directly to `main`.** ALL changes go through feature branches + PRs.
   - This applies to every change, no matter how small — config files, one-liners, CI tweaks, everything.
-  - **Always create a git worktree** for new work to isolate changes from the main checkout:
+  - **One-time setup per clone**:
     ```bash
-    git fetch origin
-    git worktree add ../script-manifest-<feature> -b <branch-name> origin/main
-    cd ../script-manifest-<feature>
+    scripts/setup-hooks.sh
+    ```
+    Activates the shared pre-push hook (blocks `<feature> → origin/main` pushes) and sets `push.default=current`.
+  - **Create new worktrees with the helper** (handles upstream tracking + hook activation):
+    ```bash
+    scripts/new-worktree.sh <branch-name>
+    # equivalent to:
+    #   git fetch origin
+    #   git worktree add ../script-manifest-<branch> -b <branch> origin/main
+    #   git branch --unset-upstream <branch>
+    #   (cd ../script-manifest-<branch> && scripts/setup-hooks.sh)
     ```
   - Branch format: `<change-type:feat,chore,sec,fix,docs>/<issue>-<short description>` (example: `feat/TICK-111-add-new-thing`).
   - Keep all commits for that feature on its dedicated branch until merged.
-  - **Pushing worktree branches**: Worktrees created from `origin/main` track `main` as upstream. A bare `git push` will push to `main`, not the feature branch. **Always use `gh pr create` to push and open the PR in one step**, or push explicitly with `git push origin HEAD:<branch-name>`:
+  - **Pushing worktree branches**: with `scripts/new-worktree.sh` + `scripts/setup-hooks.sh` applied, `git push` is safe — it targets the same-named remote branch via `push.default=current`, and the pre-push hook refuses any `<feature> → main` push. If you bypass the helpers (raw `git worktree add -b <feature> origin/main`), the worktree tracks `origin/main` and a plain `git push` will target main; use one of the explicit forms instead:
     ```bash
     # CORRECT — gh pr create pushes the branch automatically:
     gh pr create --head <branch-name> --base main --title "..." --body "..."
@@ -78,7 +86,7 @@ linear i create "[Subtask] <subtask title>" \
     # CORRECT — explicit refspec:
     git push origin HEAD:<branch-name>
 
-    # WRONG — pushes to tracked upstream (main):
+    # WRONG (only if helpers were skipped) — pushes to tracked upstream (main):
     git push
     git push -u origin <branch-name>
     ```

--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# new-worktree.sh: create a feature worktree with the correct upstream tracking.
+#
+# Usage:
+#   scripts/new-worktree.sh <branch-name> [base-ref]
+#
+# Example:
+#   scripts/new-worktree.sh feat/CHAOS-123-thing
+#   scripts/new-worktree.sh fix/CHAOS-456-bug origin/main
+#
+# What it does (vs. the raw `git worktree add` recipe):
+#   1. Creates the worktree at ../script-manifest-<sanitized-branch-name>.
+#   2. Branches from origin/main (or the explicit base-ref).
+#   3. Explicitly clears the upstream so plain `git push` cannot target
+#      origin/main from this worktree (see CHAOS-1006).
+#   4. Runs scripts/setup-hooks.sh inside the new worktree so the shared
+#      pre-push protection is active immediately.
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "usage: $0 <branch-name> [base-ref]" >&2
+    exit 2
+fi
+
+branch="$1"
+base_ref="${2:-origin/main}"
+
+# Sanitize branch name into a directory suffix (replace / with -).
+dir_suffix="$(printf '%s' "$branch" | tr '/' '-')"
+repo_root="$(git rev-parse --show-toplevel)"
+parent_dir="$(dirname "$repo_root")"
+repo_name="$(basename "$repo_root")"
+worktree_path="$parent_dir/${repo_name}-${dir_suffix}"
+
+if [ -e "$worktree_path" ]; then
+    echo "error: $worktree_path already exists" >&2
+    exit 1
+fi
+
+echo "[new-worktree] fetching origin..."
+git fetch origin
+
+echo "[new-worktree] creating worktree at $worktree_path on branch $branch (from $base_ref)"
+git worktree add "$worktree_path" -b "$branch" "$base_ref"
+
+cd "$worktree_path"
+
+# Belt and suspenders: explicitly unset the upstream so `git push` (with
+# any push.default) cannot accidentally target origin/main. Push must be
+# explicit (`git push origin HEAD:refs/heads/<branch>` or `gh pr create`).
+git branch --unset-upstream "$branch" 2>/dev/null || true
+
+# Activate shared hooks + push.default=current in this worktree.
+if [ -x scripts/setup-hooks.sh ]; then
+    scripts/setup-hooks.sh
+else
+    echo "[new-worktree] warning: scripts/setup-hooks.sh not executable; run it manually" >&2
+fi
+
+cat <<EOF
+
+[new-worktree] OK
+  worktree:     $worktree_path
+  branch:       $branch
+  base:         $base_ref
+  upstream:     <unset>  (push must be explicit; pre-push hook also enforced)
+
+Next steps:
+    cd $worktree_path
+    # ... make changes, commit ...
+    gh pr create --head $branch --base main --title "..." --body "..."
+EOF

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# setup-hooks.sh: enable the repo's shared git hooks for the current clone
+# and any existing worktrees.
+#
+# Run once after cloning, and once per new worktree.
+#
+# What it does:
+#   1. Points git at .githooks/ for hook resolution (instead of .git/hooks/).
+#   2. Switches push.default to `current`, so `git push` always targets a
+#      same-named branch on the remote and never the tracked upstream
+#      (defends against worktrees created with `-b <branch> origin/main`,
+#      see CHAOS-1006).
+#   3. Makes hook scripts executable.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if [ ! -d .githooks ]; then
+    echo "error: .githooks/ not found in $repo_root" >&2
+    exit 1
+fi
+
+chmod +x .githooks/* 2>/dev/null || true
+
+git config core.hooksPath .githooks
+git config push.default current
+
+cat <<EOF
+[setup-hooks] OK
+  core.hooksPath  = $(git config --get core.hooksPath)
+  push.default    = $(git config --get push.default)
+
+Active hooks:
+$(ls -1 .githooks | sed 's/^/  - /')
+
+Re-run this script after creating each new worktree:
+    git worktree add ../script-manifest-<feature> -b <branch> origin/main
+    cd ../script-manifest-<feature>
+    scripts/setup-hooks.sh
+EOF


### PR DESCRIPTION
## Summary

Closes [CHAOS-1006](https://linear.app/fullchaos/issue/CHAOS-1006/task-prevent-worktree-branches-from-pushing-to-originmain).

Hardens the worktree workflow so a feature branch created via
`git worktree add -b <feature> origin/main` can no longer accidentally
push to `origin/main` via a bare `git push`.

## Layered defenses

1. **`.githooks/pre-push`** — refuses any push that maps a non-main local
   branch to `refs/heads/main` (or `master`). Prints the correct refspec
   plus the `gh pr create` recipe.
2. **`scripts/setup-hooks.sh`** — one-time per clone/worktree:
   - `git config core.hooksPath .githooks` (activate the shared hook)
   - `git config push.default current` (push current branch to a
     same-named remote, never the tracked upstream)
3. **`scripts/new-worktree.sh`** — replaces the raw worktree recipe.
   Creates the worktree, explicitly `git branch --unset-upstream <branch>`,
   then runs `setup-hooks.sh` inside it.

`AGENTS.md` updated to point at the helpers.

## Verification

Three scripted invocations of the hook with synthetic ref pairs:

| Case | Expected | Got |
|---|---|---|
| feature → `refs/heads/main` | BLOCKED (exit 1) | BLOCKED (exit 1, full remediation message) |
| feature → its own remote ref | allowed (exit 0) | exit 0 |
| main → main | allowed (exit 0) | exit 0 |

`scripts/setup-hooks.sh` was run end-to-end in this worktree:
`core.hooksPath=.githooks`, `push.default=current`.

## Rollout note

Existing clones / worktrees keep working unchanged until a contributor
runs `scripts/setup-hooks.sh` (or creates a new worktree via the helper).
This PR does not modify any global git config and is fully reversible
per-clone with `git config --unset core.hooksPath`.