### PR TITLE
feat(CHAOS-1808): recommend competitions per project

### DIFF
--- a/apps/writer-web/app/api/v1/projects/[projectId]/recommendations/[competitionId]/dismiss/route.ts
+++ b/apps/writer-web/app/api/v1/projects/[projectId]/recommendations/[competitionId]/dismiss/route.ts
@@ -1,0 +1,25 @@
+import { proxyRequest } from "../../../../../_proxy";
+
+export const runtime = "nodejs";
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ projectId: string; competitionId: string }> }
+) {
+  const { projectId, competitionId } = await context.params;
+  return proxyRequest(
+    request,
+    `/api/v1/projects/${encodeURIComponent(projectId)}/recommendations/${encodeURIComponent(competitionId)}/dismiss`
+  );
+}
+
+export async function DELETE(
+  request: Request,
+  context: { params: Promise<{ projectId: string; competitionId: string }> }
+) {
+  const { projectId, competitionId } = await context.params;
+  return proxyRequest(
+    request,
+    `/api/v1/projects/${encodeURIComponent(projectId)}/recommendations/${encodeURIComponent(competitionId)}/dismiss`
+  );
+}

--- a/apps/writer-web/app/api/v1/projects/[projectId]/recommendations/[competitionId]/pin/route.ts
+++ b/apps/writer-web/app/api/v1/projects/[projectId]/recommendations/[competitionId]/pin/route.ts
@@ -1,0 +1,25 @@
+import { proxyRequest } from "../../../../../_proxy";
+
+export const runtime = "nodejs";
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ projectId: string; competitionId: string }> }
+) {
+  const { projectId, competitionId } = await context.params;
+  return proxyRequest(
+    request,
+    `/api/v1/projects/${encodeURIComponent(projectId)}/recommendations/${encodeURIComponent(competitionId)}/pin`
+  );
+}
+
+export async function DELETE(
+  request: Request,
+  context: { params: Promise<{ projectId: string; competitionId: string }> }
+) {
+  const { projectId, competitionId } = await context.params;
+  return proxyRequest(
+    request,
+    `/api/v1/projects/${encodeURIComponent(projectId)}/recommendations/${encodeURIComponent(competitionId)}/pin`
+  );
+}

--- a/apps/writer-web/app/api/v1/projects/[projectId]/recommended-competitions/route.ts
+++ b/apps/writer-web/app/api/v1/projects/[projectId]/recommended-competitions/route.ts
@@ -1,0 +1,11 @@
+import { proxyRequest } from "../../../_proxy";
+
+export const runtime = "nodejs";
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ projectId: string }> }
+) {
+  const { projectId } = await context.params;
+  return proxyRequest(request, `/api/v1/projects/${encodeURIComponent(projectId)}/recommended-competitions`);
+}

--- a/apps/writer-web/app/components/RecommendedCompetitions.tsx
+++ b/apps/writer-web/app/components/RecommendedCompetitions.tsx
@@ -21,7 +21,9 @@ export function RecommendedCompetitions({ projectId }: RecommendedCompetitionsPr
     }
   });
 
-  const recommendations = data?.recommendations.slice(0, 10) ?? [];
+  const recommendations = Array.isArray(data?.recommendations)
+    ? data.recommendations.slice(0, 10)
+    : [];
 
   async function updateOverride(recommendation: CompetitionRecommendation, action: "dismiss" | "pin") {
     const isPinnedAction = action === "pin";

--- a/apps/writer-web/app/components/RecommendedCompetitions.tsx
+++ b/apps/writer-web/app/components/RecommendedCompetitions.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import Link from "next/link";
+import type { Route } from "next";
+import useSWR from "swr";
+import type { CompetitionRecommendation, RecommendationsResponse } from "@script-manifest/contracts";
+import { ApiError, fetcher } from "../lib/fetcher";
+import { useToast } from "./toast";
+import { SkeletonCard } from "./skeleton";
+
+type RecommendedCompetitionsProps = {
+  projectId: string;
+};
+
+export function RecommendedCompetitions({ projectId }: RecommendedCompetitionsProps) {
+  const toast = useToast();
+  const key = projectId ? `/api/v1/projects/${encodeURIComponent(projectId)}/recommended-competitions` : null;
+  const { data, isLoading, mutate } = useSWR<RecommendationsResponse>(key, fetcher, {
+    onError(err: unknown) {
+      toast.error(err instanceof ApiError ? err.message : "Failed to load recommendations.");
+    }
+  });
+
+  const recommendations = data?.recommendations.slice(0, 10) ?? [];
+
+  async function updateOverride(recommendation: CompetitionRecommendation, action: "dismiss" | "pin") {
+    const isPinnedAction = action === "pin";
+    const method = isPinnedAction && recommendation.isPinned ? "DELETE" : "POST";
+    const response = await fetch(
+      `/api/v1/projects/${encodeURIComponent(projectId)}/recommendations/${encodeURIComponent(recommendation.competition.id)}/${action}`,
+      { method }
+    );
+    if (!response.ok) {
+      const body = (await response.json().catch(() => ({}))) as { error?: string };
+      toast.error(body.error ?? `Unable to ${action} recommendation.`);
+      return;
+    }
+    await mutate();
+    toast.success(action === "dismiss" ? "Recommendation dismissed." : recommendation.isPinned ? "Recommendation unpinned." : "Recommendation pinned.");
+  }
+
+  return (
+    <article className="subcard stack">
+      <div className="subcard-header">
+        <div>
+          <p className="eyebrow">Next Submissions</p>
+          <h3 className="text-2xl text-foreground">Recommended competitions</h3>
+        </div>
+        <button type="button" className="btn btn-secondary" onClick={() => void mutate()} disabled={isLoading}>
+          Refresh matches
+        </button>
+      </div>
+
+      {isLoading ? <SkeletonCard /> : null}
+      {!isLoading && recommendations.length === 0 ? (
+        <p className="muted">No open recommendations yet. Dismissed or submitted competitions are hidden.</p>
+      ) : null}
+
+      <div className="grid gap-3">
+        {recommendations.map((recommendation) => (
+          <article key={recommendation.competition.id} className="rounded-xl border border-zinc-300/60 bg-surface p-4">
+            <div className="subcard-header">
+              <div>
+                <strong className="text-lg text-foreground">{recommendation.competition.title}</strong>
+                <p className="muted mt-1">
+                  {recommendation.competition.format} | {recommendation.competition.genre} | {new Date(recommendation.competition.deadline).toLocaleDateString()}
+                </p>
+              </div>
+              <span className="stat-chip">{recommendation.score}/100</span>
+            </div>
+
+            <details className="mt-3 rounded-lg border border-border/60 p-3">
+              <summary className="cursor-pointer font-semibold text-foreground">Why this match?</summary>
+              <ul className="mt-2 space-y-1 text-sm text-foreground-secondary">
+                {recommendation.reasons.map((reason) => (
+                  <li key={`${recommendation.competition.id}-${reason.factor}`}>
+                    <span className="font-semibold">{reason.contribution > 0 ? "+" : ""}{reason.contribution}</span> {reason.description}
+                  </li>
+                ))}
+              </ul>
+            </details>
+
+            <div className="inline-form mt-3">
+              <button type="button" className="btn btn-secondary" onClick={() => void updateOverride(recommendation, "pin")}>
+                {recommendation.isPinned ? "Unpin" : "📌 Pin"}
+              </button>
+              <button type="button" className="btn btn-danger" onClick={() => void updateOverride(recommendation, "dismiss")}>
+                Dismiss
+              </button>
+              <Link
+                className="btn btn-primary"
+                href={`/submissions?projectId=${encodeURIComponent(projectId)}&competitionId=${encodeURIComponent(recommendation.competition.id)}` as Route}
+              >
+                Submit
+              </Link>
+            </div>
+          </article>
+        ))}
+      </div>
+    </article>
+  );
+}

--- a/apps/writer-web/app/projects/page.tsx
+++ b/apps/writer-web/app/projects/page.tsx
@@ -15,6 +15,7 @@ import useSWR from "swr";
 import useSWRMutation from "swr/mutation";
 import { EmptyState } from "../components/emptyState";
 import { Modal } from "../components/modal";
+import { RecommendedCompetitions } from "../components/RecommendedCompetitions";
 import { SkeletonCard } from "../components/skeleton";
 import { useToast } from "../components/toast";
 import { useAuth } from "../lib/AuthProvider";
@@ -693,6 +694,8 @@ export default function ProjectsPage() {
           />
         ) : (
           <div className="stack">
+            <RecommendedCompetitions projectId={selectedProject.id} />
+
             <section className="stack">
               <div className="subcard-header">
                 <h3 className="text-2xl text-foreground">Co-Writers</h3>

--- a/packages/contracts/src/competition-recommendation.ts
+++ b/packages/contracts/src/competition-recommendation.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+import { CompetitionSchema } from "./competition.js";
+
+export const CompetitionRecommendationReasonSchema = z.object({
+  factor: z.string().min(1),
+  contribution: z.number(),
+  description: z.string().min(1)
+});
+
+export type CompetitionRecommendationReason = z.infer<typeof CompetitionRecommendationReasonSchema>;
+
+export const CompetitionRecommendationSchema = z.object({
+  competition: CompetitionSchema,
+  score: z.number().min(0).max(100),
+  reasons: z.array(CompetitionRecommendationReasonSchema),
+  isPinned: z.boolean(),
+  isDismissed: z.boolean()
+});
+
+export type CompetitionRecommendation = z.infer<typeof CompetitionRecommendationSchema>;
+
+export const RecommendationsResponseSchema = z.object({
+  projectId: z.string().min(1),
+  recommendations: z.array(CompetitionRecommendationSchema)
+});
+
+export type RecommendationsResponse = z.infer<typeof RecommendationsResponseSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -5,6 +5,7 @@ export * from "./auth.js";
 export * from "./notification.js";
 export * from "./competition.js";
 export * from "./saved-competition.js";
+export * from "./competition-recommendation.js";
 export * from "./script.js";
 export * from "./industry.js";
 export * from "./programs.js";

--- a/packages/db/migrations/027_competition_recommendations.sql
+++ b/packages/db/migrations/027_competition_recommendations.sql
@@ -1,0 +1,23 @@
+-- Migration 027: project competition recommendation overrides
+
+CREATE TABLE IF NOT EXISTS project_competition_dismissals (
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  competition_id TEXT NOT NULL REFERENCES competitions(id) ON DELETE CASCADE,
+  dismissed_by_user_id TEXT NOT NULL REFERENCES app_users(id),
+  dismissed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (project_id, competition_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pcd_project
+  ON project_competition_dismissals(project_id);
+
+CREATE TABLE IF NOT EXISTS project_competition_pins (
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  competition_id TEXT NOT NULL REFERENCES competitions(id) ON DELETE CASCADE,
+  pinned_by_user_id TEXT NOT NULL REFERENCES app_users(id),
+  pinned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (project_id, competition_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pcp_project
+  ON project_competition_pins(project_id);

--- a/services/api-gateway/src/routes/competitions.test.ts
+++ b/services/api-gateway/src/routes/competitions.test.ts
@@ -143,3 +143,100 @@ test("admin competition routes enforce admin auth and validate payload", async (
   assert.equal(headers[0]?.["x-admin-user-id"], "admin_01");
   assert.equal(headers[1]?.["x-admin-user-id"], "admin_01");
 });
+
+test("recommendation routes require project owner and forward auth user id", async (t) => {
+  const urls: string[] = [];
+  const methods: string[] = [];
+  const headers: Record<string, string>[] = [];
+
+  const server = await buildServer({
+    logger: false,
+    requestFn: (async (url, options) => {
+      const urlStr = String(url);
+      if (urlStr.includes("/internal/auth/me")) {
+        return jsonResponse({
+          user: { id: "writer_1", role: "writer", email: "writer@example.com", displayName: "Writer" },
+          expiresAt: "2026-12-31T00:00:00.000Z"
+        });
+      }
+      if (urlStr.startsWith("http://profile-svc/internal/projects/project_1")) {
+        return jsonResponse({ project: { id: "project_1", ownerUserId: "writer_1" } });
+      }
+      urls.push(urlStr);
+      methods.push(options?.method ?? "GET");
+      headers.push((options?.headers as Record<string, string> | undefined) ?? {});
+      return jsonResponse({ recommendations: [] });
+    }) as typeof request,
+    identityServiceBase: "http://identity-svc",
+    profileServiceBase: "http://profile-svc",
+    competitionDirectoryBase: "http://competition-svc"
+  });
+  t.after(async () => {
+    await server.close();
+  });
+
+  const missingAuth = await server.inject({
+    method: "GET",
+    url: "/api/v1/projects/project_1/recommended-competitions"
+  });
+  assert.equal(missingAuth.statusCode, 401);
+
+  const list = await server.inject({
+    method: "GET",
+    url: "/api/v1/projects/project_1/recommended-competitions",
+    headers: { authorization: "Bearer writer-token" }
+  });
+  assert.equal(list.statusCode, 200);
+
+  const dismiss = await server.inject({
+    method: "POST",
+    url: "/api/v1/projects/project_1/recommendations/comp 1/dismiss",
+    headers: { authorization: "Bearer writer-token" }
+  });
+  assert.equal(dismiss.statusCode, 200);
+
+  const pin = await server.inject({
+    method: "DELETE",
+    url: "/api/v1/projects/project_1/recommendations/comp 1/pin",
+    headers: { authorization: "Bearer writer-token" }
+  });
+  assert.equal(pin.statusCode, 200);
+
+  assert.deepEqual(urls, [
+    "http://competition-svc/internal/projects/project_1/recommended-competitions",
+    "http://competition-svc/internal/projects/project_1/recommendations/comp%201/dismiss",
+    "http://competition-svc/internal/projects/project_1/recommendations/comp%201/pin"
+  ]);
+  assert.deepEqual(methods, ["GET", "POST", "DELETE"]);
+  assert.deepEqual(headers.map((header) => header["x-auth-user-id"]), ["writer_1", "writer_1", "writer_1"]);
+});
+
+test("recommendation routes reject non-owner projects", async (t) => {
+  const server = await buildServer({
+    logger: false,
+    requestFn: (async (url) => {
+      const urlStr = String(url);
+      if (urlStr.includes("/internal/auth/me")) {
+        return jsonResponse({ user: { id: "writer_1", role: "writer" } });
+      }
+      if (urlStr.startsWith("http://profile-svc/internal/projects/project_2")) {
+        return jsonResponse({ project: { id: "project_2", ownerUserId: "writer_2" } });
+      }
+      return jsonResponse({ ok: true });
+    }) as typeof request,
+    identityServiceBase: "http://identity-svc",
+    profileServiceBase: "http://profile-svc",
+    competitionDirectoryBase: "http://competition-svc"
+  });
+  t.after(async () => {
+    await server.close();
+  });
+
+  const response = await server.inject({
+    method: "GET",
+    url: "/api/v1/projects/project_2/recommended-competitions",
+    headers: { authorization: "Bearer writer-token" }
+  });
+
+  assert.equal(response.statusCode, 403);
+});

--- a/services/api-gateway/src/routes/competitions.ts
+++ b/services/api-gateway/src/routes/competitions.ts
@@ -6,6 +6,7 @@ import {
 } from "@script-manifest/contracts";
 import {
   type GatewayContext,
+  addAuthUserIdHeader,
   buildQuerySuffix,
   proxyJsonRequest,
   resolveAdminByRole,
@@ -87,6 +88,41 @@ export function registerCompetitionRoutes(server: FastifyInstance, ctx: GatewayC
       `${ctx.competitionDirectoryBase}/internal/writers/${encodeURIComponent(userId)}/saved-competitions`,
       { method: "GET" }
     );
+  });
+
+  server.get<{ Params: { projectId: string } }>("/api/v1/projects/:projectId/recommended-competitions", async (req, reply) => {
+    const { projectId } = req.params;
+    const userId = await resolveRecommendationProjectOwner(projectId, req.headers, req.log, ctx);
+    if (!userId) {
+      return reply.status(req.headers.authorization ? 403 : 401).send({ error: req.headers.authorization ? "forbidden" : "unauthorized" });
+    }
+
+    const querySuffix = buildQuerySuffix(req.query);
+    return proxyJsonRequest(
+      reply,
+      ctx.requestFn,
+      `${ctx.competitionDirectoryBase}/internal/projects/${encodeURIComponent(projectId)}/recommended-competitions${querySuffix}`,
+      {
+        method: "GET",
+        headers: addAuthUserIdHeader({}, userId)
+      }
+    );
+  });
+
+  server.post<{ Params: { projectId: string; competitionId: string } }>("/api/v1/projects/:projectId/recommendations/:competitionId/dismiss", async (req, reply) => {
+    return proxyRecommendationOverride(req.params.projectId, req.params.competitionId, "dismiss", "POST", req, reply, ctx);
+  });
+
+  server.delete<{ Params: { projectId: string; competitionId: string } }>("/api/v1/projects/:projectId/recommendations/:competitionId/dismiss", async (req, reply) => {
+    return proxyRecommendationOverride(req.params.projectId, req.params.competitionId, "dismiss", "DELETE", req, reply, ctx);
+  });
+
+  server.post<{ Params: { projectId: string; competitionId: string } }>("/api/v1/projects/:projectId/recommendations/:competitionId/pin", async (req, reply) => {
+    return proxyRecommendationOverride(req.params.projectId, req.params.competitionId, "pin", "POST", req, reply, ctx);
+  });
+
+  server.delete<{ Params: { projectId: string; competitionId: string } }>("/api/v1/projects/:projectId/recommendations/:competitionId/pin", async (req, reply) => {
+    return proxyRecommendationOverride(req.params.projectId, req.params.competitionId, "pin", "DELETE", req, reply, ctx);
   });
 
   server.post("/api/v1/admin/competitions", async (req, reply) => {
@@ -212,4 +248,58 @@ export function registerCompetitionRoutes(server: FastifyInstance, ctx: GatewayC
       }
     );
   });
+}
+
+type ProjectOwnerResponse = {
+  id?: string;
+  ownerUserId?: string;
+  project?: {
+    id?: string;
+    ownerUserId?: string;
+  };
+};
+
+async function resolveRecommendationProjectOwner(
+  projectId: string,
+  headers: Record<string, unknown>,
+  logger: Parameters<typeof resolveUserId>[3],
+  ctx: GatewayContext
+): Promise<string | null> {
+  const userId = await resolveUserId(ctx.requestFn, ctx.identityServiceBase, headers, logger);
+  if (!userId) return null;
+
+  const projectResponse = await ctx.requestFn(
+    `${ctx.profileServiceBase}/internal/projects/${encodeURIComponent(projectId)}`,
+    { method: "GET" }
+  );
+  if (projectResponse.statusCode !== 200) return null;
+
+  const body = await projectResponse.body.json() as ProjectOwnerResponse;
+  const ownerUserId = body.project?.ownerUserId ?? body.ownerUserId;
+  return ownerUserId === userId ? userId : null;
+}
+
+async function proxyRecommendationOverride(
+  projectId: string,
+  competitionId: string,
+  action: "dismiss" | "pin",
+  method: "POST" | "DELETE",
+  req: { headers: Record<string, unknown>; log: Parameters<typeof resolveUserId>[3] },
+  reply: Parameters<typeof proxyJsonRequest>[0],
+  ctx: GatewayContext
+) {
+  const userId = await resolveRecommendationProjectOwner(projectId, req.headers, req.log, ctx);
+  if (!userId) {
+    return reply.status(req.headers.authorization ? 403 : 401).send({ error: req.headers.authorization ? "forbidden" : "unauthorized" });
+  }
+
+  return proxyJsonRequest(
+    reply,
+    ctx.requestFn,
+    `${ctx.competitionDirectoryBase}/internal/projects/${encodeURIComponent(projectId)}/recommendations/${encodeURIComponent(competitionId)}/${action}`,
+    {
+      method,
+      headers: addAuthUserIdHeader({}, userId)
+    }
+  );
 }

--- a/services/competition-directory-service/src/index.test.ts
+++ b/services/competition-directory-service/src/index.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { Competition, CompetitionAccessType, CompetitionFilters, CompetitionVisibility } from "@script-manifest/contracts";
+import type { Competition, CompetitionAccessType, CompetitionFilters, CompetitionRecommendation, CompetitionVisibility, Project } from "@script-manifest/contracts";
 import { buildServer } from "./index.js";
 import type { CompetitionDirectoryRepository } from "./repository.js";
 import { request } from "undici";
@@ -19,6 +19,8 @@ function textResponse(payload: unknown, statusCode = 200): RequestResult {
 
 class MemoryCompetitionDirectoryRepository implements CompetitionDirectoryRepository {
   private readonly competitions = new Map<string, Competition>();
+  private readonly dismissed = new Set<string>();
+  private readonly pinned = new Set<string>();
 
   constructor() {
     this.competitions.set("comp_001", {
@@ -97,6 +99,58 @@ class MemoryCompetitionDirectoryRepository implements CompetitionDirectoryReposi
 
   async listSavedCompetitions(): Promise<[]> {
     return [];
+  }
+
+  async getRecommendationContext(projectId: string, userId: string) {
+    if (projectId !== "project_1" || userId !== "writer_1") return null;
+    const project: Project = {
+      id: "project_1",
+      ownerUserId: "writer_1",
+      title: "Moon Harbor",
+      logline: "",
+      synopsis: "",
+      format: "feature",
+      genre: "drama",
+      language: "en",
+      country: "US",
+      pageCount: 100,
+      isDiscoverable: false,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z"
+    };
+    return {
+      project,
+      competitions: Array.from(this.competitions.values()).map((competition) => ({
+        competition,
+        isDismissed: this.dismissed.has(competition.id),
+        isPinned: this.pinned.has(competition.id),
+        alreadySubmitted: false,
+        prestigeTier: competition.id === "comp_001" ? "elite" as const : "standard" as const
+      })),
+      preferredFeeTier: "low" as const
+    };
+  }
+
+  async dismissRecommendation(projectId: string, competitionId: string, userId: string): Promise<boolean> {
+    if (projectId !== "project_1" || userId !== "writer_1") return false;
+    this.dismissed.add(competitionId);
+    return true;
+  }
+
+  async undismissRecommendation(projectId: string, competitionId: string, userId: string): Promise<boolean> {
+    if (projectId !== "project_1" || userId !== "writer_1") return false;
+    return this.dismissed.delete(competitionId);
+  }
+
+  async pinRecommendation(projectId: string, competitionId: string, userId: string): Promise<boolean> {
+    if (projectId !== "project_1" || userId !== "writer_1") return false;
+    this.pinned.add(competitionId);
+    return true;
+  }
+
+  async unpinRecommendation(projectId: string, competitionId: string, userId: string): Promise<boolean> {
+    if (projectId !== "project_1" || userId !== "writer_1") return false;
+    return this.pinned.delete(competitionId);
   }
 
   async listDueReminderDispatches(): Promise<[]> {
@@ -271,4 +325,70 @@ test("competition admin curation route requires x-admin-user-id header", async (
     }
   });
   assert.equal(allowed.statusCode, 201);
+});
+
+test("recommended competitions require project owner and support dismiss and pin overrides", async (t) => {
+  const repository = new MemoryCompetitionDirectoryRepository();
+  const server = buildServer({
+    logger: false,
+    repository,
+    requestFn: (async () => textResponse({ ok: true }, 201)) as typeof request
+  });
+  t.after(async () => {
+    await server.close();
+  });
+
+  const unauthorized = await server.inject({
+    method: "GET",
+    url: "/internal/projects/project_1/recommended-competitions"
+  });
+  assert.equal(unauthorized.statusCode, 401);
+
+  const first = await server.inject({
+    method: "GET",
+    url: "/internal/projects/project_1/recommended-competitions",
+    headers: { "x-auth-user-id": "writer_1" }
+  });
+  assert.equal(first.statusCode, 200);
+  const firstPayload = first.json() as { recommendations: CompetitionRecommendation[] };
+  assert.equal(firstPayload.recommendations[0]?.competition.id, "comp_001");
+
+  const dismiss = await server.inject({
+    method: "POST",
+    url: "/internal/projects/project_1/recommendations/comp_001/dismiss",
+    headers: { "x-auth-user-id": "writer_1" }
+  });
+  assert.equal(dismiss.statusCode, 200);
+
+  const afterDismiss = await server.inject({
+    method: "GET",
+    url: "/internal/projects/project_1/recommended-competitions",
+    headers: { "x-auth-user-id": "writer_1" }
+  });
+  assert.equal(afterDismiss.statusCode, 200);
+  const dismissedPayload = afterDismiss.json() as { recommendations: CompetitionRecommendation[] };
+  assert.equal(dismissedPayload.recommendations.length, 0);
+
+  const unDismiss = await server.inject({
+    method: "DELETE",
+    url: "/internal/projects/project_1/recommendations/comp_001/dismiss",
+    headers: { "x-auth-user-id": "writer_1" }
+  });
+  assert.equal(unDismiss.statusCode, 200);
+
+  const pin = await server.inject({
+    method: "POST",
+    url: "/internal/projects/project_1/recommendations/comp_001/pin",
+    headers: { "x-auth-user-id": "writer_1" }
+  });
+  assert.equal(pin.statusCode, 200);
+
+  const afterPin = await server.inject({
+    method: "GET",
+    url: "/internal/projects/project_1/recommended-competitions",
+    headers: { "x-auth-user-id": "writer_1" }
+  });
+  const pinnedPayload = afterPin.json() as { recommendations: CompetitionRecommendation[] };
+  assert.equal(pinnedPayload.recommendations[0]?.score, 100);
+  assert.equal(pinnedPayload.recommendations[0]?.isPinned, true);
 });

--- a/services/competition-directory-service/src/index.ts
+++ b/services/competition-directory-service/src/index.ts
@@ -1,4 +1,4 @@
-import { type FastifyInstance, type FastifyReply } from "fastify";
+import { type FastifyInstance, type FastifyReply, type FastifyRequest } from "fastify";
 import { randomUUID } from "node:crypto";
 import { request } from "undici";
 import { bootstrapService, registerMetrics, registerSentryErrorHandler, setupErrorReporting, validateRequiredEnv, isMainModule, readHeader, createFastifyServer } from "@script-manifest/service-utils";
@@ -17,6 +17,7 @@ import { z } from "zod";
 import type { CompetitionDirectoryRepository } from "./repository.js";
 import { PgCompetitionDirectoryRepository } from "./pgRepository.js";
 import { startCompetitionReminderWorker } from "./reminderWorker.js";
+import { recommendForProject } from "./recommendationEngine.js";
 
 type RequestFn = typeof request;
 
@@ -139,6 +140,41 @@ export function buildServer(options: CompetitionDirectoryOptions = {}): FastifyI
     const { writerId } = req.params;
     const savedCompetitions = await repository.listSavedCompetitions(writerId);
     return reply.send({ savedCompetitions });
+  });
+
+  server.get<{ Params: { projectId: string }; Querystring: { includeDismissed?: string } }>("/internal/projects/:projectId/recommended-competitions", async (req, reply) => {
+    const userId = readHeader(req, "x-auth-user-id");
+    if (!userId) {
+      return reply.status(401).send({ error: "unauthorized" });
+    }
+
+    const context = await repository.getRecommendationContext(req.params.projectId, userId);
+    if (!context) {
+      return reply.status(404).send({ error: "project_not_found" });
+    }
+
+    return reply.send(recommendForProject(req.params.projectId, {
+      project: context.project,
+      competitions: context.competitions,
+      preferredFeeTier: context.preferredFeeTier,
+      includeDismissed: req.query.includeDismissed === "true"
+    }));
+  });
+
+  server.post<{ Params: { projectId: string; competitionId: string } }>("/internal/projects/:projectId/recommendations/:competitionId/dismiss", async (req, reply) => {
+    return updateRecommendationOverride(req.params.projectId, req.params.competitionId, req, reply, repository.dismissRecommendation.bind(repository));
+  });
+
+  server.delete<{ Params: { projectId: string; competitionId: string } }>("/internal/projects/:projectId/recommendations/:competitionId/dismiss", async (req, reply) => {
+    return updateRecommendationOverride(req.params.projectId, req.params.competitionId, req, reply, repository.undismissRecommendation.bind(repository));
+  });
+
+  server.post<{ Params: { projectId: string; competitionId: string } }>("/internal/projects/:projectId/recommendations/:competitionId/pin", async (req, reply) => {
+    return updateRecommendationOverride(req.params.projectId, req.params.competitionId, req, reply, repository.pinRecommendation.bind(repository));
+  });
+
+  server.delete<{ Params: { projectId: string; competitionId: string } }>("/internal/projects/:projectId/recommendations/:competitionId/pin", async (req, reply) => {
+    return updateRecommendationOverride(req.params.projectId, req.params.competitionId, req, reply, repository.unpinRecommendation.bind(repository));
   });
 
   server.post("/internal/competitions", async (req, reply) => {
@@ -353,4 +389,22 @@ async function upsertCompetition(
     upserted: true,
     created: !existed
   });
+}
+
+async function updateRecommendationOverride(
+  projectId: string,
+  competitionId: string,
+  req: FastifyRequest,
+  reply: FastifyReply,
+  action: (projectId: string, competitionId: string, userId: string) => Promise<boolean>
+) {
+  const userId = readHeader(req, "x-auth-user-id");
+  if (!userId) {
+    return reply.status(401).send({ error: "unauthorized" });
+  }
+  const updated = await action(projectId, competitionId, userId);
+  if (!updated) {
+    return reply.status(404).send({ error: "project_or_competition_not_found" });
+  }
+  return reply.send({ updated: true });
 }

--- a/services/competition-directory-service/src/pgRepository.ts
+++ b/services/competition-directory-service/src/pgRepository.ts
@@ -1,8 +1,8 @@
 import { getPool, runMigrations, toFtsPrefixQuery } from "@script-manifest/db";
-import type { Competition, CompetitionAccessType, CompetitionFilters, CompetitionVisibility, SaveCompetitionRequest, SavedCompetition } from "@script-manifest/contracts";
+import type { Competition, CompetitionAccessType, CompetitionFilters, CompetitionVisibility, Project, SaveCompetitionRequest, SavedCompetition } from "@script-manifest/contracts";
 import { publishSearchSyncEvent } from "@script-manifest/service-utils";
 import { searchCompetitions as typesenseSearch, type CompetitionDocument } from "@script-manifest/search";
-import type { CompetitionDirectoryRepository, DueCompetitionReminderDispatch } from "./repository.js";
+import type { CompetitionDirectoryRepository, DueCompetitionReminderDispatch, FeeTier, PrestigeTier, RecommendationInput } from "./repository.js";
 
 const typesenseEnabled = process.env.TYPESENSE_ENABLED === "true";
 
@@ -24,6 +24,29 @@ type CompetitionRow = {
   updated_at: Date;
 };
 
+type ProjectRow = {
+  id: string;
+  owner_user_id: string;
+  title: string;
+  logline: string;
+  synopsis: string;
+  format: string;
+  genre: string;
+  language: string;
+  country: string | null;
+  page_count: number;
+  is_discoverable: boolean;
+  created_at: Date;
+  updated_at: Date;
+};
+
+type RecommendationCompetitionRow = CompetitionRow & {
+  is_dismissed: boolean;
+  is_pinned: boolean;
+  already_submitted: boolean;
+  prestige_tier: string | null;
+};
+
 function mapCompetition(row: CompetitionRow): Competition {
   return {
     id: row.id,
@@ -39,6 +62,24 @@ function mapCompetition(row: CompetitionRow): Competition {
     status: row.status as Competition["status"],
     visibility: row.visibility as Competition["visibility"],
     accessType: row.access_type as Competition["accessType"]
+  };
+}
+
+function mapProject(row: ProjectRow): Project {
+  return {
+    id: row.id,
+    ownerUserId: row.owner_user_id,
+    title: row.title,
+    logline: row.logline,
+    synopsis: row.synopsis,
+    format: row.format,
+    genre: row.genre,
+    language: row.language,
+    country: row.country,
+    pageCount: row.page_count,
+    isDiscoverable: row.is_discoverable,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString()
   };
 }
 
@@ -91,6 +132,22 @@ async function publishSync(operation: "upsert" | "delete", row: CompetitionRow |
   } catch {
     // Search sync is best-effort — never block the write path
   }
+}
+
+function normalizePrestigeTier(value: string | null): PrestigeTier {
+  if (value === "elite" || value === "premier" || value === "notable" || value === "standard") {
+    return value;
+  }
+  return "standard";
+}
+
+function mostCommonFeeTier(values: FeeTier[]): FeeTier | null {
+  if (values.length === 0) return null;
+  const counts = new Map<FeeTier, number>();
+  for (const value of values) {
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return [...counts.entries()].sort((left, right) => right[1] - left[1])[0]?.[0] ?? null;
 }
 
 export class PgCompetitionDirectoryRepository implements CompetitionDirectoryRepository {
@@ -319,6 +376,110 @@ export class PgCompetitionDirectoryRepository implements CompetitionDirectoryRep
       remindDaysBefore: row.remind_days_before,
       competition: mapCompetition(row)
     }));
+  }
+
+  async getRecommendationContext(projectId: string, userId: string): Promise<{
+    project: Project;
+    competitions: RecommendationInput[];
+    preferredFeeTier: FeeTier | null;
+  } | null> {
+    const db = getPool();
+    const projectResult = await db.query<ProjectRow>(
+      `SELECT * FROM projects WHERE id = $1 AND owner_user_id = $2`,
+      [projectId, userId]
+    );
+    const projectRow = projectResult.rows[0];
+    if (!projectRow) return null;
+
+    const competitionResult = await db.query<RecommendationCompetitionRow>(
+      `SELECT c.*,
+              (pcd.competition_id IS NOT NULL) AS is_dismissed,
+              (pcp.competition_id IS NOT NULL) AS is_pinned,
+              (s.competition_id IS NOT NULL) AS already_submitted,
+              cp.tier AS prestige_tier
+       FROM competitions c
+       LEFT JOIN project_competition_dismissals pcd
+         ON pcd.project_id = $1 AND pcd.competition_id = c.id
+       LEFT JOIN project_competition_pins pcp
+         ON pcp.project_id = $1 AND pcp.competition_id = c.id
+       LEFT JOIN submissions s
+         ON s.project_id = $1 AND s.competition_id = c.id
+       LEFT JOIN competition_prestige cp
+         ON cp.competition_id = c.id
+       WHERE c.status = 'active'
+         AND c.visibility = 'listed'
+         AND c.deadline > NOW()
+       ORDER BY c.deadline ASC`,
+      [projectId]
+    );
+
+    const feeResult = await db.query<{ fee_tier: FeeTier }>(
+      `SELECT c.fee_tier
+       FROM submissions s
+       JOIN competitions c ON c.id = s.competition_id
+       WHERE s.writer_id = $1 AND c.fee_tier IS NOT NULL
+       ORDER BY s.created_at DESC
+       LIMIT 5`,
+      [userId]
+    );
+
+    return {
+      project: mapProject(projectRow),
+      competitions: competitionResult.rows.map((row) => ({
+        competition: mapCompetition(row),
+        isDismissed: row.is_dismissed,
+        isPinned: row.is_pinned,
+        alreadySubmitted: row.already_submitted,
+        prestigeTier: normalizePrestigeTier(row.prestige_tier)
+      })),
+      preferredFeeTier: mostCommonFeeTier(feeResult.rows.map((row) => row.fee_tier))
+    };
+  }
+
+  async dismissRecommendation(projectId: string, competitionId: string, userId: string): Promise<boolean> {
+    const result = await getPool().query(
+      `INSERT INTO project_competition_dismissals (project_id, competition_id, dismissed_by_user_id)
+       SELECT $1, $2, $3
+       WHERE EXISTS (SELECT 1 FROM projects WHERE id = $1 AND owner_user_id = $3)
+       ON CONFLICT (project_id, competition_id) DO UPDATE
+       SET dismissed_by_user_id = EXCLUDED.dismissed_by_user_id,
+           dismissed_at = NOW()`,
+      [projectId, competitionId, userId]
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async undismissRecommendation(projectId: string, competitionId: string, userId: string): Promise<boolean> {
+    const result = await getPool().query(
+      `DELETE FROM project_competition_dismissals
+       WHERE project_id = $1 AND competition_id = $2
+         AND EXISTS (SELECT 1 FROM projects WHERE id = $1 AND owner_user_id = $3)`,
+      [projectId, competitionId, userId]
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async pinRecommendation(projectId: string, competitionId: string, userId: string): Promise<boolean> {
+    const result = await getPool().query(
+      `INSERT INTO project_competition_pins (project_id, competition_id, pinned_by_user_id)
+       SELECT $1, $2, $3
+       WHERE EXISTS (SELECT 1 FROM projects WHERE id = $1 AND owner_user_id = $3)
+       ON CONFLICT (project_id, competition_id) DO UPDATE
+       SET pinned_by_user_id = EXCLUDED.pinned_by_user_id,
+           pinned_at = NOW()`,
+      [projectId, competitionId, userId]
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async unpinRecommendation(projectId: string, competitionId: string, userId: string): Promise<boolean> {
+    const result = await getPool().query(
+      `DELETE FROM project_competition_pins
+       WHERE project_id = $1 AND competition_id = $2
+         AND EXISTS (SELECT 1 FROM projects WHERE id = $1 AND owner_user_id = $3)`,
+      [projectId, competitionId, userId]
+    );
+    return (result.rowCount ?? 0) > 0;
   }
 
   async listDueReminderDispatches(limit = 50): Promise<DueCompetitionReminderDispatch[]> {

--- a/services/competition-directory-service/src/recommendationEngine.test.ts
+++ b/services/competition-directory-service/src/recommendationEngine.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Competition, Project } from "@script-manifest/contracts";
+import { recommendForProject } from "./recommendationEngine.js";
+
+const baseProject: Project = {
+  id: "project_1",
+  ownerUserId: "writer_1",
+  title: "Moon Harbor",
+  logline: "A coastal family drama.",
+  synopsis: "",
+  format: "feature",
+  genre: "drama",
+  language: "en",
+  country: "US",
+  pageCount: 102,
+  isDiscoverable: false,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z"
+};
+
+function competition(overrides: Partial<Competition> = {}): Competition {
+  return {
+    id: "comp_1",
+    title: "Feature Lab",
+    description: "A feature screenplay lab.",
+    format: "feature",
+    genre: "drama",
+    feeUsd: 25,
+    location: "Worldwide",
+    language: "en",
+    feeTier: "low",
+    deadline: "2026-06-15T00:00:00.000Z",
+    status: "active",
+    visibility: "listed",
+    accessType: "open",
+    ...overrides
+  };
+}
+
+test("recommendForProject scores format, genre, language, location, fee, deadline, and prestige independently", () => {
+  const result = recommendForProject("project_1", {
+    project: baseProject,
+    competitions: [competition()],
+    preferredFeeTier: "low",
+    prestigeByCompetitionId: new Map([["comp_1", "elite"]]),
+    now: new Date("2026-06-01T00:00:00.000Z")
+  });
+
+  const [recommendation] = result.recommendations;
+  assert.equal(result.projectId, "project_1");
+  assert.equal(recommendation?.score, 100);
+  assert.deepEqual(
+    recommendation?.reasons.map((reason) => [reason.factor, reason.contribution]),
+    [
+      ["format", 40],
+      ["genre", 30],
+      ["language", 10],
+      ["location", 5],
+      ["fee_tier", 10],
+      ["deadline", 15],
+      ["prestige", 10]
+    ]
+  );
+});
+
+test("recommendForProject applies mismatch penalties and deadline buckets", () => {
+  const result = recommendForProject("project_1", {
+    project: baseProject,
+    competitions: [
+      competition({
+        id: "comp_mismatch",
+        format: "short",
+        genre: "horror",
+        language: "es",
+        location: "GB",
+        feeTier: "high",
+        deadline: "2026-07-10T00:00:00.000Z"
+      })
+    ],
+    preferredFeeTier: "low",
+    now: new Date("2026-06-01T00:00:00.000Z")
+  });
+
+  const recommendation = result.recommendations[0];
+  assert.equal(recommendation?.score, 0);
+  assert.deepEqual(
+    recommendation?.reasons.map((reason) => [reason.factor, reason.contribution]),
+    [
+      ["format", -20],
+      ["genre", -10],
+      ["language", -10],
+      ["location", -5],
+      ["fee_tier", 0],
+      ["deadline", 5],
+      ["prestige", 0]
+    ]
+  );
+});
+
+test("recommendForProject filters dismissed and already submitted competitions while pinned entries override score", () => {
+  const result = recommendForProject("project_1", {
+    project: baseProject,
+    competitions: [
+      competition({ id: "comp_dismissed" }),
+      competition({ id: "comp_submitted" }),
+      competition({ id: "comp_pinned", format: "short", genre: "horror" })
+    ],
+    dismissedCompetitionIds: new Set(["comp_dismissed"]),
+    submittedCompetitionIds: new Set(["comp_submitted"]),
+    pinnedCompetitionIds: new Set(["comp_pinned"]),
+    now: new Date("2026-06-01T00:00:00.000Z")
+  });
+
+  assert.deepEqual(result.recommendations.map((item) => item.competition.id), ["comp_pinned"]);
+  assert.equal(result.recommendations[0]?.score, 100);
+  assert.equal(result.recommendations[0]?.isPinned, true);
+  assert.equal(result.recommendations[0]?.reasons[0]?.factor, "pinned");
+});
+
+test("recommendForProject can explicitly include dismissed competitions", () => {
+  const result = recommendForProject("project_1", {
+    project: baseProject,
+    competitions: [competition({ id: "comp_dismissed" })],
+    dismissedCompetitionIds: new Set(["comp_dismissed"]),
+    includeDismissed: true,
+    now: new Date("2026-06-01T00:00:00.000Z")
+  });
+
+  assert.equal(result.recommendations[0]?.competition.id, "comp_dismissed");
+  assert.equal(result.recommendations[0]?.isDismissed, true);
+});

--- a/services/competition-directory-service/src/recommendationEngine.ts
+++ b/services/competition-directory-service/src/recommendationEngine.ts
@@ -1,0 +1,172 @@
+import type { Competition, CompetitionRecommendation, RecommendationsResponse, Project } from "@script-manifest/contracts";
+
+export type PrestigeTier = "standard" | "notable" | "elite" | "premier";
+export type FeeTier = NonNullable<Competition["feeTier"]>;
+
+export type RecommendationInput = {
+  competition: Competition;
+  isDismissed?: boolean;
+  isPinned?: boolean;
+  alreadySubmitted?: boolean;
+  prestigeTier?: PrestigeTier;
+};
+
+export type RecommendForProjectOptions = {
+  project: Project;
+  competitions: Array<Competition | RecommendationInput>;
+  dismissedCompetitionIds?: ReadonlySet<string>;
+  pinnedCompetitionIds?: ReadonlySet<string>;
+  submittedCompetitionIds?: ReadonlySet<string>;
+  prestigeByCompetitionId?: ReadonlyMap<string, PrestigeTier>;
+  preferredFeeTier?: FeeTier | null;
+  includeDismissed?: boolean;
+  now?: Date;
+  limit?: number;
+};
+
+type Reason = CompetitionRecommendation["reasons"][number];
+
+const adjacentGenres = new Map<string, ReadonlySet<string>>([
+  ["drama", new Set(["family", "romance", "historical", "literary"])],
+  ["comedy", new Set(["romance", "family", "animation"])],
+  ["horror", new Set(["thriller", "sci-fi", "science fiction", "fantasy"])],
+  ["thriller", new Set(["horror", "mystery", "crime", "action"])],
+  ["sci-fi", new Set(["science fiction", "fantasy", "horror"])],
+  ["science fiction", new Set(["sci-fi", "fantasy", "horror"])],
+  ["fantasy", new Set(["sci-fi", "science fiction", "animation", "horror"])],
+  ["action", new Set(["thriller", "adventure", "crime"])],
+  ["romance", new Set(["comedy", "drama", "family"])]
+]);
+
+export function recommendForProject(projectId: string, opts: RecommendForProjectOptions): RecommendationsResponse {
+  const now = opts.now ?? new Date();
+  const limit = opts.limit ?? 20;
+  const recommendations = opts.competitions
+    .map((raw) => normalizeInput(raw, opts))
+    .filter((input) => opts.includeDismissed || !input.isDismissed)
+    .filter((input) => !input.alreadySubmitted)
+    .map((input) => scoreRecommendation(opts.project, input, opts.preferredFeeTier ?? null, now))
+    .sort((left, right) => {
+      if (left.isPinned !== right.isPinned) return left.isPinned ? -1 : 1;
+      if (right.score !== left.score) return right.score - left.score;
+      return new Date(left.competition.deadline).getTime() - new Date(right.competition.deadline).getTime();
+    })
+    .slice(0, limit);
+
+  return { projectId, recommendations };
+}
+
+function normalizeInput(raw: Competition | RecommendationInput, opts: RecommendForProjectOptions): Required<RecommendationInput> {
+  const input = "competition" in raw ? raw : { competition: raw };
+  const id = input.competition.id;
+  return {
+    competition: input.competition,
+    isDismissed: input.isDismissed ?? opts.dismissedCompetitionIds?.has(id) ?? false,
+    isPinned: input.isPinned ?? opts.pinnedCompetitionIds?.has(id) ?? false,
+    alreadySubmitted: input.alreadySubmitted ?? opts.submittedCompetitionIds?.has(id) ?? false,
+    prestigeTier: input.prestigeTier ?? opts.prestigeByCompetitionId?.get(id) ?? "standard"
+  };
+}
+
+function scoreRecommendation(project: Project, input: Required<RecommendationInput>, preferredFeeTier: FeeTier | null, now: Date): CompetitionRecommendation {
+  if (input.isPinned) {
+    return {
+      competition: input.competition,
+      score: 100,
+      reasons: [{ factor: "pinned", contribution: 100, description: "Pinned by you." }],
+      isPinned: true,
+      isDismissed: input.isDismissed
+    };
+  }
+
+  const reasons: Reason[] = [
+    scoreFormat(project, input.competition),
+    scoreGenre(project, input.competition),
+    scoreLanguage(project, input.competition),
+    scoreLocation(project, input.competition),
+    scoreFeeTier(input.competition, preferredFeeTier),
+    scoreDeadline(input.competition, now),
+    scorePrestige(input.prestigeTier)
+  ];
+  const total = reasons.reduce((sum, reason) => sum + reason.contribution, 0);
+  return {
+    competition: input.competition,
+    score: clamp(total, 0, 100),
+    reasons,
+    isPinned: false,
+    isDismissed: input.isDismissed
+  };
+}
+
+function scoreFormat(project: Project, competition: Competition): Reason {
+  if (same(project.format, competition.format)) {
+    return { factor: "format", contribution: 40, description: `Format matches ${project.format}.` };
+  }
+  return { factor: "format", contribution: competition.format ? -20 : 0, description: `Format differs from ${project.format}.` };
+}
+
+function scoreGenre(project: Project, competition: Competition): Reason {
+  const projectGenre = normalize(project.genre);
+  const competitionGenre = normalize(competition.genre);
+  if (projectGenre === competitionGenre) {
+    return { factor: "genre", contribution: 30, description: `Genre matches ${project.genre}.` };
+  }
+  if (adjacentGenres.get(projectGenre)?.has(competitionGenre)) {
+    return { factor: "genre", contribution: 15, description: `${competition.genre} is adjacent to ${project.genre}.` };
+  }
+  return { factor: "genre", contribution: -10, description: `Genre differs from ${project.genre}.` };
+}
+
+function scoreLanguage(project: Project, competition: Competition): Reason {
+  const projectLanguage = project.language ?? "en";
+  const competitionLanguage = competition.language ?? "en";
+  if (same(projectLanguage, competitionLanguage)) {
+    return { factor: "language", contribution: 10, description: `Language matches ${projectLanguage}.` };
+  }
+  return { factor: "language", contribution: -10, description: `Language ${competitionLanguage} differs from ${projectLanguage}.` };
+}
+
+function scoreLocation(project: Project, competition: Competition): Reason {
+  const projectCountry = project.country ?? "Worldwide";
+  const location = competition.location ?? "Worldwide";
+  if (same(location, "Worldwide") || same(projectCountry, location)) {
+    return { factor: "location", contribution: 5, description: same(location, "Worldwide") ? "Open worldwide." : `Location matches ${projectCountry}.` };
+  }
+  return { factor: "location", contribution: -5, description: `Location ${location} differs from ${projectCountry}.` };
+}
+
+function scoreFeeTier(competition: Competition, preferredFeeTier: FeeTier | null): Reason {
+  if (!preferredFeeTier || !competition.feeTier) {
+    return { factor: "fee_tier", contribution: 0, description: "No fee preference yet." };
+  }
+  if (competition.feeTier === preferredFeeTier) {
+    return { factor: "fee_tier", contribution: 10, description: `Fee tier matches recent ${preferredFeeTier} submissions.` };
+  }
+  return { factor: "fee_tier", contribution: 0, description: `Fee tier differs from recent ${preferredFeeTier} submissions.` };
+}
+
+function scoreDeadline(competition: Competition, now: Date): Reason {
+  const days = Math.ceil((new Date(competition.deadline).getTime() - now.getTime()) / 86_400_000);
+  if (days <= 14) return { factor: "deadline", contribution: 15, description: "Deadline is within 14 days." };
+  if (days <= 30) return { factor: "deadline", contribution: 10, description: "Deadline is within 30 days." };
+  if (days <= 60) return { factor: "deadline", contribution: 5, description: "Deadline is within 60 days." };
+  return { factor: "deadline", contribution: 0, description: "Deadline is more than 60 days away." };
+}
+
+function scorePrestige(tier: PrestigeTier): Reason {
+  if (tier === "elite" || tier === "premier") return { factor: "prestige", contribution: 10, description: "Elite competition prestige." };
+  if (tier === "notable") return { factor: "prestige", contribution: 5, description: "Notable competition prestige." };
+  return { factor: "prestige", contribution: 0, description: "Standard competition prestige." };
+}
+
+function same(left: string, right: string): boolean {
+  return normalize(left) === normalize(right);
+}
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/services/competition-directory-service/src/repository.ts
+++ b/services/competition-directory-service/src/repository.ts
@@ -1,4 +1,5 @@
-import type { Competition, CompetitionAccessType, CompetitionFilters, CompetitionVisibility, SaveCompetitionRequest, SavedCompetition } from "@script-manifest/contracts";
+import type { Competition, CompetitionAccessType, CompetitionFilters, CompetitionVisibility, Project, SaveCompetitionRequest, SavedCompetition } from "@script-manifest/contracts";
+import type { FeeTier, PrestigeTier, RecommendationInput } from "./recommendationEngine.js";
 
 export type DueCompetitionReminderDispatch = {
   id: string;
@@ -25,8 +26,19 @@ export interface CompetitionDirectoryRepository extends CompetitionReminderDispa
   saveCompetition(input: SaveCompetitionRequest & { competitionId: string }): Promise<SavedCompetition>;
   unsaveCompetition(writerId: string, competitionId: string): Promise<boolean>;
   listSavedCompetitions(writerId: string): Promise<SavedCompetition[]>;
+  getRecommendationContext(projectId: string, userId: string): Promise<{
+    project: Project;
+    competitions: RecommendationInput[];
+    preferredFeeTier: FeeTier | null;
+  } | null>;
+  dismissRecommendation(projectId: string, competitionId: string, userId: string): Promise<boolean>;
+  undismissRecommendation(projectId: string, competitionId: string, userId: string): Promise<boolean>;
+  pinRecommendation(projectId: string, competitionId: string, userId: string): Promise<boolean>;
+  unpinRecommendation(projectId: string, competitionId: string, userId: string): Promise<boolean>;
 
   cancelCompetition(id: string): Promise<Competition | null>;
   updateVisibility(id: string, visibility: CompetitionVisibility): Promise<Competition | null>;
   updateAccessType(id: string, accessType: CompetitionAccessType): Promise<Competition | null>;
 }
+
+export type { FeeTier, PrestigeTier, RecommendationInput };


### PR DESCRIPTION
## Summary
- Add project recommendation override tables and shared recommendation contracts
- Add pure competition recommendation scoring engine plus competition-directory endpoints for list/dismiss/pin
- Add API gateway owner-checked proxy routes and writer-web recommendations panel/proxy routes

## Verification
- pnpm install
- pnpm migrate
- pnpm --filter @script-manifest/email build
- pnpm typecheck
- pnpm --filter @script-manifest/competition-directory-service test
- pnpm --filter @script-manifest/api-gateway test
- pnpm lint (passes with existing warnings)

## Notes
- No Co-authored-by trailers added.