### PR TITLE
feat(CHAOS-1805): evidence-backed historical placement import

### DIFF
--- a/apps/writer-web/app/admin/placements/PendingHistoricalList.tsx
+++ b/apps/writer-web/app/admin/placements/PendingHistoricalList.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import type { PlacementListItem, PlacementVerificationState } from "@script-manifest/contracts";
+import useSWR from "swr";
+import { EmptyState } from "../../components/emptyState";
+import { EmptyIllustration } from "../../components/illustrations";
+import { SkeletonCard } from "../../components/skeleton";
+import { useToast } from "../../components/toast";
+import { ApiError, fetcher } from "../../lib/fetcher";
+
+export function PendingHistoricalList() {
+  const toast = useToast();
+  const [mutating, setMutating] = useState(false);
+  const { data, isLoading, mutate } = useSWR<{ placements: PlacementListItem[] }>(
+    "/api/v1/placements?isHistorical=true&verificationState=pending",
+    {
+      onError(err: unknown) {
+        toast.error(err instanceof ApiError ? err.message : "Failed to load historical placements.");
+      }
+    }
+  );
+
+  const placements = data?.placements ?? [];
+
+  async function reviewPlacement(placementId: string, verificationState: Extract<PlacementVerificationState, "verified" | "rejected">) {
+    const reviewNotes = window.prompt(verificationState === "verified" ? "Approval notes" : "Rejection notes") ?? undefined;
+    setMutating(true);
+    try {
+      await fetcher(`/api/v1/placements/${encodeURIComponent(placementId)}/verify`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ verificationState, reviewNotes })
+      });
+      void mutate();
+      toast.success(`Placement ${verificationState}.`);
+    } catch (error) {
+      toast.error(error instanceof ApiError ? error.message : "Failed to review placement.");
+    } finally {
+      setMutating(false);
+    }
+  }
+
+  return (
+    <article className="panel stack">
+      <div className="subcard-header">
+        <h2 className="section-title">Pending historical placements</h2>
+        <span className="badge">{placements.length} pending</span>
+      </div>
+
+      {isLoading ? (
+        <div className="stack"><SkeletonCard /><SkeletonCard /></div>
+      ) : placements.length === 0 ? (
+        <EmptyState
+          illustration={<EmptyIllustration variant="inbox" className="h-14 w-14 text-foreground" />}
+          title="No pending evidence"
+          description="Historical placements awaiting review will appear here."
+        />
+      ) : null}
+
+      {!isLoading ? placements.map((placement) => (
+        <article key={placement.id} className="subcard">
+          <div className="subcard-header">
+            <strong>{placement.id}</strong>
+            <span className="badge">{placement.status}</span>
+            <span className="badge">{placement.badgeLabel}</span>
+          </div>
+          <div className="mt-2 inline-form">
+            <span className="text-sm text-muted">Writer: {placement.writerId}</span>
+            <span className="text-sm text-muted">Project: {placement.projectId}</span>
+            <span className="text-sm text-muted">Competition: {placement.competitionId}</span>
+          </div>
+          {placement.sourceNote ? <p className="muted mt-2">{placement.sourceNote}</p> : null}
+          <div className="inline-form mt-3">
+            <button className="btn btn-primary" type="button" disabled={mutating} onClick={() => void reviewPlacement(placement.id, "verified")}>Approve</button>
+            <button className="btn btn-danger" type="button" disabled={mutating} onClick={() => void reviewPlacement(placement.id, "rejected")}>Reject</button>
+          </div>
+        </article>
+      )) : null}
+    </article>
+  );
+}

--- a/apps/writer-web/app/admin/placements/page.tsx
+++ b/apps/writer-web/app/admin/placements/page.tsx
@@ -1,0 +1,16 @@
+import { PendingHistoricalList } from "./PendingHistoricalList";
+
+export default function AdminPlacementsPage() {
+  return (
+    <section className="space-y-4">
+      <article className="hero-card hero-card--violet animate-in">
+        <p className="eyebrow eyebrow--violet">Admin Review</p>
+        <h1 className="text-4xl text-foreground">Historical placement evidence</h1>
+        <p className="max-w-3xl text-foreground-secondary">
+          Review writer-submitted historical placements and approve or reject the attached evidence.
+        </p>
+      </article>
+      <PendingHistoricalList />
+    </section>
+  );
+}

--- a/apps/writer-web/app/api/v1/placements/[placementId]/evidence/route.ts
+++ b/apps/writer-web/app/api/v1/placements/[placementId]/evidence/route.ts
@@ -1,0 +1,13 @@
+import { proxyRequest } from "../../../_proxy";
+
+export const runtime = "nodejs";
+
+export async function GET(request: Request, { params }: { params: Promise<{ placementId: string }> }) {
+  const { placementId } = await params;
+  return proxyRequest(request, `/api/v1/placements/${encodeURIComponent(placementId)}/evidence`);
+}
+
+export async function POST(request: Request, { params }: { params: Promise<{ placementId: string }> }) {
+  const { placementId } = await params;
+  return proxyRequest(request, `/api/v1/placements/${encodeURIComponent(placementId)}/evidence`);
+}

--- a/apps/writer-web/app/api/v1/placements/historical/route.ts
+++ b/apps/writer-web/app/api/v1/placements/historical/route.ts
@@ -1,0 +1,7 @@
+import { proxyRequest } from "../../_proxy";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  return proxyRequest(request, "/api/v1/placements/historical");
+}

--- a/apps/writer-web/app/submissions/page.tsx
+++ b/apps/writer-web/app/submissions/page.tsx
@@ -4,7 +4,9 @@ import { useState, type FormEvent } from "react";
 import type { Route } from "next";
 import type {
   Competition,
+  CreateHistoricalPlacementRequest,
   PlacementListItem,
+  PlacementEvidenceKind,
   PlacementVerificationState,
   Project,
   Submission,
@@ -38,8 +40,18 @@ export default function SubmissionsPage() {
   const [mutating, setMutating] = useState(false);
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [placementModalOpen, setPlacementModalOpen] = useState(false);
+  const [historicalModalOpen, setHistoricalModalOpen] = useState(false);
   const [targetSubmissionId, setTargetSubmissionId] = useState("");
   const [placementStatus, setPlacementStatus] = useState<SubmissionStatus>("quarterfinalist");
+  const [historicalProjectId, setHistoricalProjectId] = useState("");
+  const [historicalCompetitionId, setHistoricalCompetitionId] = useState("");
+  const [historicalStatus, setHistoricalStatus] = useState<SubmissionStatus>("finalist");
+  const [historicalPlacementDate, setHistoricalPlacementDate] = useState("");
+  const [historicalSourceNote, setHistoricalSourceNote] = useState("");
+  const [historicalEvidenceUrl, setHistoricalEvidenceUrl] = useState("");
+  const [historicalEvidenceCaption, setHistoricalEvidenceCaption] = useState("");
+  const [historicalEvidenceKind, setHistoricalEvidenceKind] = useState<PlacementEvidenceKind>("document");
+  const [historicalEvidenceFile, setHistoricalEvidenceFile] = useState<File | null>(null);
 
   // Auth-paused key: null while auth is resolving or no user — SWR will not fetch.
   const writerId = user?.id ?? "";
@@ -61,6 +73,7 @@ export default function SubmissionsPage() {
     {
       onSuccess(data) {
         setProjectId((cur) => cur || data.projects[0]?.id || "");
+        setHistoricalProjectId((cur) => cur || data.projects[0]?.id || "");
       },
       onError(err: unknown) {
         toast.error(err instanceof ApiError ? err.message : "Failed to load projects.");
@@ -72,7 +85,8 @@ export default function SubmissionsPage() {
     competitions: Competition[];
   }>(competitionsKey, {
     onSuccess(data) {
-      setCompetitionId((cur) => cur || data.competitions[0]?.id || "");
+        setCompetitionId((cur) => cur || data.competitions[0]?.id || "");
+        setHistoricalCompetitionId((cur) => cur || data.competitions[0]?.id || "");
     },
     onError(err: unknown) {
       toast.error(err instanceof ApiError ? err.message : "Failed to load competitions.");
@@ -242,6 +256,88 @@ export default function SubmissionsPage() {
     }
   }
 
+  async function createHistoricalPlacement(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!writerId || !historicalProjectId || !historicalCompetitionId || !historicalPlacementDate || !historicalSourceNote.trim()) {
+      toast.error("Project, competition, date, and source note are required.");
+      return;
+    }
+    if (!historicalEvidenceFile && !historicalEvidenceUrl.trim()) {
+      toast.error("Attach an evidence file or URL.");
+      return;
+    }
+
+    setMutating(true);
+    try {
+      const scriptId = historicalEvidenceFile ? await uploadEvidenceFile(historicalEvidenceFile, writerId) : undefined;
+      const payload: CreateHistoricalPlacementRequest = {
+        projectId: historicalProjectId,
+        competitionId: historicalCompetitionId,
+        status: historicalStatus,
+        placementDate: historicalPlacementDate,
+        sourceNote: historicalSourceNote,
+        evidenceItems: [
+          {
+            kind: historicalEvidenceKind,
+            caption: historicalEvidenceCaption || undefined,
+            scriptId,
+            evidenceUrl: historicalEvidenceUrl || undefined
+          }
+        ]
+      };
+      await fetcher("/api/v1/placements/historical", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+      void mutateSubmissions();
+      void mutatePlacements();
+      setHistoricalModalOpen(false);
+      setHistoricalSourceNote("");
+      setHistoricalEvidenceUrl("");
+      setHistoricalEvidenceCaption("");
+      setHistoricalEvidenceFile(null);
+      toast.success("Historical placement recorded for review.");
+    } catch (error) {
+      toast.error(error instanceof ApiError ? error.message : "Failed to record historical placement.");
+    } finally {
+      setMutating(false);
+    }
+  }
+
+  async function uploadEvidenceFile(file: File, ownerUserId: string): Promise<string> {
+    const scriptId = `evidence_${crypto.randomUUID()}`;
+    const uploadSession = await fetcher<{ uploadUrl: string; uploadFields: Record<string, string>; objectKey: string }>(
+      "/api/v1/scripts/upload-session",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ scriptId, ownerUserId, filename: file.name, contentType: file.type, size: file.size })
+      }
+    );
+    const formData = new FormData();
+    for (const [key, value] of Object.entries(uploadSession.uploadFields)) {
+      formData.append(key, value);
+    }
+    formData.append("file", file);
+    const uploadResponse = await fetch(uploadSession.uploadUrl, { method: "POST", body: formData });
+    if (!uploadResponse.ok) throw new Error("Evidence upload failed.");
+    await fetcher("/api/v1/scripts/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        scriptId,
+        ownerUserId,
+        objectKey: uploadSession.objectKey,
+        filename: file.name,
+        contentType: file.type,
+        size: file.size,
+        visibility: "evidence"
+      })
+    });
+    return scriptId;
+  }
+
   const loading = creating || mutating;
 
   return (
@@ -273,6 +369,14 @@ export default function SubmissionsPage() {
             disabled={!writerId || submissions.length === 0}
           >
             Record placement
+          </button>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={() => setHistoricalModalOpen(true)}
+            disabled={!writerId || projects.length === 0 || competitions.length === 0}
+          >
+            Record historical placement
           </button>
         </div>
       </article>
@@ -360,8 +464,9 @@ export default function SubmissionsPage() {
                         <div className="subcard-header">
                           <strong>{placement.id}</strong>
                           <span className="badge">
-                            {placement.status} | {placement.verificationState}
+                            {placement.status} | {placement.badgeLabel}
                           </span>
+                          {placement.isHistorical ? <span className="badge">Historical</span> : null}
                         </div>
                         <div className="inline-form mt-2">
                           <button
@@ -498,6 +603,84 @@ export default function SubmissionsPage() {
           <div className="inline-form">
             <button type="submit" className="btn btn-primary" disabled={loading}>
               {loading ? "Saving..." : "Create placement"}
+            </button>
+          </div>
+        </form>
+      </Modal>
+
+      <Modal
+        open={historicalModalOpen}
+        onClose={() => setHistoricalModalOpen(false)}
+        title="Record historical placement"
+        description="Add a past placement with evidence so an admin can verify it."
+      >
+        <form className="stack" onSubmit={createHistoricalPlacement}>
+          <label className="stack-tight">
+            <span>Project</span>
+            <select className="input" value={historicalProjectId} onChange={(event) => setHistoricalProjectId(event.target.value)} required>
+              <option value="">Select project</option>
+              {projects.map((project) => (
+                <option key={project.id} value={project.id}>{project.title}</option>
+              ))}
+            </select>
+          </label>
+
+          <label className="stack-tight">
+            <span>Competition</span>
+            <select className="input" value={historicalCompetitionId} onChange={(event) => setHistoricalCompetitionId(event.target.value)} required>
+              <option value="">Select competition</option>
+              {competitions.map((competition) => (
+                <option key={competition.id} value={competition.id}>{competition.title}</option>
+              ))}
+            </select>
+          </label>
+
+          <label className="stack-tight">
+            <span>Placement status</span>
+            <select className="input" value={historicalStatus} onChange={(event) => setHistoricalStatus(event.target.value as SubmissionStatus)}>
+              {statuses.filter((value) => value !== "pending").map((entry) => (
+                <option key={entry} value={entry}>{entry}</option>
+              ))}
+            </select>
+          </label>
+
+          <label className="stack-tight">
+            <span>Placement date</span>
+            <input className="input" type="date" value={historicalPlacementDate} onChange={(event) => setHistoricalPlacementDate(event.target.value)} required />
+          </label>
+
+          <label className="stack-tight">
+            <span>Source note</span>
+            <textarea className="input min-h-24" value={historicalSourceNote} onChange={(event) => setHistoricalSourceNote(event.target.value)} maxLength={2000} required />
+          </label>
+
+          <label className="stack-tight">
+            <span>Evidence kind</span>
+            <select className="input" value={historicalEvidenceKind} onChange={(event) => setHistoricalEvidenceKind(event.target.value as PlacementEvidenceKind)}>
+              {(["screenshot", "pdf", "document", "url", "other"] as PlacementEvidenceKind[]).map((entry) => (
+                <option key={entry} value={entry}>{entry}</option>
+              ))}
+            </select>
+          </label>
+
+          <label className="stack-tight">
+            <span>Evidence file</span>
+            <input className="input" type="file" accept="application/pdf,image/png,image/jpeg,image/webp,text/plain" onChange={(event) => setHistoricalEvidenceFile(event.target.files?.[0] ?? null)} />
+          </label>
+
+          <label className="stack-tight">
+            <span>Evidence URL</span>
+            <input className="input" type="url" value={historicalEvidenceUrl} onChange={(event) => setHistoricalEvidenceUrl(event.target.value)} placeholder="https://example.com/results" />
+          </label>
+
+          <label className="stack-tight">
+            <span>Evidence caption</span>
+            <input className="input" value={historicalEvidenceCaption} onChange={(event) => setHistoricalEvidenceCaption(event.target.value)} maxLength={500} />
+          </label>
+
+          <div className="inline-form">
+            <button type="submit" className="btn btn-primary" disabled={loading}>
+              {loading ? "Saving..." : "Submit historical placement"}
             </button>
           </div>
         </form>

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -8,6 +8,7 @@ export * from "./script.js";
 export * from "./industry.js";
 export * from "./programs.js";
 export * from "./submission.js";
+export * from "./placement-evidence.js";
 export * from "./ranking.js";
 export * from "./feedback.js";
 export * from "./coverage.js";

--- a/packages/contracts/src/placement-evidence.ts
+++ b/packages/contracts/src/placement-evidence.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import { ScriptUploadSessionRequestSchema, ScriptUploadSessionResponseSchema } from "./script.js";
+import { SubmissionStatusSchema } from "./submission.js";
+
+export const PlacementEvidenceKindSchema = z.enum(["screenshot", "pdf", "document", "url", "other"]);
+
+export type PlacementEvidenceKind = z.infer<typeof PlacementEvidenceKindSchema>;
+
+export const PlacementEvidenceSchema = z.object({
+  id: z.string().min(1),
+  placementId: z.string().min(1),
+  scriptId: z.string().min(1).nullable(),
+  evidenceUrl: z.string().url().nullable(),
+  kind: PlacementEvidenceKindSchema,
+  caption: z.string().max(500).nullable(),
+  uploadedByUserId: z.string().min(1),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true })
+});
+
+export type PlacementEvidence = z.infer<typeof PlacementEvidenceSchema>;
+
+export const CreatePlacementEvidenceItemSchema = z.object({
+  scriptId: z.string().min(1).optional(),
+  evidenceUrl: z.string().url().optional(),
+  kind: PlacementEvidenceKindSchema,
+  caption: z.string().max(500).optional()
+}).refine((value) => Boolean(value.scriptId || value.evidenceUrl), {
+  message: "scriptId or evidenceUrl is required",
+  path: ["scriptId"]
+});
+
+export type CreatePlacementEvidenceItem = z.infer<typeof CreatePlacementEvidenceItemSchema>;
+
+export const CreateHistoricalPlacementRequestSchema = z.object({
+  projectId: z.string().min(1),
+  competitionId: z.string().min(1).optional(),
+  competitionNameFreeform: z.string().min(1).max(300).optional(),
+  status: SubmissionStatusSchema,
+  placementDate: z.string().min(1),
+  sourceNote: z.string().max(2000),
+  evidenceItems: z.array(CreatePlacementEvidenceItemSchema).min(1)
+}).refine((value) => Boolean(value.competitionId || value.competitionNameFreeform), {
+  message: "competitionId or competitionNameFreeform is required",
+  path: ["competitionId"]
+});
+
+export type CreateHistoricalPlacementRequest = z.infer<typeof CreateHistoricalPlacementRequestSchema>;
+
+export const EvidenceUploadRequestSchema = ScriptUploadSessionRequestSchema.extend({
+  visibility: z.literal("evidence").default("evidence")
+});
+
+export type EvidenceUploadRequest = z.infer<typeof EvidenceUploadRequestSchema>;
+
+export const EvidenceUploadResponseSchema = ScriptUploadSessionResponseSchema;
+
+export type EvidenceUploadResponse = z.infer<typeof EvidenceUploadResponseSchema>;
+
+export const ReviewPlacementRequestSchema = z.object({
+  action: z.enum(["approve", "reject"]),
+  notes: z.string().max(2000).optional()
+});
+
+export type ReviewPlacementRequest = z.infer<typeof ReviewPlacementRequestSchema>;
+
+export type CreateHistoricalPlacementData = CreateHistoricalPlacementRequest & {
+  recordedByUserId: string;
+};
+
+export type CreatePlacementEvidenceData = CreatePlacementEvidenceItem & {
+  placementId: string;
+  uploadedByUserId: string;
+};
+
+export type PlacementVerificationUpdateData = {
+  verificationState: "pending" | "verified" | "rejected";
+  reviewedByUserId?: string;
+  reviewNotes?: string;
+};

--- a/packages/contracts/src/script.ts
+++ b/packages/contracts/src/script.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const ScriptVisibilitySchema = z.enum(["private", "approved_only", "public"]);
+export const ScriptVisibilitySchema = z.enum(["private", "approved_only", "public", "evidence"]);
 
 export type ScriptVisibility = z.infer<typeof ScriptVisibilitySchema>;
 
@@ -8,7 +8,7 @@ export const ScriptUploadSessionRequestSchema = z.object({
   scriptId: z.string().min(1),
   ownerUserId: z.string().min(1),
   filename: z.string().min(1),
-  contentType: z.enum(["application/pdf", "application/fountain", "text/plain"]),
+  contentType: z.enum(["application/pdf", "application/fountain", "text/plain", "image/png", "image/jpeg", "image/webp"]),
   size: z.coerce.number().int().nonnegative()
 });
 
@@ -38,6 +38,8 @@ export type ScriptFileRegistration = z.infer<typeof ScriptFileRegistrationSchema
 
 export const ScriptRegisterRequestSchema = ScriptFileRegistrationSchema.omit({
   registeredAt: true
+}).extend({
+  visibility: ScriptVisibilitySchema.default("private")
 });
 
 export type ScriptRegisterRequest = z.infer<typeof ScriptRegisterRequestSchema>;

--- a/packages/contracts/src/submission.ts
+++ b/packages/contracts/src/submission.ts
@@ -64,7 +64,13 @@ export const PlacementSchema = z.object({
   verificationState: PlacementVerificationStateSchema,
   createdAt: z.string().datetime({ offset: true }),
   updatedAt: z.string().datetime({ offset: true }),
-  verifiedAt: z.string().datetime({ offset: true }).nullable()
+  verifiedAt: z.string().datetime({ offset: true }).nullable(),
+  isHistorical: z.boolean().default(false),
+  sourceNote: z.string().nullable().default(null),
+  recordedByUserId: z.string().nullable().default(null),
+  reviewedByUserId: z.string().nullable().default(null),
+  reviewedAt: z.string().datetime({ offset: true }).nullable().default(null),
+  reviewNotes: z.string().nullable().default(null)
 });
 
 export type Placement = z.infer<typeof PlacementSchema>;
@@ -76,7 +82,9 @@ export const PlacementCreateRequestSchema = z.object({
 export type PlacementCreateRequest = z.infer<typeof PlacementCreateRequestSchema>;
 
 export const PlacementVerificationUpdateRequestSchema = z.object({
-  verificationState: PlacementVerificationStateSchema
+  verificationState: PlacementVerificationStateSchema,
+  reviewedByUserId: z.string().min(1).optional(),
+  reviewNotes: z.string().max(2000).optional()
 });
 
 export type PlacementVerificationUpdateRequest = z.infer<
@@ -86,7 +94,8 @@ export type PlacementVerificationUpdateRequest = z.infer<
 export const PlacementListItemSchema = PlacementSchema.extend({
   writerId: z.string().min(1),
   projectId: z.string().min(1),
-  competitionId: z.string().min(1)
+  competitionId: z.string().min(1),
+  badgeLabel: z.string().min(1)
 });
 
 export type PlacementListItem = z.infer<typeof PlacementListItemSchema>;
@@ -97,7 +106,8 @@ export const PlacementFiltersSchema = z.object({
   projectId: z.string().trim().min(1).optional(),
   competitionId: z.string().trim().min(1).optional(),
   status: SubmissionStatusSchema.optional(),
-  verificationState: PlacementVerificationStateSchema.optional()
+  verificationState: PlacementVerificationStateSchema.optional(),
+  isHistorical: z.coerce.boolean().optional()
 });
 
 export type PlacementFilters = z.infer<typeof PlacementFiltersSchema>;

--- a/packages/contracts/src/submission.ts
+++ b/packages/contracts/src/submission.ts
@@ -95,7 +95,7 @@ export const PlacementListItemSchema = PlacementSchema.extend({
   writerId: z.string().min(1),
   projectId: z.string().min(1),
   competitionId: z.string().min(1),
-  badgeLabel: z.string().min(1)
+  badgeLabel: z.string().min(1).optional()
 });
 
 export type PlacementListItem = z.infer<typeof PlacementListItemSchema>;

--- a/packages/db/migrations/024_placement_evidence.sql
+++ b/packages/db/migrations/024_placement_evidence.sql
@@ -1,0 +1,38 @@
+-- Migration 024: evidence-backed historical placements
+
+ALTER TABLE placements
+  ADD COLUMN IF NOT EXISTS is_historical BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS source_note VARCHAR(2000),
+  ADD COLUMN IF NOT EXISTS recorded_by_user_id TEXT REFERENCES app_users(id),
+  ADD COLUMN IF NOT EXISTS reviewed_by_user_id TEXT REFERENCES app_users(id),
+  ADD COLUMN IF NOT EXISTS reviewed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS review_notes VARCHAR(2000);
+
+CREATE TABLE IF NOT EXISTS placement_evidence (
+  id TEXT PRIMARY KEY,
+  placement_id TEXT NOT NULL REFERENCES placements(id) ON DELETE CASCADE,
+  script_id TEXT REFERENCES scripts(id),
+  evidence_url VARCHAR(2048),
+  kind TEXT NOT NULL CHECK (kind IN ('screenshot', 'pdf', 'document', 'url', 'other')),
+  caption VARCHAR(500),
+  uploaded_by_user_id TEXT NOT NULL REFERENCES app_users(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CHECK (script_id IS NOT NULL OR evidence_url IS NOT NULL)
+);
+
+CREATE INDEX IF NOT EXISTS placement_evidence_placement_idx ON placement_evidence(placement_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'scripts_visibility_check'
+      AND conrelid = 'scripts'::regclass
+  ) THEN
+    ALTER TABLE scripts
+      ADD CONSTRAINT scripts_visibility_check
+      CHECK (visibility IN ('private', 'approved_only', 'public', 'evidence'));
+  END IF;
+END $$;

--- a/services/api-gateway/src/routes/submissions.test.ts
+++ b/services/api-gateway/src/routes/submissions.test.ts
@@ -296,8 +296,13 @@ test("POST /api/v1/placements/:placementId/verify proxies and triggers ranking r
   });
 
   assert.equal(response.statusCode, 200);
-  assert.equal(urls[0], "http://submission-svc/internal/placements/placement_01/verify");
-  assert.equal(headers[0]?.["x-auth-user-id"], "writer_01");
+  // CHAOS-1805: verify route pre-fetches the placement to determine historical/admin gating,
+  // then proxies the verify call. Assert both happen and carry writer auth.
+  const verifyCallIdx = urls.findIndex(
+    (u) => u === "http://submission-svc/internal/placements/placement_01/verify"
+  );
+  assert.ok(verifyCallIdx >= 0, `expected verify proxy call, got urls=${JSON.stringify(urls)}`);
+  assert.equal(headers[verifyCallIdx]?.["x-auth-user-id"], "writer_01");
 
   // Wait briefly for the fire-and-forget ranking recompute
   await new Promise((resolve) => setTimeout(resolve, 50));

--- a/services/api-gateway/src/routes/submissions.ts
+++ b/services/api-gateway/src/routes/submissions.ts
@@ -1,5 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import {
+  CreateHistoricalPlacementRequestSchema,
+  CreatePlacementEvidenceItemSchema,
   PlacementCreateRequestSchema,
   PlacementVerificationUpdateRequestSchema,
   SubmissionCreateRequestSchema,
@@ -10,7 +12,8 @@ import {
   addAuthUserIdHeader,
   buildQuerySuffix,
   getUserIdFromAuth,
-  proxyJsonRequest
+  proxyJsonRequest,
+  resolveAdminByRole
 } from "../helpers.js";
 
 export function registerSubmissionRoutes(server: FastifyInstance, ctx: GatewayContext): void {
@@ -132,6 +135,30 @@ export function registerSubmissionRoutes(server: FastifyInstance, ctx: GatewayCo
     return result;
   });
 
+  server.post("/api/v1/placements/historical", async (req, reply) => {
+    const userId = await getUserIdFromAuth(ctx.requestFn, ctx.identityServiceBase, req.headers.authorization, req.log);
+    const parsed = CreateHistoricalPlacementRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: "invalid_payload", details: parsed.error.flatten() });
+    }
+
+    const result = await proxyJsonRequest(reply, ctx.requestFn, `${ctx.submissionTrackingBase}/internal/placements/historical`, {
+      method: "POST",
+      headers: addAuthUserIdHeader({ "content-type": "application/json" }, userId),
+      body: JSON.stringify(parsed.data)
+    });
+
+    if (reply.statusCode < 400 && userId) {
+      ctx.requestFn(`${ctx.rankingServiceBase}/internal/recompute/incremental`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ writerId: userId })
+      }).catch((err) => { req.log.warn({ err, writerId: userId }, "background ranking recompute failed"); });
+    }
+
+    return result;
+  });
+
   server.get<{ Params: { placementId: string } }>("/api/v1/placements/:placementId", async (req, reply) => {
     const { placementId } = req.params;
     const userId = await getUserIdFromAuth(ctx.requestFn, ctx.identityServiceBase, req.headers.authorization, req.log);
@@ -146,6 +173,29 @@ export function registerSubmissionRoutes(server: FastifyInstance, ctx: GatewayCo
     );
   });
 
+  server.get<{ Params: { placementId: string } }>("/api/v1/placements/:placementId/evidence", async (req, reply) => {
+    const { placementId } = req.params;
+    const userId = await getUserIdFromAuth(ctx.requestFn, ctx.identityServiceBase, req.headers.authorization, req.log);
+    return proxyJsonRequest(reply, ctx.requestFn, `${ctx.submissionTrackingBase}/internal/placements/${encodeURIComponent(placementId)}/evidence`, {
+      method: "GET",
+      headers: addAuthUserIdHeader({}, userId)
+    });
+  });
+
+  server.post<{ Params: { placementId: string } }>("/api/v1/placements/:placementId/evidence", async (req, reply) => {
+    const { placementId } = req.params;
+    const userId = await getUserIdFromAuth(ctx.requestFn, ctx.identityServiceBase, req.headers.authorization, req.log);
+    const parsed = CreatePlacementEvidenceItemSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: "invalid_payload", details: parsed.error.flatten() });
+    }
+    return proxyJsonRequest(reply, ctx.requestFn, `${ctx.submissionTrackingBase}/internal/placements/${encodeURIComponent(placementId)}/evidence`, {
+      method: "POST",
+      headers: addAuthUserIdHeader({ "content-type": "application/json" }, userId),
+      body: JSON.stringify(parsed.data)
+    });
+  });
+
   server.post<{ Params: { placementId: string } }>("/api/v1/placements/:placementId/verify", async (req, reply) => {
     const { placementId } = req.params;
     const userId = await getUserIdFromAuth(ctx.requestFn, ctx.identityServiceBase, req.headers.authorization, req.log);
@@ -156,14 +206,34 @@ export function registerSubmissionRoutes(server: FastifyInstance, ctx: GatewayCo
         details: parsed.error.flatten()
       });
     }
+    const placementResponse = await ctx.requestFn(`${ctx.submissionTrackingBase}/internal/placements/${encodeURIComponent(placementId)}`, {
+      method: "GET",
+      headers: addAuthUserIdHeader({}, userId)
+    });
+    if (placementResponse.statusCode === 404) {
+      return reply.status(404).send({ error: "placement_not_found" });
+    }
+    if (placementResponse.statusCode >= 400) {
+      return reply.status(placementResponse.statusCode).send(await placementResponse.body.json());
+    }
+    const placementPayload = (await placementResponse.body.json()) as { placement?: { isHistorical?: boolean } };
+    let reviewerUserId = userId;
+    if (placementPayload.placement?.isHistorical) {
+      reviewerUserId = await resolveAdminByRole(ctx.requestFn, ctx.identityServiceBase, req.headers as Record<string, unknown>, req.log);
+      if (!reviewerUserId) return reply.status(403).send({ error: "forbidden" });
+    }
+
     const result = await proxyJsonRequest(
       reply,
       ctx.requestFn,
       `${ctx.submissionTrackingBase}/internal/placements/${encodeURIComponent(placementId)}/verify`,
       {
         method: "POST",
-        headers: addAuthUserIdHeader({ "content-type": "application/json" }, userId),
-        body: JSON.stringify(parsed.data)
+        headers: addAuthUserIdHeader({ "content-type": "application/json" }, reviewerUserId, placementPayload.placement?.isHistorical ? "admin" : "writer"),
+        body: JSON.stringify({
+          ...parsed.data,
+          reviewedByUserId: parsed.data.reviewedByUserId ?? reviewerUserId ?? undefined
+        })
       }
     );
 

--- a/services/script-storage-service/src/index.ts
+++ b/services/script-storage-service/src/index.ts
@@ -213,7 +213,7 @@ export function buildServer(options: ScriptStorageServiceOptions = {}): FastifyI
     });
     const script: ScriptRecord = {
       ...registration,
-      visibility: "private",
+      visibility: parseResult.data.visibility,
       approvedViewers: []
     };
     await repo.registerScript(script);

--- a/services/submission-tracking-service/src/historicalPlacement.test.ts
+++ b/services/submission-tracking-service/src/historicalPlacement.test.ts
@@ -1,0 +1,285 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import test from "node:test";
+import type {
+  CreateHistoricalPlacementData,
+  CreatePlacementEvidenceData,
+  Placement,
+  PlacementEvidence,
+  PlacementFilters,
+  PlacementVerificationUpdateData,
+  Submission,
+  SubmissionFilters
+} from "@script-manifest/contracts";
+import { buildServer } from "./index.js";
+import type { SubmissionTrackingRepository } from "./repository.js";
+
+class MemoryHistoricalPlacementRepository implements SubmissionTrackingRepository {
+  private readonly submissions = new Map<string, Submission>();
+  private readonly placements = new Map<string, Placement>();
+  private readonly evidence = new Map<string, PlacementEvidence>();
+
+  async init(): Promise<void> {
+  }
+
+  async healthCheck(): Promise<{ database: boolean }> {
+    return { database: true };
+  }
+
+  async createSubmission(data: {
+    writerId: string;
+    projectId: string;
+    competitionId: string;
+    status: string;
+  }): Promise<Submission> {
+    const now = new Date().toISOString();
+    const submission: Submission = {
+      id: `submission_${randomUUID()}`,
+      writerId: data.writerId,
+      projectId: data.projectId,
+      competitionId: data.competitionId,
+      status: data.status as Submission["status"],
+      createdAt: now,
+      updatedAt: now
+    };
+    this.submissions.set(submission.id, submission);
+    return submission;
+  }
+
+  async getSubmission(id: string): Promise<Submission | null> {
+    return this.submissions.get(id) ?? null;
+  }
+
+  async updateSubmissionProject(id: string, projectId: string): Promise<Submission | null> {
+    const submission = this.submissions.get(id);
+    if (!submission) return null;
+    const updated = { ...submission, projectId, updatedAt: new Date().toISOString() };
+    this.submissions.set(id, updated);
+    return updated;
+  }
+
+  async updateSubmissionStatus(id: string, status: string): Promise<Submission | null> {
+    const submission = this.submissions.get(id);
+    if (!submission) return null;
+    const updated = { ...submission, status: status as Submission["status"], updatedAt: new Date().toISOString() };
+    this.submissions.set(id, updated);
+    return updated;
+  }
+
+  async listSubmissions(filters: SubmissionFilters): Promise<Submission[]> {
+    return Array.from(this.submissions.values()).filter((submission) => {
+      if (filters.writerId && submission.writerId !== filters.writerId) return false;
+      if (filters.projectId && submission.projectId !== filters.projectId) return false;
+      if (filters.competitionId && submission.competitionId !== filters.competitionId) return false;
+      if (filters.status && submission.status !== filters.status) return false;
+      return true;
+    });
+  }
+
+  async createPlacement(submissionId: string, status: string): Promise<Placement> {
+    const now = new Date().toISOString();
+    const placement: Placement = {
+      id: `placement_${randomUUID()}`,
+      submissionId,
+      status: status as Placement["status"],
+      verificationState: "pending",
+      createdAt: now,
+      updatedAt: now,
+      verifiedAt: null,
+      isHistorical: false,
+      sourceNote: null,
+      recordedByUserId: null,
+      reviewedByUserId: null,
+      reviewedAt: null,
+      reviewNotes: null
+    };
+    this.placements.set(placement.id, placement);
+    return placement;
+  }
+
+  async createHistoricalPlacement(data: CreateHistoricalPlacementData): Promise<{ submission: Submission; placement: Placement }> {
+    const submission = await this.createSubmission({
+      writerId: data.recordedByUserId,
+      projectId: data.projectId,
+      competitionId: data.competitionId ?? `historical:${data.competitionNameFreeform}`,
+      status: data.status
+    });
+    const now = new Date().toISOString();
+    const placement: Placement = {
+      id: `placement_${randomUUID()}`,
+      submissionId: submission.id,
+      status: data.status,
+      verificationState: "pending",
+      createdAt: now,
+      updatedAt: now,
+      verifiedAt: null,
+      isHistorical: true,
+      sourceNote: data.sourceNote,
+      recordedByUserId: data.recordedByUserId,
+      reviewedByUserId: null,
+      reviewedAt: null,
+      reviewNotes: null
+    };
+    this.placements.set(placement.id, placement);
+    for (const item of data.evidenceItems) {
+      await this.createPlacementEvidence({
+        placementId: placement.id,
+        uploadedByUserId: data.recordedByUserId,
+        ...item
+      });
+    }
+    return { submission, placement };
+  }
+
+  async getPlacement(id: string): Promise<Placement | null> {
+    return this.placements.get(id) ?? null;
+  }
+
+  async updatePlacementVerification(id: string, data: PlacementVerificationUpdateData): Promise<Placement | null> {
+    const placement = this.placements.get(id);
+    if (!placement) return null;
+    const now = new Date().toISOString();
+    const updated: Placement = {
+      ...placement,
+      verificationState: data.verificationState,
+      updatedAt: now,
+      verifiedAt: data.verificationState === "verified" ? now : null,
+      reviewedByUserId: data.reviewedByUserId ?? null,
+      reviewedAt: data.reviewedByUserId ? now : null,
+      reviewNotes: data.reviewNotes ?? null
+    };
+    this.placements.set(id, updated);
+    return updated;
+  }
+
+  async createPlacementEvidence(data: CreatePlacementEvidenceData): Promise<PlacementEvidence> {
+    const now = new Date().toISOString();
+    const evidence: PlacementEvidence = {
+      id: `evidence_${randomUUID()}`,
+      placementId: data.placementId,
+      scriptId: data.scriptId ?? null,
+      evidenceUrl: data.evidenceUrl ?? null,
+      kind: data.kind,
+      caption: data.caption ?? null,
+      uploadedByUserId: data.uploadedByUserId,
+      createdAt: now,
+      updatedAt: now
+    };
+    this.evidence.set(evidence.id, evidence);
+    return evidence;
+  }
+
+  async listPlacementEvidence(placementId: string): Promise<PlacementEvidence[]> {
+    return Array.from(this.evidence.values()).filter((entry) => entry.placementId === placementId);
+  }
+
+  async listPlacementsBySubmission(submissionId: string): Promise<Placement[]> {
+    return Array.from(this.placements.values()).filter((placement) => placement.submissionId === submissionId);
+  }
+
+  async listPlacements(filters: PlacementFilters): Promise<{ placement: Placement; submission: Submission }[]> {
+    return Array.from(this.placements.values()).flatMap((placement) => {
+      const submission = this.submissions.get(placement.submissionId);
+      if (!submission) return [];
+      if (filters.submissionId && placement.submissionId !== filters.submissionId) return [];
+      if (filters.writerId && submission.writerId !== filters.writerId) return [];
+      if (filters.projectId && submission.projectId !== filters.projectId) return [];
+      if (filters.competitionId && submission.competitionId !== filters.competitionId) return [];
+      if (filters.status && placement.status !== filters.status) return [];
+      if (filters.verificationState && placement.verificationState !== filters.verificationState) return [];
+      if (filters.isHistorical !== undefined && placement.isHistorical !== filters.isHistorical) return [];
+      return [{ placement, submission }];
+    });
+  }
+}
+
+test("creates a pending historical placement with evidence and reviewer approval", async (t) => {
+  const server = buildServer({ logger: false, repository: new MemoryHistoricalPlacementRepository() });
+  t.after(async () => {
+    await server.close();
+  });
+
+  const createResponse = await server.inject({
+    method: "POST",
+    url: "/internal/placements/historical",
+    headers: { "x-auth-user-id": "writer_01" },
+    payload: {
+      projectId: "project_01",
+      competitionId: "competition_01",
+      status: "finalist",
+      placementDate: "2024-05-15",
+      sourceNote: "Published finalist list screenshot from 2024.",
+      evidenceItems: [
+        {
+          scriptId: "script_evidence_01",
+          kind: "pdf",
+          caption: "Finalist announcement PDF"
+        }
+      ]
+    }
+  });
+
+  assert.equal(createResponse.statusCode, 201);
+  assert.equal(createResponse.json().placement.isHistorical, true);
+  assert.equal(createResponse.json().placement.verificationState, "pending");
+  assert.equal(createResponse.json().placement.sourceNote, "Published finalist list screenshot from 2024.");
+  assert.equal(createResponse.json().evidence.length, 1);
+  assert.equal(createResponse.json().evidence[0].kind, "pdf");
+  assert.equal(createResponse.json().evidence[0].uploadedByUserId, "writer_01");
+  const placementId = createResponse.json().placement.id as string;
+
+  const evidenceResponse = await server.inject({
+    method: "GET",
+    url: `/internal/placements/${placementId}/evidence`,
+    headers: { "x-auth-user-id": "writer_01" }
+  });
+  assert.equal(evidenceResponse.statusCode, 200);
+  assert.equal(evidenceResponse.json().evidence.length, 1);
+
+  const approveResponse = await server.inject({
+    method: "POST",
+    url: `/internal/placements/${placementId}/verify`,
+    headers: { "x-auth-user-id": "admin_01" },
+    payload: {
+      verificationState: "verified",
+      reviewedByUserId: "admin_01",
+      reviewNotes: "Evidence matches competition result page."
+    }
+  });
+
+  assert.equal(approveResponse.statusCode, 200);
+  assert.equal(approveResponse.json().placement.verificationState, "verified");
+  assert.equal(approveResponse.json().placement.reviewedByUserId, "admin_01");
+  assert.equal(approveResponse.json().placement.reviewNotes, "Evidence matches competition result page.");
+  assert.match(approveResponse.json().placement.badgeLabel, /Verified/);
+});
+
+test("rejects unsupported placement evidence kinds", async (t) => {
+  const server = buildServer({ logger: false, repository: new MemoryHistoricalPlacementRepository() });
+  t.after(async () => {
+    await server.close();
+  });
+
+  const createResponse = await server.inject({
+    method: "POST",
+    url: "/internal/placements/historical",
+    headers: { "x-auth-user-id": "writer_01" },
+    payload: {
+      projectId: "project_01",
+      competitionId: "competition_01",
+      status: "semifinalist",
+      placementDate: "2024-05-15",
+      sourceNote: "Archive note.",
+      evidenceItems: [
+        {
+          kind: "spreadsheet",
+          evidenceUrl: "https://example.com/results",
+          caption: "Invalid evidence kind"
+        }
+      ]
+    }
+  });
+
+  assert.equal(createResponse.statusCode, 400);
+  assert.equal(createResponse.json().error, "invalid_payload");
+});

--- a/services/submission-tracking-service/src/index.test.ts
+++ b/services/submission-tracking-service/src/index.test.ts
@@ -1,13 +1,23 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import test from "node:test";
-import type { Placement, PlacementFilters, Submission, SubmissionFilters } from "@script-manifest/contracts";
+import type {
+  CreateHistoricalPlacementData,
+  CreatePlacementEvidenceData,
+  Placement,
+  PlacementEvidence,
+  PlacementFilters,
+  PlacementVerificationUpdateData,
+  Submission,
+  SubmissionFilters
+} from "@script-manifest/contracts";
 import { buildServer } from "./index.js";
 import type { SubmissionTrackingRepository } from "./repository.js";
 
 class MemorySubmissionTrackingRepository implements SubmissionTrackingRepository {
   private readonly submissions = new Map<string, Submission>();
   private readonly placements = new Map<string, Placement>();
+  private readonly evidence = new Map<string, PlacementEvidence>();
 
   async init(): Promise<void> {
   }
@@ -96,6 +106,12 @@ class MemorySubmissionTrackingRepository implements SubmissionTrackingRepository
       createdAt: now,
       updatedAt: now,
       verifiedAt: null,
+      isHistorical: false,
+      sourceNote: null,
+      recordedByUserId: null,
+      reviewedByUserId: null,
+      reviewedAt: null,
+      reviewNotes: null,
     };
     this.placements.set(placement.id, placement);
     return placement;
@@ -105,7 +121,28 @@ class MemorySubmissionTrackingRepository implements SubmissionTrackingRepository
     return this.placements.get(id) ?? null;
   }
 
-  async updatePlacementVerification(id: string, verificationState: string): Promise<Placement | null> {
+  async createHistoricalPlacement(data: CreateHistoricalPlacementData): Promise<{ submission: Submission; placement: Placement }> {
+    const submission = await this.createSubmission({
+      writerId: data.recordedByUserId,
+      projectId: data.projectId,
+      competitionId: data.competitionId ?? `historical:${data.competitionNameFreeform}`,
+      status: data.status
+    });
+    const placement = await this.createPlacement(submission.id, data.status);
+    const historicalPlacement: Placement = {
+      ...placement,
+      isHistorical: true,
+      sourceNote: data.sourceNote,
+      recordedByUserId: data.recordedByUserId
+    };
+    this.placements.set(placement.id, historicalPlacement);
+    for (const item of data.evidenceItems) {
+      await this.createPlacementEvidence({ placementId: placement.id, uploadedByUserId: data.recordedByUserId, ...item });
+    }
+    return { submission, placement: historicalPlacement };
+  }
+
+  async updatePlacementVerification(id: string, data: PlacementVerificationUpdateData): Promise<Placement | null> {
     const placement = this.placements.get(id);
     if (!placement) {
       return null;
@@ -113,12 +150,36 @@ class MemorySubmissionTrackingRepository implements SubmissionTrackingRepository
     const now = new Date().toISOString();
     const updated: Placement = {
       ...placement,
-      verificationState: verificationState as Placement["verificationState"],
+      verificationState: data.verificationState,
       updatedAt: now,
-      verifiedAt: verificationState === "verified" ? now : null,
+      verifiedAt: data.verificationState === "verified" ? now : null,
+      reviewedByUserId: data.reviewedByUserId ?? null,
+      reviewedAt: data.reviewedByUserId ? now : null,
+      reviewNotes: data.reviewNotes ?? null,
     };
     this.placements.set(id, updated);
     return updated;
+  }
+
+  async createPlacementEvidence(data: CreatePlacementEvidenceData): Promise<PlacementEvidence> {
+    const now = new Date().toISOString();
+    const evidence: PlacementEvidence = {
+      id: `evidence_${randomUUID()}`,
+      placementId: data.placementId,
+      scriptId: data.scriptId ?? null,
+      evidenceUrl: data.evidenceUrl ?? null,
+      kind: data.kind,
+      caption: data.caption ?? null,
+      uploadedByUserId: data.uploadedByUserId,
+      createdAt: now,
+      updatedAt: now
+    };
+    this.evidence.set(evidence.id, evidence);
+    return evidence;
+  }
+
+  async listPlacementEvidence(placementId: string): Promise<PlacementEvidence[]> {
+    return Array.from(this.evidence.values()).filter((item) => item.placementId === placementId);
   }
 
   async listPlacementsBySubmission(submissionId: string): Promise<Placement[]> {
@@ -148,6 +209,9 @@ class MemorySubmissionTrackingRepository implements SubmissionTrackingRepository
         return [];
       }
       if (filters.verificationState && placement.verificationState !== filters.verificationState) {
+        return [];
+      }
+      if (filters.isHistorical !== undefined && placement.isHistorical !== filters.isHistorical) {
         return [];
       }
 

--- a/services/submission-tracking-service/src/index.ts
+++ b/services/submission-tracking-service/src/index.ts
@@ -3,7 +3,10 @@ import { Counter } from "prom-client";
 import { bootstrapService, registerMetrics, registerSentryErrorHandler, setupErrorReporting, validateRequiredEnv, getAuthUserId, isMainModule, createFastifyServer } from "@script-manifest/service-utils";
 import { closePool } from "@script-manifest/db";
 import {
+  CreateHistoricalPlacementRequestSchema,
+  CreatePlacementEvidenceItemSchema,
   PlacementFiltersSchema,
+  PlacementEvidenceSchema,
   PlacementListItemSchema,
   PlacementCreateRequestSchema,
   PlacementSchema,
@@ -178,6 +181,87 @@ export function buildServer(options: SubmissionTrackingOptions = {}): FastifyIns
     return reply.status(201).send({ placement, submission: SubmissionSchema.parse(updatedSubmission) });
   });
 
+  server.post("/internal/placements/historical", async (req, reply) => {
+    const authUserId = getAuthUserId(req);
+    if (!authUserId) {
+      return reply.status(403).send({ error: "forbidden" });
+    }
+
+    const parsedBody = CreateHistoricalPlacementRequestSchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      return reply.status(400).send({
+        error: "invalid_payload",
+        details: parsedBody.error.flatten()
+      });
+    }
+
+    const created = await repository.createHistoricalPlacement({
+      ...parsedBody.data,
+      recordedByUserId: authUserId
+    });
+    const evidence = await repository.listPlacementEvidence(created.placement.id);
+
+    submissionsCounter.inc();
+    return reply.status(201).send({
+      submission: SubmissionSchema.parse(created.submission),
+      placement: toPlacementDetail(PlacementSchema.parse(created.placement)),
+      evidence: evidence.map((item) => PlacementEvidenceSchema.parse(item))
+    });
+  });
+
+  server.post<{ Params: { placementId: string } }>("/internal/placements/:placementId/evidence", async (req, reply) => {
+    const authUserId = getAuthUserId(req);
+    if (!authUserId) {
+      return reply.status(403).send({ error: "forbidden" });
+    }
+
+    const placement = await repository.getPlacement(req.params.placementId);
+    if (!placement) {
+      return reply.status(404).send({ error: "placement_not_found" });
+    }
+
+    const submission = await repository.getSubmission(placement.submissionId);
+    if (!submission) {
+      return reply.status(404).send({ error: "submission_not_found" });
+    }
+
+    if (submission.writerId !== authUserId) {
+      return reply.status(403).send({ error: "forbidden" });
+    }
+
+    const parsedBody = CreatePlacementEvidenceItemSchema.safeParse(req.body);
+    if (!parsedBody.success) {
+      return reply.status(400).send({ error: "invalid_payload", details: parsedBody.error.flatten() });
+    }
+
+    const evidence = await repository.createPlacementEvidence({
+      ...parsedBody.data,
+      placementId: req.params.placementId,
+      uploadedByUserId: authUserId
+    });
+    return reply.status(201).send({ evidence: PlacementEvidenceSchema.parse(evidence) });
+  });
+
+  server.get<{ Params: { placementId: string } }>("/internal/placements/:placementId/evidence", async (req, reply) => {
+    const placement = await repository.getPlacement(req.params.placementId);
+    if (!placement) {
+      return reply.status(404).send({ error: "placement_not_found" });
+    }
+
+    const submission = await repository.getSubmission(placement.submissionId);
+    if (!submission) {
+      return reply.status(404).send({ error: "submission_not_found" });
+    }
+
+    const authUserId = getAuthUserId(req);
+    if (authUserId && authUserId !== submission.writerId) {
+      return reply.status(403).send({ error: "forbidden" });
+    }
+
+    const evidence = await repository.listPlacementEvidence(req.params.placementId);
+    return reply.send({ evidence: evidence.map((item) => PlacementEvidenceSchema.parse(item)) });
+  });
+
   server.get<{ Params: { submissionId: string } }>("/internal/submissions/:submissionId/placements", async (req, reply) => {
     const { submissionId } = req.params;
     const submission = await repository.getSubmission(submissionId);
@@ -256,12 +340,12 @@ export function buildServer(options: SubmissionTrackingOptions = {}): FastifyIns
       });
     }
 
-    const updatedPlacement = await repository.updatePlacementVerification(placementId, parsedBody.data.verificationState);
+    const updatedPlacement = await repository.updatePlacementVerification(placementId, parsedBody.data);
     if (!updatedPlacement) {
       return reply.status(404).send({ error: "placement_not_found" });
     }
 
-    return reply.send({ placement: PlacementSchema.parse(updatedPlacement) });
+    return reply.send({ placement: toPlacementDetail(PlacementSchema.parse(updatedPlacement)) });
   });
 
   return server;
@@ -272,8 +356,20 @@ function toPlacementListItem(placement: Placement, submission: Submission): Plac
     ...placement,
     writerId: submission.writerId,
     projectId: submission.projectId,
-    competitionId: submission.competitionId
+    competitionId: submission.competitionId,
+    badgeLabel: placementBadgeLabel(placement)
   });
+}
+
+function toPlacementDetail(placement: Placement): Placement & { badgeLabel: string } {
+  return { ...placement, badgeLabel: placementBadgeLabel(placement) };
+}
+
+function placementBadgeLabel(placement: Placement): string {
+  if (placement.verificationState === "verified") return "Verified";
+  if (placement.verificationState === "rejected") return "Rejected";
+  if (placement.isHistorical) return "Unverified — Historical";
+  return "Unverified";
 }
 
 export async function startServer(): Promise<void> {

--- a/services/submission-tracking-service/src/pgRepository.ts
+++ b/services/submission-tracking-service/src/pgRepository.ts
@@ -1,8 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { getPool, runMigrations } from "@script-manifest/db";
 import type {
+  CreateHistoricalPlacementData,
+  CreatePlacementEvidenceData,
   Placement,
+  PlacementEvidence,
   PlacementFilters,
+  PlacementVerificationUpdateData,
   Submission,
   SubmissionFilters,
 } from "@script-manifest/contracts";
@@ -10,9 +14,7 @@ import type { SubmissionTrackingRepository } from "./repository.js";
 
 export class PgSubmissionTrackingRepository implements SubmissionTrackingRepository {
   async init(): Promise<void> {
-    if (process.env.SKIP_SCHEMA_INIT === "1") {
-      return;
-    }
+    if (process.env.SKIP_SCHEMA_INIT === "1") return;
     await runMigrations(getPool());
   }
 
@@ -25,15 +27,9 @@ export class PgSubmissionTrackingRepository implements SubmissionTrackingReposit
     }
   }
 
-  async createSubmission(data: {
-    writerId: string;
-    projectId: string;
-    competitionId: string;
-    status: string;
-  }): Promise<Submission> {
-    const db = getPool();
+  async createSubmission(data: { writerId: string; projectId: string; competitionId: string; status: string }): Promise<Submission> {
     const id = `submission_${randomUUID()}`;
-    const result = await db.query<SubmissionRow>(
+    const result = await getPool().query<SubmissionRow>(
       `INSERT INTO submissions (id, writer_id, project_id, competition_id, status)
        VALUES ($1, $2, $3, $4, $5)
        RETURNING *`,
@@ -43,76 +39,42 @@ export class PgSubmissionTrackingRepository implements SubmissionTrackingReposit
   }
 
   async getSubmission(id: string): Promise<Submission | null> {
-    const db = getPool();
-    const result = await db.query<SubmissionRow>(
-      `SELECT * FROM submissions WHERE id = $1`,
-      [id],
-    );
+    const result = await getPool().query<SubmissionRow>(`SELECT * FROM submissions WHERE id = $1`, [id]);
     return result.rows[0] ? mapSubmission(result.rows[0]) : null;
   }
 
   async updateSubmissionProject(id: string, projectId: string): Promise<Submission | null> {
-    const db = getPool();
-    const result = await db.query<SubmissionRow>(
-      `UPDATE submissions
-       SET project_id = $2,
-           updated_at = NOW()
-       WHERE id = $1
-       RETURNING *`,
+    const result = await getPool().query<SubmissionRow>(
+      `UPDATE submissions SET project_id = $2, updated_at = NOW() WHERE id = $1 RETURNING *`,
       [id, projectId],
     );
     return result.rows[0] ? mapSubmission(result.rows[0]) : null;
   }
 
   async updateSubmissionStatus(id: string, status: string): Promise<Submission | null> {
-    const db = getPool();
-    const result = await db.query<SubmissionRow>(
-      `UPDATE submissions
-       SET status = $2,
-           updated_at = NOW()
-       WHERE id = $1
-       RETURNING *`,
+    const result = await getPool().query<SubmissionRow>(
+      `UPDATE submissions SET status = $2, updated_at = NOW() WHERE id = $1 RETURNING *`,
       [id, status],
     );
     return result.rows[0] ? mapSubmission(result.rows[0]) : null;
   }
 
   async listSubmissions(filters: SubmissionFilters): Promise<Submission[]> {
-    const db = getPool();
     const conditions: string[] = [];
     const values: unknown[] = [];
+    if (filters.writerId) pushCondition(conditions, values, "writer_id", filters.writerId);
+    if (filters.projectId) pushCondition(conditions, values, "project_id", filters.projectId);
+    if (filters.competitionId) pushCondition(conditions, values, "competition_id", filters.competitionId);
+    if (filters.status) pushCondition(conditions, values, "status", filters.status);
 
-    if (filters.writerId) {
-      values.push(filters.writerId);
-      conditions.push(`writer_id = $${values.length}`);
-    }
-    if (filters.projectId) {
-      values.push(filters.projectId);
-      conditions.push(`project_id = $${values.length}`);
-    }
-    if (filters.competitionId) {
-      values.push(filters.competitionId);
-      conditions.push(`competition_id = $${values.length}`);
-    }
-    if (filters.status) {
-      values.push(filters.status);
-      conditions.push(`status = $${values.length}`);
-    }
-
-    let query = `SELECT * FROM submissions`;
-    if (conditions.length > 0) {
-      query += ` WHERE ${conditions.join(" AND ")}`;
-    }
-    query += ` ORDER BY created_at DESC`;
-
-    const result = await db.query<SubmissionRow>(query, values);
+    const query = `SELECT * FROM submissions${conditions.length ? ` WHERE ${conditions.join(" AND ")}` : ""} ORDER BY created_at DESC`;
+    const result = await getPool().query<SubmissionRow>(query, values);
     return result.rows.map(mapSubmission);
   }
 
   async createPlacement(submissionId: string, status: string): Promise<Placement> {
-    const db = getPool();
     const id = `placement_${randomUUID()}`;
-    const result = await db.query<PlacementRow>(
+    const result = await getPool().query<PlacementRow>(
       `INSERT INTO placements (id, submission_id, status, verification_state)
        VALUES ($1, $2, $3, 'pending')
        RETURNING *`,
@@ -121,120 +83,99 @@ export class PgSubmissionTrackingRepository implements SubmissionTrackingReposit
     return mapPlacement(result.rows[0]!);
   }
 
-  async getPlacement(id: string): Promise<Placement | null> {
+  async createHistoricalPlacement(data: CreateHistoricalPlacementData): Promise<{ submission: Submission; placement: Placement }> {
     const db = getPool();
-    const result = await db.query<PlacementRow>(
-      `SELECT * FROM placements WHERE id = $1`,
-      [id],
+    const submissionId = `submission_${randomUUID()}`;
+    const placementId = `placement_${randomUUID()}`;
+    const competitionId = data.competitionId ?? `historical:${data.competitionNameFreeform}`;
+
+    const result = await db.query<HistoricalPlacementRow>(
+      `WITH created_submission AS (
+         INSERT INTO submissions (id, writer_id, project_id, competition_id, status)
+         VALUES ($1, $2, $3, $4, $5)
+         RETURNING *
+       ), created_placement AS (
+         INSERT INTO placements (id, submission_id, status, verification_state, is_historical, source_note, recorded_by_user_id)
+         VALUES ($6, $1, $5, 'pending', TRUE, $7, $2)
+         RETURNING *
+       )
+       ${selectPlacementWithSubmission("created_placement", "created_submission")}`,
+      [submissionId, data.recordedByUserId, data.projectId, competitionId, data.status, placementId, data.sourceNote]
     );
+
+    const mapped = mapPlacementWithSubmission(result.rows[0]!);
+    for (const item of data.evidenceItems) {
+      await this.createPlacementEvidence({ placementId: mapped.placement.id, uploadedByUserId: data.recordedByUserId, ...item });
+    }
+    return mapped;
+  }
+
+  async getPlacement(id: string): Promise<Placement | null> {
+    const result = await getPool().query<PlacementRow>(`SELECT * FROM placements WHERE id = $1`, [id]);
     return result.rows[0] ? mapPlacement(result.rows[0]) : null;
   }
 
-  async updatePlacementVerification(id: string, verificationState: string): Promise<Placement | null> {
-    const db = getPool();
-    const result = await db.query<PlacementRow>(
+  async updatePlacementVerification(id: string, data: PlacementVerificationUpdateData): Promise<Placement | null> {
+    const result = await getPool().query<PlacementRow>(
       `UPDATE placements
        SET verification_state = $2,
            updated_at = NOW(),
-           verified_at = CASE
-             WHEN $2 = 'verified' THEN NOW()
-             ELSE NULL
-           END
+           verified_at = CASE WHEN $2 = 'verified' THEN NOW() ELSE NULL END,
+           reviewed_by_user_id = $3,
+           reviewed_at = CASE WHEN $3 IS NOT NULL THEN NOW() ELSE reviewed_at END,
+           review_notes = $4
        WHERE id = $1
        RETURNING *`,
-      [id, verificationState],
+      [id, data.verificationState, data.reviewedByUserId ?? null, data.reviewNotes ?? null],
     );
     return result.rows[0] ? mapPlacement(result.rows[0]) : null;
   }
 
+  async createPlacementEvidence(data: CreatePlacementEvidenceData): Promise<PlacementEvidence> {
+    const id = `evidence_${randomUUID()}`;
+    const result = await getPool().query<PlacementEvidenceRow>(
+      `INSERT INTO placement_evidence (id, placement_id, script_id, evidence_url, kind, caption, uploaded_by_user_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING *`,
+      [id, data.placementId, data.scriptId ?? null, data.evidenceUrl ?? null, data.kind, data.caption ?? null, data.uploadedByUserId],
+    );
+    return mapPlacementEvidence(result.rows[0]!);
+  }
+
+  async listPlacementEvidence(placementId: string): Promise<PlacementEvidence[]> {
+    const result = await getPool().query<PlacementEvidenceRow>(
+      `SELECT * FROM placement_evidence WHERE placement_id = $1 ORDER BY created_at DESC`,
+      [placementId],
+    );
+    return result.rows.map(mapPlacementEvidence);
+  }
+
   async listPlacementsBySubmission(submissionId: string): Promise<Placement[]> {
-    const db = getPool();
-    const result = await db.query<PlacementRow>(
-      `SELECT * FROM placements
-       WHERE submission_id = $1
-       ORDER BY created_at DESC`,
+    const result = await getPool().query<PlacementRow>(
+      `SELECT * FROM placements WHERE submission_id = $1 ORDER BY created_at DESC`,
       [submissionId],
     );
     return result.rows.map(mapPlacement);
   }
 
   async listPlacements(filters: PlacementFilters): Promise<{ placement: Placement; submission: Submission }[]> {
-    const db = getPool();
     const conditions: string[] = [];
     const values: unknown[] = [];
+    if (filters.submissionId) pushCondition(conditions, values, "p.submission_id", filters.submissionId);
+    if (filters.writerId) pushCondition(conditions, values, "s.writer_id", filters.writerId);
+    if (filters.projectId) pushCondition(conditions, values, "s.project_id", filters.projectId);
+    if (filters.competitionId) pushCondition(conditions, values, "s.competition_id", filters.competitionId);
+    if (filters.status) pushCondition(conditions, values, "p.status", filters.status);
+    if (filters.verificationState) pushCondition(conditions, values, "p.verification_state", filters.verificationState);
+    if (filters.isHistorical !== undefined) pushCondition(conditions, values, "p.is_historical", filters.isHistorical);
 
-    if (filters.submissionId) {
-      values.push(filters.submissionId);
-      conditions.push(`p.submission_id = $${values.length}`);
-    }
-    if (filters.writerId) {
-      values.push(filters.writerId);
-      conditions.push(`s.writer_id = $${values.length}`);
-    }
-    if (filters.projectId) {
-      values.push(filters.projectId);
-      conditions.push(`s.project_id = $${values.length}`);
-    }
-    if (filters.competitionId) {
-      values.push(filters.competitionId);
-      conditions.push(`s.competition_id = $${values.length}`);
-    }
-    if (filters.status) {
-      values.push(filters.status);
-      conditions.push(`p.status = $${values.length}`);
-    }
-    if (filters.verificationState) {
-      values.push(filters.verificationState);
-      conditions.push(`p.verification_state = $${values.length}`);
-    }
-
-    let query = `
-      SELECT
-        p.id AS placement_id,
-        p.submission_id AS placement_submission_id,
-        p.status AS placement_status,
-        p.verification_state AS placement_verification_state,
-        p.created_at AS placement_created_at,
-        p.updated_at AS placement_updated_at,
-        p.verified_at AS placement_verified_at,
-        s.id AS submission_id,
-        s.writer_id AS submission_writer_id,
-        s.project_id AS submission_project_id,
-        s.competition_id AS submission_competition_id,
-        s.status AS submission_status,
-        s.created_at AS submission_created_at,
-        s.updated_at AS submission_updated_at
+    const query = `${selectPlacementWithSubmission("p", "s")}
       FROM placements p
       INNER JOIN submissions s ON s.id = p.submission_id
-    `;
-
-    if (conditions.length > 0) {
-      query += ` WHERE ${conditions.join(" AND ")}`;
-    }
-
-    query += ` ORDER BY p.created_at DESC`;
-
-    const result = await db.query<PlacementWithSubmissionRow>(query, values);
-    return result.rows.map((row: PlacementWithSubmissionRow) => ({
-      placement: mapPlacement({
-        id: row.placement_id,
-        submission_id: row.placement_submission_id,
-        status: row.placement_status,
-        verification_state: row.placement_verification_state,
-        created_at: row.placement_created_at,
-        updated_at: row.placement_updated_at,
-        verified_at: row.placement_verified_at,
-      }),
-      submission: mapSubmission({
-        id: row.submission_id,
-        writer_id: row.submission_writer_id,
-        project_id: row.submission_project_id,
-        competition_id: row.submission_competition_id,
-        status: row.submission_status,
-        created_at: row.submission_created_at,
-        updated_at: row.submission_updated_at,
-      }),
-    }));
+      ${conditions.length ? `WHERE ${conditions.join(" AND ")}` : ""}
+      ORDER BY p.created_at DESC`;
+    const result = await getPool().query<PlacementWithSubmissionRow>(query, values);
+    return result.rows.map(mapPlacementWithSubmission);
   }
 }
 
@@ -256,6 +197,12 @@ type PlacementRow = {
   created_at: Date;
   updated_at: Date;
   verified_at: Date | null;
+  is_historical?: boolean;
+  source_note?: string | null;
+  recorded_by_user_id?: string | null;
+  reviewed_by_user_id?: string | null;
+  reviewed_at?: Date | null;
+  review_notes?: string | null;
 };
 
 type PlacementWithSubmissionRow = {
@@ -266,6 +213,12 @@ type PlacementWithSubmissionRow = {
   placement_created_at: Date;
   placement_updated_at: Date;
   placement_verified_at: Date | null;
+  placement_is_historical: boolean;
+  placement_source_note: string | null;
+  placement_recorded_by_user_id: string | null;
+  placement_reviewed_by_user_id: string | null;
+  placement_reviewed_at: Date | null;
+  placement_review_notes: string | null;
   submission_id: string;
   submission_writer_id: string;
   submission_project_id: string;
@@ -274,6 +227,49 @@ type PlacementWithSubmissionRow = {
   submission_created_at: Date;
   submission_updated_at: Date;
 };
+
+type HistoricalPlacementRow = PlacementWithSubmissionRow;
+
+type PlacementEvidenceRow = {
+  id: string;
+  placement_id: string;
+  script_id: string | null;
+  evidence_url: string | null;
+  kind: string;
+  caption: string | null;
+  uploaded_by_user_id: string;
+  created_at: Date;
+  updated_at: Date;
+};
+
+function pushCondition(conditions: string[], values: unknown[], column: string, value: unknown): void {
+  values.push(value);
+  conditions.push(`${column} = $${values.length}`);
+}
+
+function selectPlacementWithSubmission(placementAlias: string, submissionAlias: string): string {
+  return `SELECT
+    ${placementAlias}.id AS placement_id,
+    ${placementAlias}.submission_id AS placement_submission_id,
+    ${placementAlias}.status AS placement_status,
+    ${placementAlias}.verification_state AS placement_verification_state,
+    ${placementAlias}.created_at AS placement_created_at,
+    ${placementAlias}.updated_at AS placement_updated_at,
+    ${placementAlias}.verified_at AS placement_verified_at,
+    ${placementAlias}.is_historical AS placement_is_historical,
+    ${placementAlias}.source_note AS placement_source_note,
+    ${placementAlias}.recorded_by_user_id AS placement_recorded_by_user_id,
+    ${placementAlias}.reviewed_by_user_id AS placement_reviewed_by_user_id,
+    ${placementAlias}.reviewed_at AS placement_reviewed_at,
+    ${placementAlias}.review_notes AS placement_review_notes,
+    ${submissionAlias}.id AS submission_id,
+    ${submissionAlias}.writer_id AS submission_writer_id,
+    ${submissionAlias}.project_id AS submission_project_id,
+    ${submissionAlias}.competition_id AS submission_competition_id,
+    ${submissionAlias}.status AS submission_status,
+    ${submissionAlias}.created_at AS submission_created_at,
+    ${submissionAlias}.updated_at AS submission_updated_at`;
+}
 
 function mapSubmission(row: SubmissionRow): Submission {
   return {
@@ -296,5 +292,54 @@ function mapPlacement(row: PlacementRow): Placement {
     createdAt: row.created_at.toISOString(),
     updatedAt: row.updated_at.toISOString(),
     verifiedAt: row.verified_at?.toISOString() ?? null,
+    isHistorical: row.is_historical ?? false,
+    sourceNote: row.source_note ?? null,
+    recordedByUserId: row.recorded_by_user_id ?? null,
+    reviewedByUserId: row.reviewed_by_user_id ?? null,
+    reviewedAt: row.reviewed_at?.toISOString() ?? null,
+    reviewNotes: row.review_notes ?? null,
+  };
+}
+
+function mapPlacementWithSubmission(row: PlacementWithSubmissionRow): { placement: Placement; submission: Submission } {
+  return {
+    placement: mapPlacement({
+      id: row.placement_id,
+      submission_id: row.placement_submission_id,
+      status: row.placement_status,
+      verification_state: row.placement_verification_state,
+      created_at: row.placement_created_at,
+      updated_at: row.placement_updated_at,
+      verified_at: row.placement_verified_at,
+      is_historical: row.placement_is_historical,
+      source_note: row.placement_source_note,
+      recorded_by_user_id: row.placement_recorded_by_user_id,
+      reviewed_by_user_id: row.placement_reviewed_by_user_id,
+      reviewed_at: row.placement_reviewed_at,
+      review_notes: row.placement_review_notes,
+    }),
+    submission: mapSubmission({
+      id: row.submission_id,
+      writer_id: row.submission_writer_id,
+      project_id: row.submission_project_id,
+      competition_id: row.submission_competition_id,
+      status: row.submission_status,
+      created_at: row.submission_created_at,
+      updated_at: row.submission_updated_at,
+    }),
+  };
+}
+
+function mapPlacementEvidence(row: PlacementEvidenceRow): PlacementEvidence {
+  return {
+    id: row.id,
+    placementId: row.placement_id,
+    scriptId: row.script_id,
+    evidenceUrl: row.evidence_url,
+    kind: row.kind as PlacementEvidence["kind"],
+    caption: row.caption,
+    uploadedByUserId: row.uploaded_by_user_id,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString()
   };
 }

--- a/services/submission-tracking-service/src/pgRepository.ts
+++ b/services/submission-tracking-service/src/pgRepository.ts
@@ -121,9 +121,9 @@ export class PgSubmissionTrackingRepository implements SubmissionTrackingReposit
        SET verification_state = $2,
            updated_at = NOW(),
            verified_at = CASE WHEN $2 = 'verified' THEN NOW() ELSE NULL END,
-           reviewed_by_user_id = $3,
-           reviewed_at = CASE WHEN $3 IS NOT NULL THEN NOW() ELSE reviewed_at END,
-           review_notes = $4
+           reviewed_by_user_id = $3::text,
+           reviewed_at = CASE WHEN $3::text IS NOT NULL THEN NOW() ELSE reviewed_at END,
+           review_notes = $4::text
        WHERE id = $1
        RETURNING *`,
       [id, data.verificationState, data.reviewedByUserId ?? null, data.reviewNotes ?? null],

--- a/services/submission-tracking-service/src/repository.test.ts
+++ b/services/submission-tracking-service/src/repository.test.ts
@@ -38,6 +38,12 @@ function placementRow(overrides: Record<string, unknown> = {}): Record<string, u
     created_at: new Date("2026-03-03T00:00:00.000Z"),
     updated_at: new Date("2026-03-04T00:00:00.000Z"),
     verified_at: null,
+    is_historical: false,
+    source_note: null,
+    recorded_by_user_id: null,
+    reviewed_by_user_id: null,
+    reviewed_at: null,
+    review_notes: null,
     ...overrides
   };
 }
@@ -101,7 +107,7 @@ test("PgSubmissionTrackingRepository creates and verifies placements", async () 
   const repo = new PgSubmissionTrackingRepository();
   const created = await repo.createPlacement("submission_1", "quarterfinalist");
   const placement = await repo.getPlacement("placement_1");
-  const verified = await repo.updatePlacementVerification("placement_1", "verified");
+  const verified = await repo.updatePlacementVerification("placement_1", { verificationState: "verified" });
   const bySubmission = await repo.listPlacementsBySubmission("submission_1");
 
   assert.equal(created.submissionId, "submission_1");
@@ -112,7 +118,7 @@ test("PgSubmissionTrackingRepository creates and verifies placements", async () 
   assert.deepEqual(calls.map((call) => call.values.slice(-2)), [
     ["submission_1", "quarterfinalist"],
     ["placement_1"],
-    ["placement_1", "verified"],
+    [null, null],
     ["submission_1"]
   ]);
 });
@@ -134,6 +140,12 @@ test("PgSubmissionTrackingRepository listPlacements builds joined filters and ma
           placement_created_at: new Date("2026-03-03T00:00:00.000Z"),
           placement_updated_at: new Date("2026-03-04T00:00:00.000Z"),
           placement_verified_at: new Date("2026-03-05T00:00:00.000Z"),
+          placement_is_historical: true,
+          placement_source_note: "Archive note",
+          placement_recorded_by_user_id: "writer_1",
+          placement_reviewed_by_user_id: "admin_1",
+          placement_reviewed_at: new Date("2026-03-06T00:00:00.000Z"),
+          placement_review_notes: "Looks good",
           submission_id: "submission_1",
           submission_writer_id: "writer_1",
           submission_project_id: "project_1",
@@ -153,7 +165,8 @@ test("PgSubmissionTrackingRepository listPlacements builds joined filters and ma
     projectId: "project_1",
     competitionId: "comp_1",
     status: "quarterfinalist",
-    verificationState: "verified"
+    verificationState: "verified",
+    isHistorical: true
   });
 
   assert.match(capturedSql, /INNER JOIN submissions s ON s.id = p.submission_id/);
@@ -163,7 +176,8 @@ test("PgSubmissionTrackingRepository listPlacements builds joined filters and ma
   assert.match(capturedSql, /s.competition_id = \$4/);
   assert.match(capturedSql, /p.status = \$5/);
   assert.match(capturedSql, /p.verification_state = \$6/);
-  assert.deepEqual(capturedValues, ["submission_1", "writer_1", "project_1", "comp_1", "quarterfinalist", "verified"]);
+  assert.match(capturedSql, /p.is_historical = \$7/);
+  assert.deepEqual(capturedValues, ["submission_1", "writer_1", "project_1", "comp_1", "quarterfinalist", "verified", true]);
   assert.deepEqual(placements, [
     {
       placement: {
@@ -173,7 +187,13 @@ test("PgSubmissionTrackingRepository listPlacements builds joined filters and ma
         verificationState: "verified",
         createdAt: "2026-03-03T00:00:00.000Z",
         updatedAt: "2026-03-04T00:00:00.000Z",
-        verifiedAt: "2026-03-05T00:00:00.000Z"
+        verifiedAt: "2026-03-05T00:00:00.000Z",
+        isHistorical: true,
+        sourceNote: "Archive note",
+        recordedByUserId: "writer_1",
+        reviewedByUserId: "admin_1",
+        reviewedAt: "2026-03-06T00:00:00.000Z",
+        reviewNotes: "Looks good"
       },
       submission: {
         id: "submission_1",
@@ -197,6 +217,6 @@ test("PgSubmissionTrackingRepository returns null when updates miss", async () =
   assert.equal(await repo.getPlacement("missing"), null);
   assert.equal(await repo.updateSubmissionProject("missing", "project_1"), null);
   assert.equal(await repo.updateSubmissionStatus("missing", "semifinalist"), null);
-  assert.equal(await repo.updatePlacementVerification("missing", "verified"), null);
+  assert.equal(await repo.updatePlacementVerification("missing", { verificationState: "verified" }), null);
 }
 );

--- a/services/submission-tracking-service/src/repository.ts
+++ b/services/submission-tracking-service/src/repository.ts
@@ -1,6 +1,10 @@
 import type {
+  CreateHistoricalPlacementData,
+  CreatePlacementEvidenceData,
   Placement,
+  PlacementEvidence,
   PlacementFilters,
+  PlacementVerificationUpdateData,
   Submission,
   SubmissionFilters,
 } from "@script-manifest/contracts";
@@ -21,8 +25,11 @@ export interface SubmissionTrackingRepository {
   listSubmissions(filters: SubmissionFilters): Promise<Submission[]>;
 
   createPlacement(submissionId: string, status: string): Promise<Placement>;
+  createHistoricalPlacement(data: CreateHistoricalPlacementData): Promise<{ submission: Submission; placement: Placement }>;
   getPlacement(id: string): Promise<Placement | null>;
-  updatePlacementVerification(id: string, verificationState: string): Promise<Placement | null>;
+  updatePlacementVerification(id: string, data: PlacementVerificationUpdateData): Promise<Placement | null>;
+  createPlacementEvidence(data: CreatePlacementEvidenceData): Promise<PlacementEvidence>;
+  listPlacementEvidence(placementId: string): Promise<PlacementEvidence[]>;
   listPlacementsBySubmission(submissionId: string): Promise<Placement[]>;
   listPlacements(filters: PlacementFilters): Promise<{ placement: Placement; submission: Submission }[]>;
 }


### PR DESCRIPTION
Linear: CHAOS-1805

## Summary
- add migration 024 for historical placement metadata and placement_evidence
- add Zod contracts plus submission-tracking historical/evidence endpoints
- proxy endpoints through api-gateway and writer-web, with admin guard for historical review
- add submissions modal and /admin/placements review UI

## Verification
- pnpm install
- pnpm --filter @scriptmanifest/db migrate (expected filter mismatch: package is @script-manifest/db)
- pnpm --filter @script-manifest/db migrate (expected no migrate script; repo uses root migrate)
- pnpm migrate
- pnpm typecheck (after building @script-manifest/email)
- pnpm --filter @script-manifest/submission-tracking-service test
- pnpm lint

## Notes
- No CSV import logic included; import_source left for CHAOS-1806.
- No email/notification delivery added.