### PR TITLE
feat(CHAOS-1806): add CSV career history import

### DIFF
--- a/apps/writer-web/app/api/v1/career-imports/[batchId]/commit/route.ts
+++ b/apps/writer-web/app/api/v1/career-imports/[batchId]/commit/route.ts
@@ -1,0 +1,12 @@
+import { proxyRequest } from "../../../_proxy";
+
+export const runtime = "nodejs";
+
+type RouteContext = {
+  params: Promise<{ batchId: string }>;
+};
+
+export async function POST(request: Request, context: RouteContext) {
+  const { batchId } = await context.params;
+  return proxyRequest(request, `/api/v1/career-imports/${encodeURIComponent(batchId)}/commit`);
+}

--- a/apps/writer-web/app/api/v1/career-imports/[batchId]/route.ts
+++ b/apps/writer-web/app/api/v1/career-imports/[batchId]/route.ts
@@ -1,0 +1,12 @@
+import { proxyRequest } from "../../_proxy";
+
+export const runtime = "nodejs";
+
+type RouteContext = {
+  params: Promise<{ batchId: string }>;
+};
+
+export async function GET(request: Request, context: RouteContext) {
+  const { batchId } = await context.params;
+  return proxyRequest(request, `/api/v1/career-imports/${encodeURIComponent(batchId)}`);
+}

--- a/apps/writer-web/app/api/v1/career-imports/route.ts
+++ b/apps/writer-web/app/api/v1/career-imports/route.ts
@@ -1,0 +1,7 @@
+import { proxyRequest } from "../_proxy";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  return proxyRequest(request, "/api/v1/career-imports");
+}

--- a/apps/writer-web/app/profile/import/page.tsx
+++ b/apps/writer-web/app/profile/import/page.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useMemo, useState, type DragEvent } from "react";
+import useSWRMutation from "swr/mutation";
+import type { ImportCommitResponse, ImportPreviewResponse } from "@script-manifest/contracts";
+import { ApiError, fetcher } from "../../lib/fetcher";
+import { useAuth } from "../../lib/AuthProvider";
+import { useToast } from "../../components/toast";
+
+const statusOptions = ["pending", "quarterfinalist", "semifinalist", "finalist", "winner"];
+
+async function postCsvPreview(url: string, { arg }: { arg: { csv: string; filename: string } }): Promise<ImportPreviewResponse> {
+  return fetcher<ImportPreviewResponse>(`${url}?filename=${encodeURIComponent(arg.filename)}`, {
+    method: "POST",
+    headers: { "content-type": "text/csv" },
+    body: arg.csv
+  });
+}
+
+async function postCommit(url: string, { arg }: { arg: { batchId: string; acceptedRowIndices: number[]; rowOverrides: Array<{ rowIndex: number; status: string }> } }): Promise<ImportCommitResponse> {
+  return fetcher<ImportCommitResponse>(`${url}/${encodeURIComponent(arg.batchId)}/commit`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(arg)
+  });
+}
+
+export default function CareerImportPage() {
+  const toast = useToast();
+  const { user, loading: authLoading } = useAuth();
+  const [preview, setPreview] = useState<ImportPreviewResponse | null>(null);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [filename, setFilename] = useState("career-history.csv");
+  const [dragActive, setDragActive] = useState(false);
+  const [statusOverrides, setStatusOverrides] = useState<Record<number, string>>({});
+  const writerId = user?.id ?? "";
+
+  const { trigger: previewCsv, isMutating: previewing } = useSWRMutation("/api/v1/career-imports", postCsvPreview, {
+    onSuccess(data) {
+      setPreview(data);
+      const accepted = new Set(data.rows.filter((row) => row.status === "ok").map((row) => row.rowIndex));
+      setSelected(accepted);
+      setStatusOverrides(Object.fromEntries(data.rows.map((row) => [row.rowIndex, row.row.status])));
+      toast.success(`Preview ready: ${data.batch.succeeded} valid, ${data.batch.failed} need review.`);
+    },
+    onError(error: unknown) {
+      toast.error(error instanceof ApiError ? error.message : "CSV preview failed.");
+    }
+  });
+
+  const { trigger: commitRows, isMutating: committing } = useSWRMutation("/api/v1/career-imports", postCommit, {
+    onSuccess(data) {
+      toast.success(`Imported ${data.committed} recovered placements.`);
+      setSelected(new Set());
+    },
+    onError(error: unknown) {
+      toast.error(error instanceof ApiError ? error.message : "Import commit failed.");
+    }
+  });
+
+  const selectedCount = selected.size;
+  const rows = useMemo(() => preview?.rows ?? [], [preview]);
+  const hasInvalidSelection = useMemo(
+    () => rows.some((row) => selected.has(row.rowIndex) && row.status !== "ok"),
+    [rows, selected]
+  );
+
+  async function handleFile(file: File) {
+    setFilename(file.name);
+    const csv = await file.text();
+    await previewCsv({ csv, filename: file.name });
+  }
+
+  function toggleRow(rowIndex: number) {
+    setSelected((current) => {
+      const next = new Set(current);
+      if (next.has(rowIndex)) next.delete(rowIndex);
+      else next.add(rowIndex);
+      return next;
+    });
+  }
+
+  function handleDrop(event: DragEvent<HTMLLabelElement>) {
+    event.preventDefault();
+    setDragActive(false);
+    const file = event.dataTransfer.files.item(0);
+    if (file) void handleFile(file);
+  }
+
+  async function commitSelectedRows() {
+    if (!preview) return;
+    const acceptedRowIndices = Array.from(selected).sort((a, b) => a - b);
+    await commitRows({
+      batchId: preview.batch.id,
+      acceptedRowIndices,
+      rowOverrides: acceptedRowIndices.map((rowIndex) => ({ rowIndex, status: statusOverrides[rowIndex] ?? "pending" }))
+    });
+  }
+
+  if (!writerId && !authLoading) {
+    return (
+      <section className="space-y-4">
+        <article className="empty-state">Sign in first to import recovered career history.</article>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-4">
+      <article className="hero-card hero-card--amber animate-in">
+        <p className="eyebrow eyebrow--amber">Recovered Proof</p>
+        <h1 className="text-4xl text-foreground">Import your recovered career history</h1>
+        <p className="max-w-2xl text-foreground-secondary">
+          Bring old Coverfly-style submissions and placements into Script Manifest with a validation preview first.
+          Every committed row is tagged as recovered proof for resume badges and future review.
+        </p>
+        <div className="inline-form">
+          <a className="btn btn-secondary no-underline" href="/career-history-template.csv" download>
+            Download CSV template
+          </a>
+          <span className="badge">500 rows max</span>
+          {filename ? <span className="badge">{filename}</span> : null}
+        </div>
+      </article>
+
+      <article className="panel">
+        <div className="grid-two items-stretch">
+          <label
+            className={`subcard flex cursor-pointer flex-col items-center justify-center gap-3 border-dashed p-8 text-center ${dragActive ? "border-amber-500 bg-amber-50" : ""}`}
+            onDragOver={(event) => {
+              event.preventDefault();
+              setDragActive(true);
+            }}
+            onDragLeave={() => setDragActive(false)}
+            onDrop={handleDrop}
+          >
+            <span className="eyebrow">Drop CSV here</span>
+            <strong className="text-xl text-foreground">Validate before anything is written</strong>
+            <span className="muted">CSV stays server-side and creates a preview batch only.</span>
+            <input
+              className="sr-only"
+              type="file"
+              accept=".csv,text/csv"
+              onChange={(event) => {
+                const file = event.target.files?.item(0);
+                if (file) void handleFile(file);
+              }}
+            />
+          </label>
+
+          <div className="subcard stack">
+            <p className="eyebrow">Preview summary</p>
+            <div className="grid grid-cols-3 gap-3">
+              <Metric label="Rows" value={preview?.batch.rowCount ?? 0} />
+              <Metric label="Ready" value={preview?.batch.succeeded ?? 0} />
+              <Metric label="Needs review" value={preview?.batch.failed ?? 0} />
+            </div>
+            <button
+              type="button"
+              className="btn btn-primary"
+              disabled={!preview || selectedCount === 0 || hasInvalidSelection || committing || previewing}
+              onClick={() => void commitSelectedRows()}
+            >
+              {committing ? "Importing..." : `Commit ${selectedCount} selected rows`}
+            </button>
+            {hasInvalidSelection ? <p className="text-sm text-red-700">Deselect error rows before committing.</p> : null}
+          </div>
+        </div>
+      </article>
+
+      {preview ? (
+        <article className="panel overflow-hidden">
+          <div className="subcard-header mb-4">
+            <div>
+              <p className="eyebrow">Validation Preview</p>
+              <h2 className="section-title">Choose rows to recover</h2>
+            </div>
+            <span className="badge">Batch {preview.batch.id}</span>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[900px] text-left text-sm">
+              <thead className="text-foreground-secondary">
+                <tr className="border-b border-zinc-200">
+                  <th className="p-2">Import</th>
+                  <th className="p-2">Status</th>
+                  <th className="p-2">Project</th>
+                  <th className="p-2">Competition</th>
+                  <th className="p-2">Year</th>
+                  <th className="p-2">Placement</th>
+                  <th className="p-2">Issues</th>
+                </tr>
+              </thead>
+              <tbody>
+                {preview.rows.map((row) => (
+                  <tr key={row.rowIndex} className="border-b border-zinc-100 align-top">
+                    <td className="p-2">
+                      <input
+                        type="checkbox"
+                        checked={selected.has(row.rowIndex)}
+                        onChange={() => toggleRow(row.rowIndex)}
+                        aria-label={`Select row ${row.rowIndex + 1}`}
+                      />
+                    </td>
+                    <td className="p-2">
+                      <span className={`badge ${row.status === "ok" ? "" : "bg-red-100 text-red-800"}`}>
+                        {row.status === "ok" ? "OK" : "ERROR"}
+                      </span>
+                    </td>
+                    <td className="p-2 font-medium text-foreground">{row.row.project_title || "—"}</td>
+                    <td className="p-2">{row.row.competition_name || "—"}</td>
+                    <td className="p-2">{row.row.year || "—"}</td>
+                    <td className="p-2">
+                      <select
+                        className="input min-w-36"
+                        value={statusOverrides[row.rowIndex] ?? row.row.status}
+                        onChange={(event) => setStatusOverrides((current) => ({ ...current, [row.rowIndex]: event.target.value }))}
+                        disabled={row.status !== "ok"}
+                      >
+                        {statusOptions.map((status) => <option key={status} value={status}>{status}</option>)}
+                      </select>
+                    </td>
+                    <td className="p-2 text-red-700">{row.errors.length ? row.errors.join("; ") : "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </article>
+      ) : null}
+    </section>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-surface p-3">
+      <p className="eyebrow">{label}</p>
+      <p className="text-3xl text-foreground">{value}</p>
+    </div>
+  );
+}

--- a/apps/writer-web/app/profile/page.tsx
+++ b/apps/writer-web/app/profile/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { useState, type FormEvent } from "react";
 import useSWR from "swr";
 import useSWRMutation from "swr/mutation";
@@ -217,6 +218,9 @@ export default function ProfilePage() {
           >
             {isLoading ? "Refreshing..." : "Refresh profile"}
           </button>
+          <Link className="btn btn-secondary no-underline" href="/profile/import">
+            Import recovered history
+          </Link>
         </div>
       </article>
 

--- a/apps/writer-web/app/submissions/page.tsx
+++ b/apps/writer-web/app/submissions/page.tsx
@@ -476,6 +476,7 @@ export default function SubmissionsPage() {
                           <span className="badge">
                             {placement.status} | {placement.badgeLabel}
                           </span>
+                          {placement.importSource === "recovered_csv" ? <span className="badge">Recovered</span> : null}
                           {placement.isHistorical ? <span className="badge">Historical</span> : null}
                         </div>
                         <div className="inline-form mt-2">

--- a/apps/writer-web/public/career-history-template.csv
+++ b/apps/writer-web/public/career-history-template.csv
@@ -1,0 +1,3 @@
+project_title,competition_name,year,status,placement_date,source_url,source_note
+Pilot One,Austin Film Festival,2023,finalist,2023-10-15,https://example.com/results,Archived finalist announcement
+Feature Two,Nicholl Fellowship,2021,semifinalist,,https://example.com/archive,Recovered from old portfolio export

--- a/packages/contracts/src/career-import.ts
+++ b/packages/contracts/src/career-import.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+import { SubmissionStatusSchema } from "./submission.js";
+
+export const CsvRowSchema = z.object({
+  project_title: z.string().default(""),
+  competition_name: z.string().default(""),
+  year: z.string().default(""),
+  status: z.string().default(""),
+  placement_date: z.string().default(""),
+  source_url: z.string().default(""),
+  source_note: z.string().default("")
+});
+export type CsvRow = z.infer<typeof CsvRowSchema>;
+
+export const CareerImportPreviewRowSchema = z.object({
+  rowIndex: z.number().int().min(0),
+  row: CsvRowSchema,
+  status: z.enum(["ok", "error"]),
+  errors: z.array(z.string())
+});
+export type CareerImportPreviewRow = z.infer<typeof CareerImportPreviewRowSchema>;
+
+export const CareerHistoryImportSchema = z.object({
+  id: z.string().min(1),
+  writerId: z.string().min(1),
+  filename: z.string().nullable(),
+  rowCount: z.number().int().min(0),
+  succeeded: z.number().int().min(0),
+  failed: z.number().int().min(0),
+  status: z.enum(["pending", "validated", "committed", "failed"]),
+  errorLog: z.array(CareerImportPreviewRowSchema),
+  createdAt: z.string().datetime({ offset: true }),
+  committedAt: z.string().datetime({ offset: true }).nullable()
+});
+export type CareerHistoryImport = z.infer<typeof CareerHistoryImportSchema>;
+
+export const ImportPreviewResponseSchema = z.object({
+  batch: CareerHistoryImportSchema,
+  rows: z.array(CareerImportPreviewRowSchema)
+});
+export type ImportPreviewResponse = z.infer<typeof ImportPreviewResponseSchema>;
+
+export const ImportCommitRequestSchema = z.object({
+  batchId: z.string().min(1),
+  acceptedRowIndices: z.array(z.number().int().min(0)).max(500),
+  rowOverrides: z.array(z.object({
+    rowIndex: z.number().int().min(0),
+    status: SubmissionStatusSchema
+  })).max(500).optional()
+});
+export type ImportCommitRequest = z.infer<typeof ImportCommitRequestSchema>;
+
+export const ImportCommitResponseSchema = z.object({
+  batchId: z.string().min(1),
+  committed: z.number().int().min(0),
+  skipped: z.number().int().min(0)
+});
+export type ImportCommitResponse = z.infer<typeof ImportCommitResponseSchema>;
+
+export const CreateCareerImportPreviewDataSchema = z.object({
+  writerId: z.string().min(1),
+  filename: z.string().max(255).nullable(),
+  rows: z.array(CsvRowSchema).max(500)
+});
+export type CreateCareerImportPreviewData = z.infer<typeof CreateCareerImportPreviewDataSchema>;
+
+export const CommitCareerImportDataSchema = ImportCommitRequestSchema.extend({
+  writerId: z.string().min(1)
+});
+export type CommitCareerImportData = z.infer<typeof CommitCareerImportDataSchema>;
+
+export const CareerImportStatusValues = SubmissionStatusSchema.options;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -9,6 +9,7 @@ export * from "./script.js";
 export * from "./industry.js";
 export * from "./programs.js";
 export * from "./submission.js";
+export * from "./career-import.js";
 export * from "./placement-evidence.js";
 export * from "./ranking.js";
 export * from "./feedback.js";

--- a/packages/contracts/src/submission.ts
+++ b/packages/contracts/src/submission.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+export const ImportSourceSchema = z.enum(["manual", "csv_import", "historical_form", "recovered_csv"]);
+export type ImportSource = z.infer<typeof ImportSourceSchema>;
+
 export const SubmissionStatusSchema = z.enum([
   "pending",
   "quarterfinalist",
@@ -16,6 +19,8 @@ export const SubmissionSchema = z.object({
   projectId: z.string().min(1),
   competitionId: z.string().min(1),
   status: SubmissionStatusSchema,
+  importSource: ImportSourceSchema.optional(),
+  importBatchId: z.string().nullable().optional(),
   createdAt: z.string().datetime({ offset: true }),
   updatedAt: z.string().datetime({ offset: true })
 });
@@ -70,7 +75,9 @@ export const PlacementSchema = z.object({
   recordedByUserId: z.string().nullable().default(null),
   reviewedByUserId: z.string().nullable().default(null),
   reviewedAt: z.string().datetime({ offset: true }).nullable().default(null),
-  reviewNotes: z.string().nullable().default(null)
+  reviewNotes: z.string().nullable().default(null),
+  importSource: ImportSourceSchema.optional(),
+  importBatchId: z.string().nullable().optional()
 });
 
 export type Placement = z.infer<typeof PlacementSchema>;

--- a/packages/db/migrations/025_career_history_imports.sql
+++ b/packages/db/migrations/025_career_history_imports.sql
@@ -1,0 +1,30 @@
+-- Migration 025: CSV imports for recovered career history
+
+CREATE TABLE IF NOT EXISTS career_history_imports (
+  id TEXT PRIMARY KEY,
+  writer_id TEXT NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
+  filename VARCHAR(255),
+  row_count INT NOT NULL DEFAULT 0,
+  succeeded INT NOT NULL DEFAULT 0,
+  failed INT NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','validated','committed','failed')),
+  error_log JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  committed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_career_history_imports_writer_created
+  ON career_history_imports(writer_id, created_at DESC);
+
+ALTER TABLE submissions
+  ADD COLUMN IF NOT EXISTS import_source TEXT NOT NULL DEFAULT 'manual'
+    CHECK (import_source IN ('manual','csv_import','historical_form','recovered_csv')),
+  ADD COLUMN IF NOT EXISTS import_batch_id TEXT REFERENCES career_history_imports(id);
+
+ALTER TABLE placements
+  ADD COLUMN IF NOT EXISTS import_source TEXT NOT NULL DEFAULT 'manual'
+    CHECK (import_source IN ('manual','csv_import','historical_form','recovered_csv')),
+  ADD COLUMN IF NOT EXISTS import_batch_id TEXT REFERENCES career_history_imports(id);
+
+CREATE INDEX IF NOT EXISTS idx_submissions_import_batch ON submissions(import_batch_id);
+CREATE INDEX IF NOT EXISTS idx_placements_import_batch ON placements(import_batch_id);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -774,6 +774,9 @@ importers:
       fastify:
         specifier: ^5.8.5
         version: 5.8.5
+      papaparse:
+        specifier: ^5.5.3
+        version: 5.5.3
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
@@ -784,6 +787,9 @@ importers:
       '@types/node':
         specifier: ^25.7.0
         version: 25.7.0
+      '@types/papaparse':
+        specifier: ^5.3.16
+        version: 5.5.2
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -3315,6 +3321,9 @@ packages:
   '@types/oracledb@6.5.2':
     resolution: {integrity: sha512-kK1eBS/Adeyis+3OlBDMeQQuasIDLUYXsi2T15ccNJ0iyUpQ4xDF7svFu3+bGVrI0CMBUclPciz+lsQR3JX3TQ==}
 
+  '@types/papaparse@5.5.2':
+    resolution: {integrity: sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==}
+
   '@types/pg-pool@2.0.7':
     resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
 
@@ -5352,6 +5361,9 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  papaparse@5.5.3:
+    resolution: {integrity: sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -9155,6 +9167,10 @@ snapshots:
     dependencies:
       '@types/node': 25.7.0
 
+  '@types/papaparse@5.5.2':
+    dependencies:
+      '@types/node': 25.9.1
+
   '@types/pg-pool@2.0.7':
     dependencies:
       '@types/pg': 8.20.0
@@ -10283,8 +10299,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 9.20.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.20.0(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.20.0(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3))(eslint@9.20.0(jiti@2.7.0)))(eslint@9.20.0(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3))(eslint@9.20.0(jiti@2.7.0)))(eslint@9.20.0(jiti@2.7.0)))(eslint@9.20.0(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.20.0(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.20.0(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.20.0(jiti@2.7.0))
@@ -10306,7 +10322,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.20.0(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3))(eslint@9.20.0(jiti@2.7.0)))(eslint@9.20.0(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10317,22 +10333,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.20.0(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3))(eslint@9.20.0(jiti@2.7.0)))(eslint@9.20.0(jiti@2.7.0)))(eslint@9.20.0(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.20.0(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3))(eslint@9.20.0(jiti@2.7.0)))(eslint@9.20.0(jiti@2.7.0)))(eslint@9.20.0(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.20.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.20.0(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3))(eslint@9.20.0(jiti@2.7.0)))(eslint@9.20.0(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.20.0(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3))(eslint@9.20.0(jiti@2.7.0)))(eslint@9.20.0(jiti@2.7.0)))(eslint@9.20.0(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10343,7 +10359,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.20.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.20.0(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.20.0(jiti@2.7.0))(typescript@5.9.3))(eslint@9.20.0(jiti@2.7.0)))(eslint@9.20.0(jiti@2.7.0)))(eslint@9.20.0(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -11549,6 +11565,8 @@ snapshots:
       p-limit: 3.1.0
 
   package-json-from-dist@1.0.1: {}
+
+  papaparse@5.5.3: {}
 
   parent-module@1.0.1:
     dependencies:

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -14,6 +14,7 @@ import { registerProfileRoutes } from "./routes/profiles.js";
 import { registerProjectRoutes } from "./routes/projects.js";
 import { registerCompetitionRoutes } from "./routes/competitions.js";
 import { registerSubmissionRoutes } from "./routes/submissions.js";
+import { registerCareerImportRoutes } from "./routes/career-imports.js";
 import { registerScriptRoutes } from "./routes/scripts.js";
 import { registerExportRoutes } from "./routes/export.js";
 import { registerFeedbackRoutes } from "./routes/feedback.js";
@@ -130,6 +131,7 @@ export async function buildServer(options: ApiGatewayOptions = {}): Promise<Fast
   registerProjectRoutes(server, ctx);
   registerCompetitionRoutes(server, ctx);
   registerSubmissionRoutes(server, ctx);
+  registerCareerImportRoutes(server, ctx);
   registerScriptRoutes(server, ctx);
   registerExportRoutes(server, ctx);
   registerFeedbackRoutes(server, ctx);

--- a/services/api-gateway/src/routes/career-imports.test.ts
+++ b/services/api-gateway/src/routes/career-imports.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { request } from "undici";
+import { buildServer } from "../index.js";
+
+type RequestResult = Awaited<ReturnType<typeof request>>;
+
+function jsonResponse(payload: unknown, statusCode = 200): RequestResult {
+  return {
+    statusCode,
+    body: {
+      json: async () => payload,
+      text: async () => JSON.stringify(payload)
+    }
+  } as RequestResult;
+}
+
+test("POST /api/v1/career-imports proxies CSV preview with writer auth", async (t) => {
+  const urls: string[] = [];
+  const headers: Record<string, string>[] = [];
+  const bodies: string[] = [];
+  const server = await buildServer({
+    logger: false,
+    requestFn: (async (url, options) => {
+      const urlStr = String(url);
+      if (urlStr.includes("/internal/auth/me")) {
+        return jsonResponse({ user: { id: "writer_01", role: "writer" } });
+      }
+      urls.push(urlStr);
+      headers.push((options?.headers as Record<string, string> | undefined) ?? {});
+      bodies.push(typeof options?.body === "string" ? options.body : "");
+      return jsonResponse({ batch: { id: "import_01" }, rows: [] }, 201);
+    }) as typeof request,
+    identityServiceBase: "http://identity-svc",
+    submissionTrackingBase: "http://submission-svc"
+  });
+  t.after(async () => { await server.close(); });
+
+  const response = await server.inject({
+    method: "POST",
+    url: "/api/v1/career-imports?filename=career.csv",
+    headers: { authorization: "Bearer sess_1", "content-type": "text/csv" },
+    payload: "project_title,competition_name,year,status\nPilot,AFF,2023,finalist"
+  });
+
+  assert.equal(response.statusCode, 201);
+  assert.equal(urls[0], "http://submission-svc/internal/career-imports?filename=career.csv");
+  assert.equal(headers[0]?.["x-auth-user-id"], "writer_01");
+  assert.equal(headers[0]?.["content-type"], "text/csv");
+  assert.match(bodies[0] ?? "", /Pilot,AFF/);
+});
+
+test("POST /api/v1/career-imports/:batchId/commit proxies accepted rows and recomputes ranking", async (t) => {
+  const urls: string[] = [];
+  const bodies: string[] = [];
+  const server = await buildServer({
+    logger: false,
+    requestFn: (async (url, options) => {
+      const urlStr = String(url);
+      if (urlStr.includes("/internal/auth/me")) {
+        return jsonResponse({ user: { id: "writer_01", role: "writer" } });
+      }
+      urls.push(urlStr);
+      bodies.push(typeof options?.body === "string" ? options.body : "");
+      if (urlStr.includes("/commit")) return jsonResponse({ batchId: "import_01", committed: 2, skipped: 0 });
+      return jsonResponse({ ok: true });
+    }) as typeof request,
+    identityServiceBase: "http://identity-svc",
+    submissionTrackingBase: "http://submission-svc",
+    rankingServiceBase: "http://ranking-svc"
+  });
+  t.after(async () => { await server.close(); });
+
+  const response = await server.inject({
+    method: "POST",
+    url: "/api/v1/career-imports/import_01/commit",
+    headers: { authorization: "Bearer sess_1" },
+    payload: { batchId: "import_01", acceptedRowIndices: [0, 1] }
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(urls[0], "http://submission-svc/internal/career-imports/import_01/commit");
+  assert.deepEqual(JSON.parse(bodies[0] ?? "{}"), { batchId: "import_01", acceptedRowIndices: [0, 1] });
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  assert.ok(urls.some((url) => url === "http://ranking-svc/internal/recompute/incremental"));
+});
+
+test("career import routes require writer authentication", async (t) => {
+  const server = await buildServer({
+    logger: false,
+    requestFn: (async () => jsonResponse({ error: "unauthorized" }, 401)) as typeof request
+  });
+  t.after(async () => { await server.close(); });
+
+  const response = await server.inject({
+    method: "POST",
+    url: "/api/v1/career-imports",
+    headers: { "content-type": "text/csv" },
+    payload: "project_title,competition_name,year,status\nPilot,AFF,2023,finalist"
+  });
+
+  assert.equal(response.statusCode, 403);
+});

--- a/services/api-gateway/src/routes/career-imports.ts
+++ b/services/api-gateway/src/routes/career-imports.ts
@@ -1,0 +1,61 @@
+import type { FastifyInstance } from "fastify";
+import { ImportCommitRequestSchema } from "@script-manifest/contracts";
+import {
+  addAuthUserIdHeader,
+  buildQuerySuffix,
+  getUserIdFromAuth,
+  proxyJsonRequest,
+  type GatewayContext
+} from "../helpers.js";
+
+export function registerCareerImportRoutes(server: FastifyInstance, ctx: GatewayContext): void {
+  server.addContentTypeParser(["text/csv", "application/csv"], { parseAs: "string" }, (_req, body, done) => {
+    done(null, body);
+  });
+
+  server.post("/api/v1/career-imports", async (req, reply) => {
+    const userId = await getUserIdFromAuth(ctx.requestFn, ctx.identityServiceBase, req.headers.authorization, req.log);
+    if (!userId) return reply.status(403).send({ error: "forbidden" });
+    const csvBody = typeof req.body === "string" ? req.body : "";
+    return proxyJsonRequest(reply, ctx.requestFn, `${ctx.submissionTrackingBase}/internal/career-imports${buildQuerySuffix(req.query)}`, {
+      method: "POST",
+      headers: addAuthUserIdHeader({ "content-type": "text/csv" }, userId),
+      body: csvBody
+    });
+  });
+
+  server.get<{ Params: { batchId: string } }>("/api/v1/career-imports/:batchId", async (req, reply) => {
+    const userId = await getUserIdFromAuth(ctx.requestFn, ctx.identityServiceBase, req.headers.authorization, req.log);
+    if (!userId) return reply.status(403).send({ error: "forbidden" });
+    return proxyJsonRequest(reply, ctx.requestFn, `${ctx.submissionTrackingBase}/internal/career-imports/${encodeURIComponent(req.params.batchId)}`, {
+      method: "GET",
+      headers: addAuthUserIdHeader({}, userId)
+    });
+  });
+
+  server.post<{ Params: { batchId: string } }>("/api/v1/career-imports/:batchId/commit", async (req, reply) => {
+    const userId = await getUserIdFromAuth(ctx.requestFn, ctx.identityServiceBase, req.headers.authorization, req.log);
+    if (!userId) return reply.status(403).send({ error: "forbidden" });
+    const requestBody = req.body && typeof req.body === "object" ? req.body : {};
+    const parsed = ImportCommitRequestSchema.safeParse({ ...requestBody, batchId: req.params.batchId });
+    if (!parsed.success) {
+      return reply.status(400).send({ error: "invalid_payload", details: parsed.error.flatten() });
+    }
+
+    const result = await proxyJsonRequest(reply, ctx.requestFn, `${ctx.submissionTrackingBase}/internal/career-imports/${encodeURIComponent(req.params.batchId)}/commit`, {
+      method: "POST",
+      headers: addAuthUserIdHeader({ "content-type": "application/json" }, userId),
+      body: JSON.stringify(parsed.data)
+    });
+
+    if (reply.statusCode < 400) {
+      ctx.requestFn(`${ctx.rankingServiceBase}/internal/recompute/incremental`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ writerId: userId })
+      }).catch((err) => { req.log.warn({ err, writerId: userId }, "background ranking recompute failed"); });
+    }
+
+    return result;
+  });
+}

--- a/services/submission-tracking-service/package.json
+++ b/services/submission-tracking-service/package.json
@@ -15,10 +15,12 @@
     "@script-manifest/db": "workspace:*",
     "@script-manifest/service-utils": "workspace:*",
     "fastify": "^5.8.5",
+    "papaparse": "^5.5.3",
     "prom-client": "^15.1.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/papaparse": "^5.3.16",
     "@types/node": "^25.7.0",
     "tsx": "^4.19.2",
     "typescript": "^5.9.3"

--- a/services/submission-tracking-service/src/careerImport.test.ts
+++ b/services/submission-tracking-service/src/careerImport.test.ts
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import test from "node:test";
+import type {
+  CareerImportPreviewRow,
+  CommitCareerImportData,
+  CreateCareerImportPreviewData,
+  CreateHistoricalPlacementData,
+  CreatePlacementEvidenceData,
+  ImportCommitResponse,
+  ImportPreviewResponse,
+  Placement,
+  PlacementEvidence,
+  PlacementFilters,
+  PlacementVerificationUpdateData,
+  Submission,
+  SubmissionFilters
+} from "@script-manifest/contracts";
+import { buildServer } from "./index.js";
+import type { SubmissionTrackingRepository } from "./repository.js";
+
+class MemoryCareerImportRepository implements SubmissionTrackingRepository {
+  readonly submissions = new Map<string, Submission>();
+  readonly placements = new Map<string, Placement>();
+  private readonly previews = new Map<string, ImportPreviewResponse>();
+
+  async init(): Promise<void> {}
+  async healthCheck(): Promise<{ database: boolean }> { return { database: true }; }
+
+  async createSubmission(data: { writerId: string; projectId: string; competitionId: string; status: string }): Promise<Submission> {
+    const now = new Date().toISOString();
+    const submission: Submission = {
+      id: `submission_${randomUUID()}`,
+      writerId: data.writerId,
+      projectId: data.projectId,
+      competitionId: data.competitionId,
+      status: data.status as Submission["status"],
+      createdAt: now,
+      updatedAt: now,
+      importSource: "recovered_csv"
+    };
+    this.submissions.set(submission.id, submission);
+    return submission;
+  }
+
+  async getSubmission(id: string): Promise<Submission | null> { return this.submissions.get(id) ?? null; }
+  async updateSubmissionProject(id: string, projectId: string): Promise<Submission | null> {
+    const submission = this.submissions.get(id);
+    if (!submission) return null;
+    const updated = { ...submission, projectId, updatedAt: new Date().toISOString() };
+    this.submissions.set(id, updated);
+    return updated;
+  }
+  async updateSubmissionStatus(id: string, status: string): Promise<Submission | null> {
+    const submission = this.submissions.get(id);
+    if (!submission) return null;
+    const updated = { ...submission, status: status as Submission["status"], updatedAt: new Date().toISOString() };
+    this.submissions.set(id, updated);
+    return updated;
+  }
+  async listSubmissions(_filters: SubmissionFilters): Promise<Submission[]> { return Array.from(this.submissions.values()); }
+
+  async createPlacement(submissionId: string, status: string): Promise<Placement> {
+    const now = new Date().toISOString();
+    const placement: Placement = {
+      id: `placement_${randomUUID()}`,
+      submissionId,
+      status: status as Placement["status"],
+      verificationState: "pending",
+      createdAt: now,
+      updatedAt: now,
+      verifiedAt: null,
+      isHistorical: true,
+      sourceNote: null,
+      recordedByUserId: null,
+      reviewedByUserId: null,
+      reviewedAt: null,
+      reviewNotes: null,
+      importSource: "recovered_csv"
+    };
+    this.placements.set(placement.id, placement);
+    return placement;
+  }
+  async createHistoricalPlacement(_data: CreateHistoricalPlacementData): Promise<{ submission: Submission; placement: Placement }> { throw new Error("not needed"); }
+  async getPlacement(id: string): Promise<Placement | null> { return this.placements.get(id) ?? null; }
+  async updatePlacementVerification(_id: string, _data: PlacementVerificationUpdateData): Promise<Placement | null> { return null; }
+  async createPlacementEvidence(_data: CreatePlacementEvidenceData): Promise<PlacementEvidence> { throw new Error("not needed"); }
+  async listPlacementEvidence(_placementId: string): Promise<PlacementEvidence[]> { return []; }
+  async listPlacementsBySubmission(submissionId: string): Promise<Placement[]> { return Array.from(this.placements.values()).filter((p) => p.submissionId === submissionId); }
+  async listPlacements(_filters: PlacementFilters): Promise<{ placement: Placement; submission: Submission }[]> { return []; }
+
+  async createCareerImportPreview(data: CreateCareerImportPreviewData): Promise<ImportPreviewResponse> {
+    const rows: CareerImportPreviewRow[] = data.rows.map((row, rowIndex) => {
+      const errors: string[] = [];
+      if (!row.project_title?.trim()) errors.push("project_title is required");
+      if (!row.competition_name?.trim()) errors.push("competition_name is required");
+      if (!/^\d{4}$/.test(row.year?.trim() ?? "")) errors.push("year must be a 4-digit year");
+      if (!row.status?.trim()) errors.push("status is required");
+      if (row.status && !["pending", "quarterfinalist", "semifinalist", "finalist", "winner"].includes(row.status.trim())) errors.push("status is not supported");
+      return { rowIndex, row, status: errors.length === 0 ? "ok" : "error", errors };
+    });
+    const preview: ImportPreviewResponse = {
+      batch: {
+        id: `import_${randomUUID()}`,
+        writerId: data.writerId,
+        filename: data.filename,
+        rowCount: rows.length,
+        succeeded: rows.filter((row) => row.status === "ok").length,
+        failed: rows.filter((row) => row.status === "error").length,
+        status: "validated",
+        errorLog: rows,
+        createdAt: new Date().toISOString(),
+        committedAt: null
+      },
+      rows
+    };
+    this.previews.set(preview.batch.id, preview);
+    return preview;
+  }
+
+  async getCareerImport(batchId: string, _writerId: string): Promise<ImportPreviewResponse | null> {
+    return this.previews.get(batchId) ?? null;
+  }
+
+  async commitCareerImport(data: CommitCareerImportData): Promise<ImportCommitResponse> {
+    const preview = this.previews.get(data.batchId);
+    if (!preview) throw new Error("batch not found");
+    for (const row of preview.rows.filter((entry) => data.acceptedRowIndices.includes(entry.rowIndex) && entry.status === "ok")) {
+      const submission = await this.createSubmission({
+        writerId: data.writerId,
+        projectId: `project:${row.row.project_title}`,
+        competitionId: `competition:${row.row.competition_name}`,
+        status: row.row.status as Submission["status"]
+      });
+      const importedSubmission = { ...submission, importBatchId: data.batchId };
+      this.submissions.set(importedSubmission.id, importedSubmission);
+      const placement = await this.createPlacement(submission.id, row.row.status);
+      this.placements.set(placement.id, { ...placement, importBatchId: data.batchId });
+    }
+    return { batchId: data.batchId, committed: data.acceptedRowIndices.length, skipped: 0 };
+  }
+}
+
+test("previews a valid recovered career CSV", async (t) => {
+  const server = buildServer({ logger: false, repository: new MemoryCareerImportRepository() });
+  t.after(async () => { await server.close(); });
+
+  const response = await server.inject({
+    method: "POST",
+    url: "/internal/career-imports?filename=career.csv",
+    headers: { "x-auth-user-id": "writer_01", "content-type": "text/csv" },
+    payload: [
+      "project_title,competition_name,year,status,placement_date,source_url,source_note",
+      "Pilot One,Austin Film Festival,2023,finalist,2023-10-15,https://example.com/results,Archived PDF",
+      "Pilot Two,Sundance Lab,2022,semifinalist,,https://example.com/sundance,Recovered from Coverfly",
+      "Pilot Three,Nicholl Fellowship,2021,winner,2021-12-01,,"
+    ].join("\n")
+  });
+
+  assert.equal(response.statusCode, 201);
+  assert.equal(response.json().rows.length, 3);
+  assert.equal(response.json().batch.succeeded, 3);
+  assert.equal(response.json().rows[0].status, "ok");
+});
+
+test("previews invalid rows without committing them", async (t) => {
+  const server = buildServer({ logger: false, repository: new MemoryCareerImportRepository() });
+  t.after(async () => { await server.close(); });
+
+  const response = await server.inject({
+    method: "POST",
+    url: "/internal/career-imports",
+    headers: { "x-auth-user-id": "writer_01", "content-type": "text/csv" },
+    payload: [
+      "project_title,competition_name,year,status,placement_date,source_url,source_note",
+      "Pilot One,Austin Film Festival,2023,not-a-placement,,,"
+    ].join("\n")
+  });
+
+  assert.equal(response.statusCode, 201);
+  assert.equal(response.json().batch.failed, 1);
+  assert.equal(response.json().rows[0].status, "error");
+  assert.match(response.json().rows[0].errors.join(" "), /status/);
+});
+
+test("commits accepted recovered CSV rows as historical submissions and placements", async (t) => {
+  const repository = new MemoryCareerImportRepository();
+  const server = buildServer({ logger: false, repository });
+  t.after(async () => { await server.close(); });
+
+  const previewResponse = await server.inject({
+    method: "POST",
+    url: "/internal/career-imports",
+    headers: { "x-auth-user-id": "writer_01", "content-type": "text/csv" },
+    payload: [
+      "project_title,competition_name,year,status,placement_date,source_url,source_note",
+      "Pilot One,Austin Film Festival,2023,finalist,2023-10-15,https://example.com/results,Archived PDF",
+      "Pilot Two,Sundance Lab,2022,semifinalist,,https://example.com/sundance,Recovered from Coverfly",
+      "Pilot Three,Nicholl Fellowship,2021,not-a-placement,,,"
+    ].join("\n")
+  });
+  const batchId = previewResponse.json().batch.id as string;
+
+  const commitResponse = await server.inject({
+    method: "POST",
+    url: `/internal/career-imports/${encodeURIComponent(batchId)}/commit`,
+    headers: { "x-auth-user-id": "writer_01" },
+    payload: { batchId, acceptedRowIndices: [0, 1] }
+  });
+
+  assert.equal(commitResponse.statusCode, 200);
+  assert.equal(commitResponse.json().committed, 2);
+  assert.equal(repository.submissions.size, 2);
+  assert.equal(repository.placements.size, 2);
+  for (const submission of repository.submissions.values()) {
+    assert.equal(submission.importSource, "recovered_csv");
+    assert.equal(submission.importBatchId, batchId);
+  }
+  for (const placement of repository.placements.values()) {
+    assert.equal(placement.importSource, "recovered_csv");
+    assert.equal(placement.importBatchId, batchId);
+    assert.equal(placement.isHistorical, true);
+    assert.equal(placement.verificationState, "pending");
+  }
+});

--- a/services/submission-tracking-service/src/historicalPlacement.test.ts
+++ b/services/submission-tracking-service/src/historicalPlacement.test.ts
@@ -2,8 +2,12 @@ import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import test from "node:test";
 import type {
+  CommitCareerImportData,
+  CreateCareerImportPreviewData,
   CreateHistoricalPlacementData,
   CreatePlacementEvidenceData,
+  ImportCommitResponse,
+  ImportPreviewResponse,
   Placement,
   PlacementEvidence,
   PlacementFilters,
@@ -190,6 +194,18 @@ class MemoryHistoricalPlacementRepository implements SubmissionTrackingRepositor
       if (filters.isHistorical !== undefined && placement.isHistorical !== filters.isHistorical) return [];
       return [{ placement, submission }];
     });
+  }
+
+  async createCareerImportPreview(_data: CreateCareerImportPreviewData): Promise<ImportPreviewResponse> {
+    throw new Error("not implemented for this test");
+  }
+
+  async getCareerImport(_batchId: string, _writerId: string): Promise<ImportPreviewResponse | null> {
+    return null;
+  }
+
+  async commitCareerImport(_data: CommitCareerImportData): Promise<ImportCommitResponse> {
+    throw new Error("not implemented for this test");
   }
 }
 

--- a/services/submission-tracking-service/src/index.test.ts
+++ b/services/submission-tracking-service/src/index.test.ts
@@ -2,8 +2,12 @@ import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import test from "node:test";
 import type {
+  CommitCareerImportData,
+  CreateCareerImportPreviewData,
   CreateHistoricalPlacementData,
   CreatePlacementEvidenceData,
+  ImportCommitResponse,
+  ImportPreviewResponse,
   Placement,
   PlacementEvidence,
   PlacementFilters,
@@ -217,6 +221,18 @@ class MemorySubmissionTrackingRepository implements SubmissionTrackingRepository
 
       return [{ placement, submission }];
     });
+  }
+
+  async createCareerImportPreview(_data: CreateCareerImportPreviewData): Promise<ImportPreviewResponse> {
+    throw new Error("not implemented for this test");
+  }
+
+  async getCareerImport(_batchId: string, _writerId: string): Promise<ImportPreviewResponse | null> {
+    return null;
+  }
+
+  async commitCareerImport(_data: CommitCareerImportData): Promise<ImportCommitResponse> {
+    throw new Error("not implemented for this test");
   }
 }
 

--- a/services/submission-tracking-service/src/index.ts
+++ b/services/submission-tracking-service/src/index.ts
@@ -1,9 +1,15 @@
 import { type FastifyInstance } from "fastify";
+import Papa from "papaparse";
 import { Counter } from "prom-client";
 import { bootstrapService, registerMetrics, registerSentryErrorHandler, setupErrorReporting, validateRequiredEnv, getAuthUserId, isMainModule, createFastifyServer } from "@script-manifest/service-utils";
 import { closePool } from "@script-manifest/db";
 import {
   CreateHistoricalPlacementRequestSchema,
+  CsvRowSchema,
+  type CsvRow,
+  ImportCommitRequestSchema,
+  ImportCommitResponseSchema,
+  ImportPreviewResponseSchema,
   CreatePlacementEvidenceItemSchema,
   PlacementFiltersSchema,
   PlacementEvidenceSchema,
@@ -35,6 +41,10 @@ export type SubmissionTrackingOptions = {
 export function buildServer(options: SubmissionTrackingOptions = {}): FastifyInstance {
   const server = createFastifyServer({ logger: options.logger });
   const repository = options.repository ?? new PgSubmissionTrackingRepository();
+
+  server.addContentTypeParser(["text/csv", "application/csv"], { parseAs: "string" }, (_req, body, done) => {
+    done(null, body);
+  });
 
   const startedAt = Date.now();
 
@@ -209,6 +219,60 @@ export function buildServer(options: SubmissionTrackingOptions = {}): FastifyIns
     });
   });
 
+  server.post("/internal/career-imports", async (req, reply) => {
+    const authUserId = getAuthUserId(req);
+    if (!authUserId) {
+      return reply.status(403).send({ error: "forbidden" });
+    }
+
+    const csvBody = typeof req.body === "string" ? req.body : "";
+    if (!csvBody.trim()) {
+      return reply.status(400).send({ error: "empty_csv" });
+    }
+
+    const parsedCsv = parseCareerCsv(csvBody);
+    if (parsedCsv.error) {
+      return reply.status(400).send({ error: parsedCsv.error });
+    }
+
+    const filename = readStringQuery(req.query, "filename");
+    const preview = await repository.createCareerImportPreview({
+      writerId: authUserId,
+      filename: filename ? filename.slice(0, 255) : null,
+      rows: parsedCsv.rows
+    });
+    return reply.status(201).send(ImportPreviewResponseSchema.parse(preview));
+  });
+
+  server.get<{ Params: { batchId: string } }>("/internal/career-imports/:batchId", async (req, reply) => {
+    const authUserId = getAuthUserId(req);
+    if (!authUserId) {
+      return reply.status(403).send({ error: "forbidden" });
+    }
+    const preview = await repository.getCareerImport(req.params.batchId, authUserId);
+    if (!preview) {
+      return reply.status(404).send({ error: "import_not_found" });
+    }
+    return reply.send(ImportPreviewResponseSchema.parse(preview));
+  });
+
+  server.post<{ Params: { batchId: string } }>("/internal/career-imports/:batchId/commit", async (req, reply) => {
+    const authUserId = getAuthUserId(req);
+    if (!authUserId) {
+      return reply.status(403).send({ error: "forbidden" });
+    }
+    const requestBody = req.body && typeof req.body === "object" ? req.body : {};
+    const parsedBody = ImportCommitRequestSchema.safeParse({ ...requestBody, batchId: req.params.batchId });
+    if (!parsedBody.success) {
+      return reply.status(400).send({ error: "invalid_payload", details: parsedBody.error.flatten() });
+    }
+    const result = await repository.commitCareerImport({
+      ...parsedBody.data,
+      writerId: authUserId
+    });
+    return reply.send(ImportCommitResponseSchema.parse(result));
+  });
+
   server.post<{ Params: { placementId: string } }>("/internal/placements/:placementId/evidence", async (req, reply) => {
     const authUserId = getAuthUserId(req);
     if (!authUserId) {
@@ -366,10 +430,45 @@ function toPlacementDetail(placement: Placement): Placement & { badgeLabel: stri
 }
 
 function placementBadgeLabel(placement: Placement): string {
+  if (placement.importSource === "recovered_csv") return "Recovered";
   if (placement.verificationState === "verified") return "Verified";
   if (placement.verificationState === "rejected") return "Rejected";
   if (placement.isHistorical) return "Unverified — Historical";
   return "Unverified";
+}
+
+type ParsedCareerCsv = { rows: CsvRow[]; error: null } | { rows: []; error: string };
+
+function parseCareerCsv(csvBody: string): ParsedCareerCsv {
+  const result = Papa.parse<Record<string, string>>(csvBody, {
+    header: true,
+    skipEmptyLines: true,
+    transform(value) {
+      return value.trim();
+    }
+  });
+  if (result.errors.length > 0) {
+    return { rows: [], error: "invalid_csv" };
+  }
+  if (result.data.length > 500) {
+    return { rows: [], error: "too_many_rows" };
+  }
+  const rows = result.data.map((row) => CsvRowSchema.parse({
+    project_title: row.project_title ?? "",
+    competition_name: row.competition_name ?? "",
+    year: row.year ?? "",
+    status: row.status ?? "",
+    placement_date: row.placement_date ?? "",
+    source_url: row.source_url ?? "",
+    source_note: row.source_note ?? ""
+  }));
+  return { rows, error: null };
+}
+
+function readStringQuery(query: unknown, key: string): string | null {
+  if (!query || typeof query !== "object") return null;
+  const value = (query as Record<string, unknown>)[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
 export async function startServer(): Promise<void> {

--- a/services/submission-tracking-service/src/pgRepository.ts
+++ b/services/submission-tracking-service/src/pgRepository.ts
@@ -1,8 +1,13 @@
 import { randomUUID } from "node:crypto";
 import { getPool, runMigrations } from "@script-manifest/db";
 import type {
+  CareerImportPreviewRow,
+  CommitCareerImportData,
+  CreateCareerImportPreviewData,
   CreateHistoricalPlacementData,
   CreatePlacementEvidenceData,
+  ImportCommitResponse,
+  ImportPreviewResponse,
   Placement,
   PlacementEvidence,
   PlacementFilters,
@@ -177,6 +182,95 @@ export class PgSubmissionTrackingRepository implements SubmissionTrackingReposit
     const result = await getPool().query<PlacementWithSubmissionRow>(query, values);
     return result.rows.map(mapPlacementWithSubmission);
   }
+
+  async createCareerImportPreview(data: CreateCareerImportPreviewData): Promise<ImportPreviewResponse> {
+    const id = `career_import_${randomUUID()}`;
+    const rows = data.rows.map((row, rowIndex) => validateCareerImportRow(row, rowIndex));
+    const succeeded = rows.filter((row) => row.status === "ok").length;
+    const failed = rows.length - succeeded;
+    const result = await getPool().query<CareerImportRow>(
+      `INSERT INTO career_history_imports (id, writer_id, filename, row_count, succeeded, failed, status, error_log)
+       VALUES ($1, $2, $3, $4, $5, $6, 'validated', $7::jsonb)
+       RETURNING *`,
+      [id, data.writerId, data.filename, rows.length, succeeded, failed, JSON.stringify(rows)]
+    );
+    return { batch: mapCareerImport(result.rows[0]!), rows };
+  }
+
+  async getCareerImport(batchId: string, writerId: string): Promise<ImportPreviewResponse | null> {
+    const result = await getPool().query<CareerImportRow>(
+      `SELECT * FROM career_history_imports WHERE id = $1 AND writer_id = $2`,
+      [batchId, writerId]
+    );
+    const row = result.rows[0];
+    if (!row) return null;
+    const batch = mapCareerImport(row);
+    return { batch, rows: batch.errorLog };
+  }
+
+  async commitCareerImport(data: CommitCareerImportData): Promise<ImportCommitResponse> {
+    const db = getPool();
+    const client = await db.connect();
+    try {
+      await client.query("BEGIN");
+      const importResult = await client.query<CareerImportRow>(
+        `SELECT * FROM career_history_imports WHERE id = $1 AND writer_id = $2 FOR UPDATE`,
+        [data.batchId, data.writerId]
+      );
+      const importRow = importResult.rows[0];
+      if (!importRow) {
+        await client.query("ROLLBACK");
+        return { batchId: data.batchId, committed: 0, skipped: data.acceptedRowIndices.length };
+      }
+
+      const accepted = new Set(data.acceptedRowIndices);
+      const statusOverrides = new Map((data.rowOverrides ?? []).map((override) => [override.rowIndex, override.status]));
+      const rows = mapCareerImport(importRow).errorLog
+        .filter((row) => accepted.has(row.rowIndex) && row.status === "ok")
+        .map((row) => ({ ...row, row: { ...row.row, status: statusOverrides.get(row.rowIndex) ?? row.row.status } }));
+      let committed = 0;
+      for (const previewRow of rows) {
+        const row = previewRow.row;
+        const projectId = await findOrCreateProject(client, data.writerId, row.project_title);
+        const competitionId = await findOrCreateCompetition(client, row.competition_name);
+        const submissionId = `submission_${randomUUID()}`;
+        const placementId = `placement_${randomUUID()}`;
+        const placementDate = normalizePlacementDate(row.placement_date, row.year);
+        await client.query(
+          `INSERT INTO submissions (id, writer_id, project_id, competition_id, status, import_source, import_batch_id)
+           VALUES ($1, $2, $3, $4, $5, 'recovered_csv', $6)`,
+          [submissionId, data.writerId, projectId, competitionId, row.status, data.batchId]
+        );
+        await client.query(
+          `INSERT INTO placements (id, submission_id, status, verification_state, is_historical, source_note, recorded_by_user_id, import_source, import_batch_id, created_at)
+           VALUES ($1, $2, $3, 'pending', TRUE, $4, $5, 'recovered_csv', $6, $7::timestamptz)`,
+          [placementId, submissionId, row.status, row.source_note || null, data.writerId, data.batchId, placementDate]
+        );
+        if (row.source_url.trim()) {
+          await client.query(
+            `INSERT INTO placement_evidence (id, placement_id, evidence_url, kind, caption, uploaded_by_user_id)
+             VALUES ($1, $2, $3, 'url', $4, $5)`,
+            [`evidence_${randomUUID()}`, placementId, row.source_url.trim(), row.source_note || "Recovered CSV source", data.writerId]
+          );
+        }
+        committed += 1;
+      }
+
+      await client.query(
+        `UPDATE career_history_imports
+         SET status = 'committed', committed_at = NOW(), succeeded = $3, failed = row_count - $3
+         WHERE id = $1 AND writer_id = $2`,
+        [data.batchId, data.writerId, committed]
+      );
+      await client.query("COMMIT");
+      return { batchId: data.batchId, committed, skipped: data.acceptedRowIndices.length - committed };
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
 }
 
 type SubmissionRow = {
@@ -185,6 +279,8 @@ type SubmissionRow = {
   project_id: string;
   competition_id: string;
   status: string;
+  import_source?: string;
+  import_batch_id?: string | null;
   created_at: Date;
   updated_at: Date;
 };
@@ -203,6 +299,8 @@ type PlacementRow = {
   reviewed_by_user_id?: string | null;
   reviewed_at?: Date | null;
   review_notes?: string | null;
+  import_source?: string;
+  import_batch_id?: string | null;
 };
 
 type PlacementWithSubmissionRow = {
@@ -219,13 +317,34 @@ type PlacementWithSubmissionRow = {
   placement_reviewed_by_user_id: string | null;
   placement_reviewed_at: Date | null;
   placement_review_notes: string | null;
+  placement_import_source: string;
+  placement_import_batch_id: string | null;
   submission_id: string;
   submission_writer_id: string;
   submission_project_id: string;
   submission_competition_id: string;
   submission_status: string;
+  submission_import_source: string;
+  submission_import_batch_id: string | null;
   submission_created_at: Date;
   submission_updated_at: Date;
+};
+
+type CareerImportRow = {
+  id: string;
+  writer_id: string;
+  filename: string | null;
+  row_count: number;
+  succeeded: number;
+  failed: number;
+  status: string;
+  error_log: unknown;
+  created_at: Date;
+  committed_at: Date | null;
+};
+
+type Queryable = {
+  query<T>(text: string, values?: unknown[]): Promise<{ rows: T[] }>;
 };
 
 type HistoricalPlacementRow = PlacementWithSubmissionRow;
@@ -262,17 +381,21 @@ function selectPlacementWithSubmission(placementAlias: string, submissionAlias: 
     ${placementAlias}.reviewed_by_user_id AS placement_reviewed_by_user_id,
     ${placementAlias}.reviewed_at AS placement_reviewed_at,
     ${placementAlias}.review_notes AS placement_review_notes,
+    ${placementAlias}.import_source AS placement_import_source,
+    ${placementAlias}.import_batch_id AS placement_import_batch_id,
     ${submissionAlias}.id AS submission_id,
     ${submissionAlias}.writer_id AS submission_writer_id,
     ${submissionAlias}.project_id AS submission_project_id,
     ${submissionAlias}.competition_id AS submission_competition_id,
     ${submissionAlias}.status AS submission_status,
+    ${submissionAlias}.import_source AS submission_import_source,
+    ${submissionAlias}.import_batch_id AS submission_import_batch_id,
     ${submissionAlias}.created_at AS submission_created_at,
     ${submissionAlias}.updated_at AS submission_updated_at`;
 }
 
 function mapSubmission(row: SubmissionRow): Submission {
-  return {
+  const submission: Submission = {
     id: row.id,
     writerId: row.writer_id,
     projectId: row.project_id,
@@ -281,10 +404,13 @@ function mapSubmission(row: SubmissionRow): Submission {
     createdAt: row.created_at.toISOString(),
     updatedAt: row.updated_at.toISOString(),
   };
+  if (row.import_source) submission.importSource = row.import_source as Submission["importSource"];
+  if (row.import_batch_id !== undefined) submission.importBatchId = row.import_batch_id;
+  return submission;
 }
 
 function mapPlacement(row: PlacementRow): Placement {
-  return {
+  const placement: Placement = {
     id: row.id,
     submissionId: row.submission_id,
     status: row.status as Placement["status"],
@@ -299,6 +425,9 @@ function mapPlacement(row: PlacementRow): Placement {
     reviewedAt: row.reviewed_at?.toISOString() ?? null,
     reviewNotes: row.review_notes ?? null,
   };
+  if (row.import_source) placement.importSource = row.import_source as Placement["importSource"];
+  if (row.import_batch_id !== undefined) placement.importBatchId = row.import_batch_id;
+  return placement;
 }
 
 function mapPlacementWithSubmission(row: PlacementWithSubmissionRow): { placement: Placement; submission: Submission } {
@@ -317,6 +446,8 @@ function mapPlacementWithSubmission(row: PlacementWithSubmissionRow): { placemen
       reviewed_by_user_id: row.placement_reviewed_by_user_id,
       reviewed_at: row.placement_reviewed_at,
       review_notes: row.placement_review_notes,
+      import_source: row.placement_import_source,
+      import_batch_id: row.placement_import_batch_id,
     }),
     submission: mapSubmission({
       id: row.submission_id,
@@ -324,10 +455,108 @@ function mapPlacementWithSubmission(row: PlacementWithSubmissionRow): { placemen
       project_id: row.submission_project_id,
       competition_id: row.submission_competition_id,
       status: row.submission_status,
+      import_source: row.submission_import_source,
+      import_batch_id: row.submission_import_batch_id,
       created_at: row.submission_created_at,
       updated_at: row.submission_updated_at,
     }),
   };
+}
+
+function mapCareerImport(row: CareerImportRow): ImportPreviewResponse["batch"] {
+  const parsedRows = Array.isArray(row.error_log)
+    ? row.error_log.map((entry) => careerImportPreviewRowFromUnknown(entry)).filter((entry): entry is CareerImportPreviewRow => entry !== null)
+    : [];
+  return {
+    id: row.id,
+    writerId: row.writer_id,
+    filename: row.filename,
+    rowCount: row.row_count,
+    succeeded: row.succeeded,
+    failed: row.failed,
+    status: row.status as ImportPreviewResponse["batch"]["status"],
+    errorLog: parsedRows,
+    createdAt: row.created_at.toISOString(),
+    committedAt: row.committed_at?.toISOString() ?? null
+  };
+}
+
+function careerImportPreviewRowFromUnknown(value: unknown): CareerImportPreviewRow | null {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as Partial<CareerImportPreviewRow>;
+  if (typeof candidate.rowIndex !== "number" || !candidate.row || !Array.isArray(candidate.errors)) return null;
+  return {
+    rowIndex: candidate.rowIndex,
+    row: {
+      project_title: String(candidate.row.project_title ?? ""),
+      competition_name: String(candidate.row.competition_name ?? ""),
+      year: String(candidate.row.year ?? ""),
+      status: String(candidate.row.status ?? ""),
+      placement_date: String(candidate.row.placement_date ?? ""),
+      source_url: String(candidate.row.source_url ?? ""),
+      source_note: String(candidate.row.source_note ?? "")
+    },
+    status: candidate.status === "ok" ? "ok" : "error",
+    errors: candidate.errors.map(String)
+  };
+}
+
+function validateCareerImportRow(row: CreateCareerImportPreviewData["rows"][number], rowIndex: number): CareerImportPreviewRow {
+  const errors: string[] = [];
+  if (!row.project_title.trim()) errors.push("project_title is required");
+  if (!row.competition_name.trim()) errors.push("competition_name is required");
+  if (!/^\d{4}$/.test(row.year.trim())) errors.push("year must be a 4-digit year");
+  if (!row.status.trim()) errors.push("status is required");
+  if (row.status.trim() && !["pending", "quarterfinalist", "semifinalist", "finalist", "winner"].includes(row.status.trim())) {
+    errors.push("status is not supported");
+  }
+  if (row.placement_date.trim() && Number.isNaN(Date.parse(row.placement_date.trim()))) {
+    errors.push("placement_date must be a valid date");
+  }
+  if (row.source_url.trim()) {
+    try {
+      const parsed = new URL(row.source_url.trim());
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") errors.push("source_url must be http or https");
+    } catch {
+      errors.push("source_url must be a valid URL");
+    }
+  }
+  return { rowIndex, row, status: errors.length === 0 ? "ok" : "error", errors };
+}
+
+async function findOrCreateProject(client: Queryable, writerId: string, title: string): Promise<string> {
+  const existing = await client.query<{ id: string }>(
+    `SELECT id FROM projects WHERE owner_user_id = $1 AND lower(title) = lower($2::text) LIMIT 1`,
+    [writerId, title.trim()]
+  );
+  if (existing.rows[0]) return existing.rows[0].id;
+  const id = `project_${randomUUID()}`;
+  await client.query(
+    `INSERT INTO projects (id, owner_user_id, title, format, genre, is_discoverable)
+     VALUES ($1, $2, $3, 'feature', 'unknown', FALSE)`,
+    [id, writerId, title.trim()]
+  );
+  return id;
+}
+
+async function findOrCreateCompetition(client: Queryable, title: string): Promise<string> {
+  const existing = await client.query<{ id: string }>(
+    `SELECT id FROM competitions WHERE lower(title) = lower($1::text) LIMIT 1`,
+    [title.trim()]
+  );
+  if (existing.rows[0]) return existing.rows[0].id;
+  const id = `competition_${randomUUID()}`;
+  await client.query(
+    `INSERT INTO competitions (id, title, description, format, genre, fee_usd, deadline, status, visibility)
+     VALUES ($1, $2, 'Imported recovered career-history competition stub.', 'feature', 'unknown', 0, NOW(), 'active', 'unlisted')`,
+    [id, title.trim()]
+  );
+  return id;
+}
+
+function normalizePlacementDate(rawPlacementDate: string, rawYear: string): string {
+  if (rawPlacementDate.trim()) return rawPlacementDate.trim();
+  return `${rawYear.trim()}-12-31T00:00:00.000Z`;
 }
 
 function mapPlacementEvidence(row: PlacementEvidenceRow): PlacementEvidence {

--- a/services/submission-tracking-service/src/repository.ts
+++ b/services/submission-tracking-service/src/repository.ts
@@ -1,6 +1,10 @@
 import type {
   CreateHistoricalPlacementData,
+  CommitCareerImportData,
+  CreateCareerImportPreviewData,
   CreatePlacementEvidenceData,
+  ImportCommitResponse,
+  ImportPreviewResponse,
   Placement,
   PlacementEvidence,
   PlacementFilters,
@@ -32,4 +36,8 @@ export interface SubmissionTrackingRepository {
   listPlacementEvidence(placementId: string): Promise<PlacementEvidence[]>;
   listPlacementsBySubmission(submissionId: string): Promise<Placement[]>;
   listPlacements(filters: PlacementFilters): Promise<{ placement: Placement; submission: Submission }[]>;
+
+  createCareerImportPreview(data: CreateCareerImportPreviewData): Promise<ImportPreviewResponse>;
+  getCareerImport(batchId: string, writerId: string): Promise<ImportPreviewResponse | null>;
+  commitCareerImport(data: CommitCareerImportData): Promise<ImportCommitResponse>;
 }


### PR DESCRIPTION
## Summary
- add migration 025 career_history_imports and recovered import provenance on submissions/placements
- add career import contracts, submission-service CSV preview/commit endpoints, and gateway proxies
- add writer-web import template/page and Recovered placement badge

## Verification
- pnpm install
- pnpm migrate (after building @script-manifest/search dist required by migration runner)
- pnpm typecheck (after building @script-manifest/email dist required by identity-service typecheck)
- pnpm --filter @script-manifest/submission-tracking-service test
- pnpm --filter @script-manifest/api-gateway test
- pnpm lint (0 errors; existing workspace warnings remain)