### PR TITLE
feat(CHAOS-1809): add shareable writer resume

### DIFF
--- a/apps/writer-web/app/api/scripts/[scriptId]/viewer/route.ts
+++ b/apps/writer-web/app/api/scripts/[scriptId]/viewer/route.ts
@@ -38,6 +38,9 @@ export async function GET(
           { status: 502 }
         );
       }
+      if (!parseResult.data.access.isOwner) {
+        await recordScriptViewEvent(scriptId, "view");
+      }
       return NextResponse.json(parseResult.data);
     } catch (error) {
       return NextResponse.json(
@@ -86,6 +89,10 @@ export async function GET(
       );
     }
 
+    if (!parseResult.data.access.isOwner) {
+      await recordScriptViewEvent(scriptId, url.searchParams.get("download") === "1" ? "download" : "view", viewerUserId);
+    }
+
     return NextResponse.json(parseResult.data);
   } catch (error) {
     return NextResponse.json(
@@ -95,5 +102,18 @@ export async function GET(
       },
       { status: 502 }
     );
+  }
+}
+
+async function recordScriptViewEvent(scriptId: string, eventType: "view" | "download", viewerUserId?: string): Promise<void> {
+  try {
+    await fetch(new URL(`/internal/scripts/${encodeURIComponent(scriptId)}/view-event`, scriptStorageServiceBase), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ eventType, viewerUserId }),
+      cache: "no-store"
+    });
+  } catch {
+    // Viewing should not fail because proof metric capture is temporarily unavailable.
   }
 }

--- a/apps/writer-web/app/api/v1/writers/[writerId]/resume-views/route.ts
+++ b/apps/writer-web/app/api/v1/writers/[writerId]/resume-views/route.ts
@@ -1,0 +1,6 @@
+import { proxyRequest } from "../../../_proxy";
+
+export async function POST(request: Request, context: { params: Promise<{ writerId: string }> }) {
+  const { writerId } = await context.params;
+  return proxyRequest(request, `/api/v1/writers/${encodeURIComponent(writerId)}/resume-views`);
+}

--- a/apps/writer-web/app/api/v1/writers/me/resume-metrics/route.ts
+++ b/apps/writer-web/app/api/v1/writers/me/resume-metrics/route.ts
@@ -1,0 +1,5 @@
+import { proxyRequest } from "../../../_proxy";
+
+export async function GET(request: Request) {
+  return proxyRequest(request, "/api/v1/writers/me/resume-metrics");
+}

--- a/apps/writer-web/app/components/ResumeMetricsWidget.tsx
+++ b/apps/writer-web/app/components/ResumeMetricsWidget.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import useSWR from "swr";
+import type { ResumeMetricsResponse, WriterProfile } from "@script-manifest/contracts";
+import { fetcher } from "../lib/fetcher";
+
+export function ResumeMetricsWidget({ profile }: { profile: WriterProfile }) {
+  const { data } = useSWR<{ metrics: ResumeMetricsResponse }>("/api/v1/writers/me/resume-metrics", fetcher);
+  const handle = profile.customProfileUrl || profile.id;
+  const sharePath = handle.startsWith("http") ? handle : `/writers/${handle}`;
+
+  async function copyShareLink() {
+    const origin = window.location.origin;
+    await navigator.clipboard.writeText(sharePath.startsWith("http") ? sharePath : `${origin}${sharePath}`);
+  }
+
+  return (
+    <article className="panel stack">
+      <p className="eyebrow">Resume proof metrics</p>
+      <div className="grid-two">
+        <span>{data?.metrics?.totalViews7d ?? 0} views · 7d</span>
+        <span>{data?.metrics?.totalViews30d ?? 0} views · 30d</span>
+        <span>{data?.metrics?.totalScriptDownloads ?? 0} script downloads</span>
+        <span>{data?.metrics?.verifiedPlacementsCount ?? 0} verified placements</span>
+      </div>
+      <div className="inline-form">
+        <a className="btn btn-secondary no-underline" href={sharePath}>Open resume</a>
+        <button className="btn btn-secondary" type="button" onClick={() => void copyShareLink()}>Copy share link</button>
+      </div>
+    </article>
+  );
+}

--- a/apps/writer-web/app/profile/page.test.tsx
+++ b/apps/writer-web/app/profile/page.test.tsx
@@ -129,6 +129,7 @@ describe("ProfilePage", () => {
           headshotUrl: "https://cdn.example.com/writer-updated.jpg",
           customProfileUrl: "https://profiles.example.com/writer-updated",
           isSearchable: false,
+          resumePublic: true,
         }),
       })
     );

--- a/apps/writer-web/app/profile/page.tsx
+++ b/apps/writer-web/app/profile/page.tsx
@@ -10,6 +10,7 @@ import { fetcher, ApiError } from "../lib/fetcher";
 import { SkeletonText } from "../components/skeleton";
 import { useToast } from "../components/toast";
 import { useAuth } from "../lib/AuthProvider";
+import { ResumeMetricsWidget } from "../components/ResumeMetricsWidget";
 
 type EditableProfile = {
   displayName: string;
@@ -20,6 +21,7 @@ type EditableProfile = {
   headshotUrl: string;
   customProfileUrl: string;
   isSearchable: boolean;
+  resumePublic: boolean;
 };
 
 const initialDraft: EditableProfile = {
@@ -31,6 +33,7 @@ const initialDraft: EditableProfile = {
   headshotUrl: "",
   customProfileUrl: "",
   isSearchable: true,
+  resumePublic: true,
 };
 
 function isPreviewableImageUrl(value: string): boolean {
@@ -61,6 +64,7 @@ function profileToDraft(p: WriterProfile): EditableProfile {
     headshotUrl: p.headshotUrl,
     customProfileUrl: p.customProfileUrl,
     isSearchable: p.isSearchable,
+    resumePublic: p.resumePublic ?? true,
   };
 }
 
@@ -149,6 +153,7 @@ export default function ProfilePage() {
       headshotUrl: draft.headshotUrl.trim(),
       customProfileUrl: draft.customProfileUrl.trim(),
       isSearchable: draft.isSearchable,
+      resumePublic: draft.resumePublic,
     };
 
     await triggerSave(payload);
@@ -351,6 +356,17 @@ export default function ProfilePage() {
               <span>Allow profile in search results</span>
             </label>
 
+            <label className="inline-form">
+              <input
+                type="checkbox"
+                checked={draft.resumePublic}
+                onChange={(event) =>
+                  setDraft((current) => ({ ...current, resumePublic: event.target.checked }))
+                }
+              />
+              <span>Public resume page</span>
+            </label>
+
             {isPreviewableImageUrl(draft.headshotUrl) ? (
               <div className="subcard">
                 <p className="eyebrow">Headshot Preview</p>
@@ -373,6 +389,8 @@ export default function ProfilePage() {
           </form>
         </article>
       ) : null}
+
+      {profile?.resumePublic === true ? <ResumeMetricsWidget profile={profile} /> : null}
 
       {writerId ? (
         <article className="panel">

--- a/apps/writer-web/app/writers/[handle]/ResumeView.tsx
+++ b/apps/writer-web/app/writers/[handle]/ResumeView.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+import useSWRMutation from "swr/mutation";
+
+async function recordResumeView(url: string): Promise<void> {
+  await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({})
+  });
+}
+
+export function ResumeView({ writerId }: { writerId: string }) {
+  const { trigger } = useSWRMutation(
+    `/api/v1/writers/${encodeURIComponent(writerId)}/resume-views`,
+    recordResumeView
+  );
+
+  useEffect(() => {
+    void trigger();
+  }, [trigger]);
+
+  return null;
+}

--- a/apps/writer-web/app/writers/[handle]/page.tsx
+++ b/apps/writer-web/app/writers/[handle]/page.tsx
@@ -1,0 +1,96 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import type { WriterResume } from "@script-manifest/contracts";
+import { ApiError } from "../../lib/fetcher";
+import { serverFetch } from "../../lib/serverFetch";
+import { ResumeView } from "./ResumeView";
+
+type PageParams = { params: Promise<{ handle: string }> };
+
+async function loadResume(handle: string): Promise<WriterResume> {
+  try {
+    const response = await serverFetch<{ resume: WriterResume }>(`/api/v1/writers/${encodeURIComponent(handle)}/resume`);
+    return response.resume;
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      notFound();
+    }
+    throw error;
+  }
+}
+
+export async function generateMetadata({ params }: PageParams): Promise<Metadata> {
+  const { handle } = await params;
+  const resume = await loadResume(handle);
+  const title = `${resume.profile.displayName} — Writer Resume`;
+  const description = resume.profile.bio || `${resume.profile.displayName}'s verified writing proof, placements, projects, and hosted scripts.`;
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: resume.profile.headshotUrl ? [{ url: resume.profile.headshotUrl }] : undefined
+    }
+  };
+}
+
+export default async function WriterResumePage({ params }: PageParams) {
+  const { handle } = await params;
+  const resume = await loadResume(handle);
+  return (
+    <section className="space-y-6">
+      <ResumeView writerId={resume.profile.id} />
+      <article className="hero-card hero-card--amber animate-in">
+        <p className="eyebrow eyebrow--amber">Verified writer resume</p>
+        <h1 className="text-4xl text-foreground">{resume.profile.displayName}</h1>
+        <p className="max-w-3xl text-foreground-secondary">{resume.profile.bio || "Verified writing proof from Script Manifest."}</p>
+        <div className="inline-form">
+          <span className="badge">{resume.ranking.tier}</span>
+          <span className="badge">Rank #{resume.ranking.rank || "—"}</span>
+          <span className="badge">{resume.proofMetrics.verifiedPlacementsCount} verified placements</span>
+        </div>
+      </article>
+
+      <section className="grid-two">
+        <article className="panel stack">
+          <p className="eyebrow">Placements</p>
+          {resume.placements.length ? resume.placements.map((placement) => (
+            <div key={placement.id} className="subcard">
+              <div className="inline-form">
+                <strong>{placement.status}</strong>
+                <span className={placement.verificationState === "verified" ? "badge badge-success" : "badge"}>{placement.badgeLabel ?? "Verified"}</span>
+              </div>
+              <p className="text-foreground-secondary">Competition: {placement.competitionId}</p>
+            </div>
+          )) : <p className="text-foreground-secondary">No verified placements yet.</p>}
+        </article>
+
+        <article className="panel stack">
+          <p className="eyebrow">Proof metrics</p>
+          <p>{resume.proofMetrics.totalViews30d} resume views in 30 days</p>
+          <p>{resume.proofMetrics.totalScriptDownloads} script downloads</p>
+          <p>{resume.projects.length} public projects</p>
+        </article>
+      </section>
+
+      <article className="panel stack">
+        <p className="eyebrow">Projects</p>
+        {resume.projects.map((project) => (
+          <div key={project.id} className="subcard">
+            <strong>{project.title}</strong>
+            <p className="text-foreground-secondary">{project.logline}</p>
+            <span className="badge">{project.format} · {project.genre}</span>
+          </div>
+        ))}
+      </article>
+
+      <article className="panel stack">
+        <p className="eyebrow">Hosted scripts</p>
+        {resume.hostedScripts.length ? resume.hostedScripts.map((script) => (
+          <a key={script.scriptId} className="subcard no-underline" href={script.viewerPath}>{script.filename}</a>
+        )) : <p className="text-foreground-secondary">No public hosted scripts yet.</p>}
+      </article>
+    </section>
+  );
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -24,3 +24,4 @@ export * from "./feature-flags.js";
 export * from "./ip-blocking.js";
 export * from "./onboarding.js";
 export * from "./search-sync.js";
+export * from "./writer-resume.js";

--- a/packages/contracts/src/profile.ts
+++ b/packages/contracts/src/profile.ts
@@ -10,7 +10,8 @@ export const WriterProfileSchema = z.object({
   representationStatus: z.enum(["represented", "unrepresented", "seeking_rep"]),
   headshotUrl: OptionalUrlStringSchema.default(""),
   customProfileUrl: OptionalUrlStringSchema.default(""),
-  isSearchable: z.boolean().default(true)
+  isSearchable: z.boolean().default(true),
+  resumePublic: z.boolean().default(true).optional()
 });
 
 export type WriterProfile = z.infer<typeof WriterProfileSchema>;
@@ -25,7 +26,8 @@ export const WriterProfileUpdateRequestSchema = z.object({
     .optional(),
   headshotUrl: OptionalUrlStringSchema.optional(),
   customProfileUrl: OptionalUrlStringSchema.optional(),
-  isSearchable: z.boolean().optional()
+  isSearchable: z.boolean().optional(),
+  resumePublic: z.boolean().optional()
 });
 
 export type WriterProfileUpdateRequest = z.infer<typeof WriterProfileUpdateRequestSchema>;

--- a/packages/contracts/src/writer-resume.ts
+++ b/packages/contracts/src/writer-resume.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+import { OptionalUrlStringSchema } from "./common.js";
+import { PlacementListItemSchema } from "./submission.js";
+import { ProjectSchema } from "./project.js";
+
+export const ResumeProfileSchema = z.object({
+  id: z.string().min(1),
+  displayName: z.string().min(1),
+  bio: z.string().default(""),
+  headshotUrl: OptionalUrlStringSchema.default(""),
+  customProfileUrl: z.string().default(""),
+  representationStatus: z.enum(["represented", "unrepresented", "seeking_rep"]),
+  genres: z.array(z.string()).default([]),
+  resumePublic: z.boolean().optional()
+});
+
+export const ResumeBadgeSchema = z.object({
+  id: z.string().min(1).optional(),
+  label: z.string().min(1),
+  placementId: z.string().min(1).optional(),
+  competitionId: z.string().min(1).optional(),
+  awardedAt: z.string().optional()
+});
+
+export const ResumeRankingSchema = z.object({
+  totalScore: z.number().default(0),
+  rank: z.number().int().nonnegative().default(0),
+  tier: z.string().default("unranked"),
+  scoreChange30d: z.number().default(0)
+});
+
+export const HostedScriptSchema = z.object({
+  scriptId: z.string().min(1),
+  ownerUserId: z.string().min(1),
+  filename: z.string().min(1),
+  contentType: z.string().min(1),
+  size: z.number().int().nonnegative(),
+  registeredAt: z.string(),
+  viewerPath: z.string().min(1),
+  viewerUrl: z.string().min(1).optional()
+});
+
+export const ResumeProofMetricsSchema = z.object({
+  totalViews7d: z.number().int().nonnegative(),
+  totalViews30d: z.number().int().nonnegative(),
+  totalScriptDownloads: z.number().int().nonnegative(),
+  verifiedPlacementsCount: z.number().int().nonnegative(),
+  projectsCount: z.number().int().nonnegative()
+});
+
+export const WriterResumeSchema = z.object({
+  profile: ResumeProfileSchema,
+  projects: z.array(ProjectSchema),
+  placements: z.array(PlacementListItemSchema),
+  badges: z.array(ResumeBadgeSchema),
+  ranking: ResumeRankingSchema,
+  hostedScripts: z.array(HostedScriptSchema),
+  proofMetrics: ResumeProofMetricsSchema
+});
+
+export type WriterResume = z.infer<typeof WriterResumeSchema>;
+
+export const ResumeMetricsResponseSchema = ResumeProofMetricsSchema.extend({
+  writerId: z.string().min(1)
+});
+
+export type ResumeMetricsResponse = z.infer<typeof ResumeMetricsResponseSchema>;
+
+export const ResumePageViewCreateRequestSchema = z.object({
+  viewerUserId: z.string().min(1).optional(),
+  referrer: z.string().max(2048).optional(),
+  userAgentHash: z.string().min(1),
+  ipHash: z.string().min(1),
+  viewedAt: z.string().datetime({ offset: true }).optional()
+});
+
+export type ResumePageViewCreateRequest = z.infer<typeof ResumePageViewCreateRequestSchema>;
+
+export const ScriptViewEventCreateRequestSchema = z.object({
+  viewerUserId: z.string().min(1).optional(),
+  eventType: z.enum(["view", "download"]),
+  occurredAt: z.string().datetime({ offset: true }).optional()
+});
+
+export type ScriptViewEventCreateRequest = z.infer<typeof ScriptViewEventCreateRequestSchema>;

--- a/packages/db/migrations/028_resume_share_metrics.sql
+++ b/packages/db/migrations/028_resume_share_metrics.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS resume_page_views (
+  id TEXT PRIMARY KEY,
+  writer_id TEXT NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
+  viewed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  viewer_user_id TEXT REFERENCES app_users(id),
+  referrer VARCHAR(2048),
+  user_agent_hash TEXT,
+  ip_hash TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_rpv_writer_time ON resume_page_views(writer_id, viewed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_rpv_dedupe ON resume_page_views(writer_id, ip_hash, user_agent_hash, viewed_at DESC);
+
+CREATE TABLE IF NOT EXISTS script_view_events (
+  id TEXT PRIMARY KEY,
+  script_id TEXT NOT NULL,
+  owner_user_id TEXT NOT NULL REFERENCES app_users(id),
+  viewer_user_id TEXT REFERENCES app_users(id),
+  event_type TEXT NOT NULL CHECK (event_type IN ('view', 'download')),
+  occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sve_owner_time ON script_view_events(owner_user_id, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_sve_script_time ON script_view_events(script_id, occurred_at DESC);
+
+ALTER TABLE writer_profiles
+  ADD COLUMN IF NOT EXISTS resume_public BOOLEAN NOT NULL DEFAULT TRUE;

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -33,6 +33,7 @@ import { registerFeatureFlagRoutes } from "./routes/feature-flags.js";
 import { registerMfaRoutes } from "./routes/mfa.js";
 import { registerOnboardingRoutes } from "./routes/onboarding.js";
 import { registerHealthRoutes } from "./routes/health.js";
+import { registerResumeRoutes } from "./routes/resume.js";
 import { registerIpBlocklist } from "./plugins/ipBlocklist.js";
 import { registerMetrics, registerSentryErrorHandler } from "@script-manifest/service-utils";
 
@@ -128,6 +129,7 @@ export async function buildServer(options: ApiGatewayOptions = {}): Promise<Fast
   registerAuthRoutes(server, ctx);
   registerMfaRoutes(server, ctx);
   registerProfileRoutes(server, ctx);
+  registerResumeRoutes(server, ctx);
   registerProjectRoutes(server, ctx);
   registerCompetitionRoutes(server, ctx);
   registerSubmissionRoutes(server, ctx);

--- a/services/api-gateway/src/routes/resume.test.ts
+++ b/services/api-gateway/src/routes/resume.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { request } from "undici";
+import { buildServer } from "../index.js";
+
+type RequestResult = Awaited<ReturnType<typeof request>>;
+
+function jsonResponse(payload: unknown, statusCode = 200): RequestResult {
+  return {
+    statusCode,
+    headers: { "content-type": "application/json" },
+    body: {
+      json: async () => payload,
+      text: async () => JSON.stringify(payload)
+    }
+  } as unknown as RequestResult;
+}
+
+test("GET /api/v1/writers/:handle/resume proxies public resume requests without auth", async (t) => {
+  const urls: string[] = [];
+  const server = await buildServer({
+    logger: false,
+    requestFn: (async (url) => {
+      urls.push(String(url));
+      return jsonResponse({ resume: { profile: { id: "writer_01" } } });
+    }) as typeof request,
+    profileServiceBase: "http://profile-svc"
+  });
+  t.after(async () => { await server.close(); });
+
+  const response = await server.inject({ method: "GET", url: "/api/v1/writers/writer-one/resume" });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(urls[0], "http://profile-svc/internal/writers/writer-one/resume");
+});
+
+test("POST /api/v1/writers/:id/resume-views forwards hashed ip and user agent for dedupe", async (t) => {
+  const bodies: string[] = [];
+  const server = await buildServer({
+    logger: false,
+    requestFn: (async (url, options) => {
+      if (String(url).includes("/internal/auth/me")) {
+        return jsonResponse({ user: { id: "viewer_01" } });
+      }
+      bodies.push(String(options?.body ?? ""));
+      return jsonResponse({ recorded: true }, 201);
+    }) as typeof request,
+    identityServiceBase: "http://identity-svc",
+    profileServiceBase: "http://profile-svc"
+  });
+  t.after(async () => { await server.close(); });
+
+  const response = await server.inject({
+    method: "POST",
+    url: "/api/v1/writers/writer_01/resume-views",
+    headers: { authorization: "Bearer token", "user-agent": "ResumeBot", "x-forwarded-for": "203.0.113.7" }
+  });
+
+  assert.equal(response.statusCode, 201);
+  const body = JSON.parse(bodies[0] ?? "{}") as { ipHash?: string; userAgentHash?: string; viewerUserId?: string };
+  assert.equal(body.viewerUserId, "viewer_01");
+  assert.equal(body.ipHash?.length, 40);
+  assert.equal(body.userAgentHash?.length, 40);
+  assert.notEqual(body.ipHash, "203.0.113.7");
+});
+
+test("GET /api/v1/writers/me/resume-metrics requires auth and proxies writer-only metrics", async (t) => {
+  const urls: string[] = [];
+  const server = await buildServer({
+    logger: false,
+    requestFn: (async (url) => {
+      const target = String(url);
+      if (target.includes("/internal/auth/me")) {
+        return jsonResponse({ user: { id: "writer_01" } });
+      }
+      urls.push(target);
+      return jsonResponse({ metrics: { writerId: "writer_01", totalViews7d: 1, totalViews30d: 2, totalScriptDownloads: 0, verifiedPlacementsCount: 3, projectsCount: 4 } });
+    }) as typeof request,
+    identityServiceBase: "http://identity-svc",
+    profileServiceBase: "http://profile-svc"
+  });
+  t.after(async () => { await server.close(); });
+
+  const unauth = await server.inject({ method: "GET", url: "/api/v1/writers/me/resume-metrics" });
+  assert.equal(unauth.statusCode, 401);
+
+  const authed = await server.inject({ method: "GET", url: "/api/v1/writers/me/resume-metrics", headers: { authorization: "Bearer token" } });
+  assert.equal(authed.statusCode, 200);
+  assert.equal(urls[0], "http://profile-svc/internal/writers/writer_01/resume-metrics");
+});

--- a/services/api-gateway/src/routes/resume.ts
+++ b/services/api-gateway/src/routes/resume.ts
@@ -1,0 +1,68 @@
+import type { FastifyInstance } from "fastify";
+import { createHash } from "node:crypto";
+import { ResumePageViewCreateRequestSchema } from "@script-manifest/contracts";
+import {
+  type GatewayContext,
+  addAuthUserIdHeader,
+  getUserIdFromAuth,
+  proxyJsonRequest
+} from "../helpers.js";
+
+export function registerResumeRoutes(server: FastifyInstance, ctx: GatewayContext): void {
+  server.get<{ Params: { writerIdOrCustomUrl: string } }>("/api/v1/writers/:writerIdOrCustomUrl/resume", async (req, reply) => {
+    return proxyJsonRequest(
+      reply,
+      ctx.requestFn,
+      `${ctx.profileServiceBase}/internal/writers/${encodeURIComponent(req.params.writerIdOrCustomUrl)}/resume`,
+      { method: "GET" }
+    );
+  });
+
+  server.post<{ Params: { writerId: string } }>("/api/v1/writers/:writerId/resume-views", {
+    config: { rateLimit: { max: 30, timeWindow: "1 minute" } },
+    handler: async (req, reply) => {
+      const userId = await getUserIdFromAuth(ctx.requestFn, ctx.identityServiceBase, req.headers.authorization, req.log);
+      const userAgent = req.headers["user-agent"] ?? "unknown";
+      const forwardedFor = req.headers["x-forwarded-for"];
+      const ip = Array.isArray(forwardedFor) ? forwardedFor[0] ?? req.ip : forwardedFor?.split(",")[0]?.trim() ?? req.ip;
+      const body = req.body && typeof req.body === "object" ? req.body : {};
+      const parsed = ResumePageViewCreateRequestSchema.safeParse({
+        ...body,
+        viewerUserId: userId ?? undefined,
+        userAgentHash: sha1(String(userAgent)),
+        ipHash: sha1(ip),
+        referrer: req.headers.referer ?? req.headers.referrer
+      });
+      if (!parsed.success) {
+        return reply.status(400).send({ error: "invalid_payload", details: parsed.error.flatten() });
+      }
+      return proxyJsonRequest(
+        reply,
+        ctx.requestFn,
+        `${ctx.profileServiceBase}/internal/writers/${encodeURIComponent(req.params.writerId)}/resume-views`,
+        {
+          method: "POST",
+          headers: addAuthUserIdHeader({ "content-type": "application/json" }, userId),
+          body: JSON.stringify(parsed.data)
+        }
+      );
+    }
+  });
+
+  server.get("/api/v1/writers/me/resume-metrics", async (req, reply) => {
+    const userId = await getUserIdFromAuth(ctx.requestFn, ctx.identityServiceBase, req.headers.authorization, req.log);
+    if (!userId) {
+      return reply.status(401).send({ error: "unauthorized" });
+    }
+    return proxyJsonRequest(
+      reply,
+      ctx.requestFn,
+      `${ctx.profileServiceBase}/internal/writers/${encodeURIComponent(userId)}/resume-metrics`,
+      { method: "GET", headers: addAuthUserIdHeader({}, userId) }
+    );
+  });
+}
+
+function sha1(value: string): string {
+  return createHash("sha1").update(value).digest("hex");
+}

--- a/services/identity-service/src/onboarding-routes.ts
+++ b/services/identity-service/src/onboarding-routes.ts
@@ -16,6 +16,9 @@ const STEP_TO_COLUMN = {
   shareUsed: "share_used"
 } as const;
 
+type OnboardingStepKey = keyof typeof STEP_TO_COLUMN;
+type OnboardingProgressFlags = Partial<Record<OnboardingStepKey, boolean>>;
+
 export function registerOnboardingRoutes(
   server: FastifyInstance,
   onboardingRepo: OnboardingRepository,
@@ -70,8 +73,9 @@ export function registerOnboardingRoutes(
         return reply.status(400).send({ error: "invalid_payload", details: parsed.error.flatten() });
       }
 
-      for (const stepKey of Object.keys(STEP_TO_COLUMN) as Array<keyof typeof STEP_TO_COLUMN>) {
-        if (parsed.data[stepKey]) {
+      const progressFlags = parsed.data as OnboardingProgressFlags;
+      for (const stepKey of Object.keys(STEP_TO_COLUMN) as OnboardingStepKey[]) {
+        if (progressFlags[stepKey]) {
           await onboardingRepo.markStepComplete(sessionData.user.id, STEP_TO_COLUMN[stepKey]);
         }
       }

--- a/services/profile-project-service/src/index.test.ts
+++ b/services/profile-project-service/src/index.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { request } from "undici";
 import type {
+  ResumeMetricsResponse,
+  WriterResume,
   NotificationEventEnvelope,
   Project,
   ProjectCoWriter,
@@ -32,6 +35,7 @@ class MemoryRepository extends BaseMemoryRepository implements ProfileProjectRep
   private nextProject = 1;
   private nextDraft = 1;
   private nextAccessRequest = 1;
+  private resumeViews: Array<{ writerId: string; ipHash: string; userAgentHash: string; viewedAt: string }> = [];
 
   constructor() {
     super();
@@ -44,7 +48,32 @@ class MemoryRepository extends BaseMemoryRepository implements ProfileProjectRep
       representationStatus: "unrepresented",
       headshotUrl: "",
       customProfileUrl: "",
-      isSearchable: true
+      isSearchable: true,
+      resumePublic: true
+    });
+    this.profiles.set("writer_02", {
+      id: "writer_02",
+      displayName: "Writer Two",
+      bio: "Hidden search profile",
+      genres: ["Comedy"],
+      demographics: [],
+      representationStatus: "unrepresented",
+      headshotUrl: "",
+      customProfileUrl: "hidden-search",
+      isSearchable: false,
+      resumePublic: true
+    });
+    this.profiles.set("writer_03", {
+      id: "writer_03",
+      displayName: "Writer Three",
+      bio: "Hidden resume profile",
+      genres: ["Horror"],
+      demographics: [],
+      representationStatus: "seeking_rep",
+      headshotUrl: "",
+      customProfileUrl: "hidden-resume",
+      isSearchable: true,
+      resumePublic: false
     });
   }
 
@@ -54,6 +83,40 @@ class MemoryRepository extends BaseMemoryRepository implements ProfileProjectRep
 
   async getProfile(writerId: string): Promise<WriterProfile | null> {
     return this.profiles.get(writerId) ?? null;
+  }
+
+  async resolveResumeProfile(writerIdOrCustomUrl: string): Promise<WriterProfile | null> {
+    return this.profiles.get(writerIdOrCustomUrl) ?? Array.from(this.profiles.values()).find((profile) => profile.customProfileUrl === writerIdOrCustomUrl) ?? null;
+  }
+
+  async recordResumePageView(writerId: string, input: {
+    ipHash: string;
+    userAgentHash: string;
+    viewedAt?: string;
+  }): Promise<boolean> {
+    const viewedAt = input.viewedAt ?? new Date().toISOString();
+    const recentCutoff = Date.parse(viewedAt) - 60_000;
+    const duplicate = this.resumeViews.some((view) =>
+      view.writerId === writerId &&
+      view.ipHash === input.ipHash &&
+      view.userAgentHash === input.userAgentHash &&
+      Date.parse(view.viewedAt) >= recentCutoff
+    );
+    if (duplicate) return false;
+    this.resumeViews.push({ writerId, ...input, viewedAt });
+    return true;
+  }
+
+  async getResumeMetrics(writerId: string): Promise<ResumeMetricsResponse> {
+    const views = this.resumeViews.filter((view) => view.writerId === writerId).length;
+    return {
+      writerId,
+      totalViews7d: views,
+      totalViews30d: views,
+      totalScriptDownloads: 0,
+      verifiedPlacementsCount: 0,
+      projectsCount: Array.from(this.projects.values()).filter((project) => project.ownerUserId === writerId && project.isDiscoverable).length
+    };
   }
 
   async upsertProfile(
@@ -370,6 +433,96 @@ test("profile-project-service returns profile when available", async (t) => {
   assert.equal(response.json().profile.headshotUrl, "");
   assert.equal(response.json().profile.customProfileUrl, "");
   assert.equal(response.json().profile.isSearchable, true);
+});
+
+test("resume endpoint returns 404 when profile is not searchable", async (t) => {
+  const server = buildServer({ logger: false, repository: new MemoryRepository(), publisher: async () => undefined });
+  t.after(async () => { await server.close(); });
+
+  const response = await server.inject({ method: "GET", url: "/internal/writers/hidden-search/resume" });
+
+  assert.equal(response.statusCode, 404);
+  assert.equal(response.json().error, "resume_not_found");
+});
+
+test("resume endpoint returns 404 when public resume is disabled", async (t) => {
+  const server = buildServer({ logger: false, repository: new MemoryRepository(), publisher: async () => undefined });
+  t.after(async () => { await server.close(); });
+
+  const response = await server.inject({ method: "GET", url: "/internal/writers/hidden-resume/resume" });
+
+  assert.equal(response.statusCode, 404);
+  assert.equal(response.json().error, "resume_not_found");
+});
+
+test("resume endpoint resolves custom URL and filters to verified placement payload from submission service", async (t) => {
+  const repository = new MemoryRepository();
+  await repository.upsertProfile("writer_01", { customProfileUrl: "writer-one" });
+  await repository.createProject({
+    ownerUserId: "writer_01",
+    title: "Discoverable Script",
+    logline: "A verified writer ships proof.",
+    synopsis: "",
+    format: "feature",
+    genre: "drama",
+    pageCount: 101,
+    isDiscoverable: true
+  });
+  await repository.createProject({
+    ownerUserId: "writer_01",
+    title: "Private Script",
+    logline: "Should stay hidden.",
+    synopsis: "",
+    format: "feature",
+    genre: "drama",
+    pageCount: 101,
+    isDiscoverable: false
+  });
+
+  const requestedUrls: string[] = [];
+  const requestFn = (async (url) => {
+    const target = String(url);
+    requestedUrls.push(target);
+    const body = target.includes("/verified-placements")
+      ? { placements: [{ id: "placement_verified", submissionId: "sub_1", writerId: "writer_01", projectId: "project_1", competitionId: "austin", status: "finalist", verificationState: "verified", isHistorical: false, badgeLabel: "Verified", createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), verifiedAt: new Date().toISOString(), sourceNote: null, recordedByUserId: null, reviewedByUserId: null, reviewedAt: null, reviewNotes: null }] }
+      : target.includes("/public-scripts")
+        ? { scripts: [] }
+        : target.includes("/badges")
+          ? { badges: [] }
+          : target.includes("/score")
+            ? { writerId: "writer_01", totalScore: 12, rank: 4, tier: "rising", scoreChange30d: 1 }
+            : {};
+    return { statusCode: 200, body: { json: async () => body, text: async () => JSON.stringify(body) }, headers: {} };
+  }) as typeof request;
+  const server = buildServer({ logger: false, repository, publisher: async () => undefined, requestFn });
+  t.after(async () => { await server.close(); });
+
+  const response = await server.inject({ method: "GET", url: "/internal/writers/writer-one/resume" });
+
+  assert.equal(response.statusCode, 200);
+  const resume = response.json().resume as WriterResume;
+  assert.equal(resume.profile.id, "writer_01");
+  assert.equal(resume.projects.length, 1);
+  assert.equal(resume.placements.length, 1);
+  assert.equal(resume.placements[0]?.verificationState, "verified");
+  assert.ok(requestedUrls.some((url) => url.endsWith("/internal/writers/writer_01/verified-placements")));
+});
+
+test("resume page view records once per ip and user-agent hash within 60 seconds", async (t) => {
+  const repository = new MemoryRepository();
+  const server = buildServer({ logger: false, repository, publisher: async () => undefined });
+  t.after(async () => { await server.close(); });
+
+  const payload = { ipHash: "ip_hash", userAgentHash: "ua_hash", viewedAt: "2026-01-01T00:00:00.000Z" };
+  const first = await server.inject({ method: "POST", url: "/internal/writers/writer_01/resume-views", payload });
+  const second = await server.inject({ method: "POST", url: "/internal/writers/writer_01/resume-views", payload: { ...payload, viewedAt: "2026-01-01T00:00:30.000Z" } });
+  const metrics = await repository.getResumeMetrics("writer_01");
+
+  assert.equal(first.statusCode, 201);
+  assert.equal(first.json().recorded, true);
+  assert.equal(second.statusCode, 200);
+  assert.equal(second.json().recorded, false);
+  assert.equal(metrics.totalViews30d, 1);
 });
 
 test("profile-project-service round-trips rich profile fields", async (t) => {

--- a/services/profile-project-service/src/index.ts
+++ b/services/profile-project-service/src/index.ts
@@ -9,12 +9,16 @@ import {
   ProjectDraftUpdateRequestSchema,
   ProjectFiltersSchema,
   ProjectUpdateRequestSchema,
+  ResumeMetricsResponseSchema,
+  ResumePageViewCreateRequestSchema,
   ScriptAccessRequestCreateRequestSchema,
   ScriptAccessRequestDecisionRequestSchema,
   ScriptAccessRequestFiltersSchema,
+  WriterResumeSchema,
   WriterProfileUpdateRequestSchema
 } from "@script-manifest/contracts";
 import { randomUUID } from "node:crypto";
+import { request as undiciRequest } from "undici";
 import {
   type ProfileProjectRepository,
   PgProfileProjectRepository
@@ -22,11 +26,16 @@ import {
 import { registerMetrics, registerSentryErrorHandler } from "@script-manifest/service-utils";
 
 type PublishNotificationEvent = typeof publishNotificationEvent;
+type RequestFn = typeof undiciRequest;
 
 export type ProfileProjectServiceOptions = {
   logger?: boolean;
   publisher?: PublishNotificationEvent;
   repository?: ProfileProjectRepository;
+  requestFn?: RequestFn;
+  submissionTrackingBase?: string;
+  scriptStorageBase?: string;
+  rankingServiceBase?: string;
 };
 
 // lgtm [js/missing-rate-limiting]
@@ -34,6 +43,10 @@ export function buildServer(options: ProfileProjectServiceOptions = {}): Fastify
   const server = createFastifyServer({ logger: options.logger });
   const publisher = options.publisher ?? publishNotificationEvent;
   const repository = options.repository ?? new PgProfileProjectRepository();
+  const requestFn = options.requestFn ?? undiciRequest;
+  const submissionTrackingBase = options.submissionTrackingBase ?? process.env.SUBMISSION_TRACKING_SERVICE_URL ?? "http://localhost:4004";
+  const scriptStorageBase = options.scriptStorageBase ?? process.env.SCRIPT_STORAGE_SERVICE_URL ?? "http://localhost:4011";
+  const rankingServiceBase = options.rankingServiceBase ?? process.env.RANKING_SERVICE_URL ?? "http://localhost:4007";
   const runHealthCheck = options.repository ? () => repository.healthCheck() : healthCheck;
 
   server.addHook("onReady", async () => {
@@ -79,6 +92,80 @@ export function buildServer(options: ProfileProjectServiceOptions = {}): Fastify
       }
       const ok = Object.values(checks).every(Boolean);
       return reply.status(ok ? 200 : 503).send({ service: "profile-project-service", ok, checks });
+    }
+  });
+
+  server.get<{ Params: { writerIdOrCustomUrl: string } }>("/internal/writers/:writerIdOrCustomUrl/resume", {
+    config: { rateLimit: { max: 60, timeWindow: "1 minute" } },
+    handler: async (req, reply) => {
+      const profile = await repository.resolveResumeProfile(req.params.writerIdOrCustomUrl);
+      if (!profile || !profile.isSearchable || profile.resumePublic === false) {
+        return reply.status(404).send({ error: "resume_not_found" });
+      }
+
+      const [placementsBody, scriptsBody, badgesBody, scoreBody] = await Promise.all([
+        fetchJson<{ placements?: unknown[] }>(requestFn, `${submissionTrackingBase}/internal/writers/${encodeURIComponent(profile.id)}/verified-placements`, req.log),
+        fetchJson<{ scripts?: unknown[] }>(requestFn, `${scriptStorageBase}/internal/writers/${encodeURIComponent(profile.id)}/public-scripts`, req.log),
+        fetchJson<{ badges?: unknown[] }>(requestFn, `${rankingServiceBase}/internal/writers/${encodeURIComponent(profile.id)}/badges`, req.log),
+        fetchJson<Record<string, unknown>>(requestFn, `${rankingServiceBase}/internal/writers/${encodeURIComponent(profile.id)}/score`, req.log)
+      ]);
+
+      const projects = (await repository.listProjects({ ownerUserId: profile.id, limit: 100, offset: 0 })).filter((project) => project.isDiscoverable);
+      const metrics = await repository.getResumeMetrics(profile.id);
+      const placements = placementsBody.placements ?? [];
+      const scripts = scriptsBody.scripts ?? [];
+      const badges = badgesBody.badges ?? [];
+      const resume = WriterResumeSchema.parse({
+        profile: {
+          id: profile.id,
+          displayName: profile.displayName,
+          bio: profile.bio,
+          headshotUrl: profile.headshotUrl,
+          customProfileUrl: profile.customProfileUrl,
+          representationStatus: profile.representationStatus,
+          genres: profile.genres,
+          resumePublic: profile.resumePublic
+        },
+        projects,
+        placements,
+        badges,
+        ranking: {
+          totalScore: Number(scoreBody.totalScore ?? 0),
+          rank: Number(scoreBody.rank ?? 0),
+          tier: typeof scoreBody.tier === "string" ? scoreBody.tier : "unranked",
+          scoreChange30d: Number(scoreBody.scoreChange30d ?? 0)
+        },
+        hostedScripts: scripts,
+        proofMetrics: {
+          ...metrics,
+          verifiedPlacementsCount: placements.length,
+          projectsCount: projects.length
+        }
+      });
+      return reply.send({ resume });
+    }
+  });
+
+  server.post<{ Params: { writerId: string } }>("/internal/writers/:writerId/resume-views", {
+    config: { rateLimit: { max: 120, timeWindow: "1 minute" } },
+    handler: async (req, reply) => {
+      const parsed = ResumePageViewCreateRequestSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return reply.status(400).send({ error: "invalid_payload", details: parsed.error.flatten() });
+      }
+      const recorded = await repository.recordResumePageView(req.params.writerId, parsed.data);
+      return reply.status(recorded ? 201 : 200).send({ recorded });
+    }
+  });
+
+  server.get<{ Params: { writerId: string } }>("/internal/writers/:writerId/resume-metrics", {
+    config: { rateLimit: { max: 40, timeWindow: "1 minute" } },
+    handler: async (req, reply) => {
+      const authUserId = getAuthUserId(req);
+      if (authUserId !== req.params.writerId) {
+        return reply.status(403).send({ error: "forbidden" });
+      }
+      return reply.send({ metrics: ResumeMetricsResponseSchema.parse(await repository.getResumeMetrics(req.params.writerId)) });
     }
   });
 
@@ -582,6 +669,19 @@ export function buildServer(options: ProfileProjectServiceOptions = {}): Fastify
   });
 
   return server;
+}
+
+async function fetchJson<T>(requestFn: RequestFn, url: string, logger: FastifyInstance["log"]): Promise<T> {
+  try {
+    const response = await requestFn(url, { method: "GET" });
+    if (response.statusCode >= 400) {
+      return {} as T;
+    }
+    return (await response.body.json()) as T;
+  } catch (error) {
+    logger.warn({ error, url }, "resume aggregation dependency unavailable");
+    return {} as T;
+  }
 }
 
 export async function startServer(): Promise<void> {

--- a/services/profile-project-service/src/repository.test.ts
+++ b/services/profile-project-service/src/repository.test.ts
@@ -148,7 +148,8 @@ test("PgProfileProjectRepository userExists and getProfile map profile rows", as
             representation_status: "unrepresented",
             headshot_url: "https://cdn.example.com/writer_01.jpg",
             custom_profile_url: "https://profiles.example.com/writer-one",
-            is_searchable: true
+            is_searchable: true,
+            resume_public: true
           }
         ],
         rowCount: 1
@@ -170,7 +171,8 @@ test("PgProfileProjectRepository userExists and getProfile map profile rows", as
     representationStatus: "unrepresented",
     headshotUrl: "https://cdn.example.com/writer_01.jpg",
     customProfileUrl: "https://profiles.example.com/writer-one",
-    isSearchable: true
+    isSearchable: true,
+    resumePublic: true
   });
 });
 
@@ -189,6 +191,7 @@ test("PgProfileProjectRepository upsertProfile updates profile fields and publis
         "represented",
         null,
         "https://profiles.example.com/writer-one",
+        false,
         false
       ]);
       return {
@@ -202,7 +205,8 @@ test("PgProfileProjectRepository upsertProfile updates profile fields and publis
             representation_status: "represented",
             headshot_url: "https://cdn.example.com/writer_01.jpg",
             custom_profile_url: "https://profiles.example.com/writer-one",
-            is_searchable: false
+            is_searchable: false,
+            resume_public: false
           }
         ]
       };
@@ -216,7 +220,8 @@ test("PgProfileProjectRepository upsertProfile updates profile fields and publis
     genres: ["Drama", "Thriller"],
     representationStatus: "represented",
     customProfileUrl: "https://profiles.example.com/writer-one",
-    isSearchable: false
+    isSearchable: false,
+    resumePublic: false
   } satisfies WriterProfileUpdateRequest);
 
   assert.deepEqual(profile, {
@@ -228,7 +233,8 @@ test("PgProfileProjectRepository upsertProfile updates profile fields and publis
     representationStatus: "represented",
     headshotUrl: "https://cdn.example.com/writer_01.jpg",
     customProfileUrl: "https://profiles.example.com/writer-one",
-    isSearchable: false
+    isSearchable: false,
+    resumePublic: false
   });
   assert.equal(publishCalls.length, 1);
   assert.deepEqual(publishCalls[0], {

--- a/services/profile-project-service/src/repository.ts
+++ b/services/profile-project-service/src/repository.ts
@@ -14,6 +14,8 @@ import type {
   ProjectDraftUpdateRequest,
   ProjectFilters,
   ProjectUpdateRequest,
+  ResumeMetricsResponse,
+  ResumePageViewCreateRequest,
   ScriptAccessRequest,
   ScriptAccessRequestCreateRequest,
   ScriptAccessRequestFilters,
@@ -27,7 +29,10 @@ export interface ProfileProjectRepository {
   healthCheck(): Promise<{ database: boolean }>;
   userExists(userId: string): Promise<boolean>;
   getProfile(writerId: string): Promise<WriterProfile | null>;
+  resolveResumeProfile(writerIdOrCustomUrl: string): Promise<WriterProfile | null>;
   upsertProfile(writerId: string, update: WriterProfileUpdateRequest): Promise<WriterProfile | null>;
+  recordResumePageView(writerId: string, input: ResumePageViewCreateRequest): Promise<boolean>;
+  getResumeMetrics(writerId: string): Promise<ResumeMetricsResponse>;
   createProject(input: ProjectCreateInternal): Promise<Project | null>;
   listProjects(filters: ProjectFilters): Promise<Project[]>;
   getProject(projectId: string): Promise<Project | null>;
@@ -100,10 +105,11 @@ export class PgProfileProjectRepository implements ProfileProjectRepository {
       headshot_url: string;
       custom_profile_url: string;
       is_searchable: boolean;
+      resume_public: boolean;
     }>(
       `
         SELECT writer_id, display_name, bio, genres, demographics, representation_status,
-               headshot_url, custom_profile_url, is_searchable
+               headshot_url, custom_profile_url, is_searchable, resume_public
         FROM writer_profiles
         WHERE writer_id = $1
       `,
@@ -112,17 +118,7 @@ export class PgProfileProjectRepository implements ProfileProjectRepository {
 
     const row = profile.rows[0];
     if (row) {
-      return {
-        id: row.writer_id,
-        displayName: row.display_name,
-        bio: row.bio,
-        genres: row.genres,
-        demographics: row.demographics,
-        representationStatus: row.representation_status,
-        headshotUrl: row.headshot_url,
-        customProfileUrl: row.custom_profile_url,
-        isSearchable: row.is_searchable
-      };
+      return mapProfile(row);
     }
 
     const user = await db.query<{ id: string; display_name: string }>(
@@ -146,13 +142,14 @@ export class PgProfileProjectRepository implements ProfileProjectRepository {
       headshot_url: string;
       custom_profile_url: string;
       is_searchable: boolean;
+      resume_public: boolean;
     }>(
       `
         INSERT INTO writer_profiles (writer_id, display_name)
         VALUES ($1, $2)
         ON CONFLICT (writer_id) DO NOTHING
         RETURNING writer_id, display_name, bio, genres, demographics, representation_status,
-                  headshot_url, custom_profile_url, is_searchable
+                  headshot_url, custom_profile_url, is_searchable, resume_public
       `,
       [userRow.id, userRow.display_name]
     );
@@ -170,10 +167,11 @@ export class PgProfileProjectRepository implements ProfileProjectRepository {
         headshot_url: string;
         custom_profile_url: string;
         is_searchable: boolean;
+        resume_public: boolean;
       }>(
         `
           SELECT writer_id, display_name, bio, genres, demographics, representation_status,
-                 headshot_url, custom_profile_url, is_searchable
+                  headshot_url, custom_profile_url, is_searchable, resume_public
           FROM writer_profiles
           WHERE writer_id = $1
         `,
@@ -183,34 +181,30 @@ export class PgProfileProjectRepository implements ProfileProjectRepository {
       if (!refetchedRow) {
         return null;
       }
-      return {
-        id: refetchedRow.writer_id,
-        displayName: refetchedRow.display_name,
-        bio: refetchedRow.bio,
-        genres: refetchedRow.genres,
-        demographics: refetchedRow.demographics,
-        representationStatus: refetchedRow.representation_status,
-        headshotUrl: refetchedRow.headshot_url,
-        customProfileUrl: refetchedRow.custom_profile_url,
-        isSearchable: refetchedRow.is_searchable
-      };
+      return mapProfile(refetchedRow);
     }
 
     const insertedRow = inserted.rows[0];
     if (!insertedRow) {
       return null;
     }
-    return {
-      id: insertedRow.writer_id,
-      displayName: insertedRow.display_name,
-      bio: insertedRow.bio,
-      genres: insertedRow.genres,
-      demographics: insertedRow.demographics,
-      representationStatus: insertedRow.representation_status,
-      headshotUrl: insertedRow.headshot_url,
-      customProfileUrl: insertedRow.custom_profile_url,
-      isSearchable: insertedRow.is_searchable
-    };
+    return mapProfile(insertedRow);
+  }
+
+  async resolveResumeProfile(writerIdOrCustomUrl: string): Promise<WriterProfile | null> {
+    const db = getPool();
+    const result = await db.query<ProfileRow>(
+      `
+        SELECT writer_id, display_name, bio, genres, demographics, representation_status,
+               headshot_url, custom_profile_url, is_searchable, resume_public
+        FROM writer_profiles
+        WHERE writer_id = $1
+           OR custom_profile_url = $1
+           OR regexp_replace(custom_profile_url, '^https?://[^/]+/writers/', '') = $1
+      `,
+      [writerIdOrCustomUrl]
+    );
+    return result.rows[0] ? mapProfile(result.rows[0]) : null;
   }
 
   async upsertProfile(
@@ -228,6 +222,7 @@ export class PgProfileProjectRepository implements ProfileProjectRepository {
       headshot_url: string;
       custom_profile_url: string;
       is_searchable: boolean;
+      resume_public: boolean;
     }>(
       `
         UPDATE writer_profiles
@@ -239,10 +234,11 @@ export class PgProfileProjectRepository implements ProfileProjectRepository {
             headshot_url       = COALESCE($7, headshot_url),
             custom_profile_url = COALESCE($8, custom_profile_url),
             is_searchable      = COALESCE($9, is_searchable),
+            resume_public      = COALESCE($10, resume_public),
             updated_at         = NOW()
         WHERE writer_id = $1
         RETURNING writer_id, display_name, bio, genres, demographics,
-                  representation_status, headshot_url, custom_profile_url, is_searchable
+                  representation_status, headshot_url, custom_profile_url, is_searchable, resume_public
       `,
       [
         writerId,
@@ -253,7 +249,8 @@ export class PgProfileProjectRepository implements ProfileProjectRepository {
         update.representationStatus ?? null,
         update.headshotUrl ?? null,
         update.customProfileUrl ?? null,
-        update.isSearchable ?? null
+        update.isSearchable ?? null,
+        update.resumePublic ?? null
       ]
     );
 
@@ -261,17 +258,7 @@ export class PgProfileProjectRepository implements ProfileProjectRepository {
     if (!row) {
       return null;
     }
-    const profile = {
-      id: row.writer_id,
-      displayName: row.display_name,
-      bio: row.bio,
-      genres: row.genres,
-      demographics: row.demographics,
-      representationStatus: row.representation_status,
-      headshotUrl: row.headshot_url,
-      customProfileUrl: row.custom_profile_url,
-      isSearchable: row.is_searchable
-    };
+    const profile = mapProfile(row);
 
     try {
       await publishSearchSyncEvent({
@@ -361,6 +348,70 @@ export class PgProfileProjectRepository implements ProfileProjectRepository {
     }
 
     return null;
+  }
+
+  async recordResumePageView(writerId: string, input: ResumePageViewCreateRequest): Promise<boolean> {
+    const db = getPool();
+    const duplicate = await db.query<{ id: string }>(
+      `
+        SELECT id
+        FROM resume_page_views
+        WHERE writer_id = $1
+          AND ip_hash = $2
+          AND user_agent_hash = $3
+          AND viewed_at >= COALESCE($4::timestamptz, NOW()) - INTERVAL '60 seconds'
+        LIMIT 1
+      `,
+      [writerId, input.ipHash, input.userAgentHash, input.viewedAt ?? null]
+    );
+    if (duplicate.rows[0]) {
+      return false;
+    }
+
+    await db.query(
+      `
+        INSERT INTO resume_page_views (id, writer_id, viewer_user_id, referrer, user_agent_hash, ip_hash, viewed_at)
+        VALUES ($1, $2, $3, $4, $5, $6, COALESCE($7::timestamptz, NOW()))
+      `,
+      [
+        `rpv_${randomUUID()}`,
+        writerId,
+        input.viewerUserId ?? null,
+        input.referrer ?? null,
+        input.userAgentHash,
+        input.ipHash,
+        input.viewedAt ?? null
+      ]
+    );
+    return true;
+  }
+
+  async getResumeMetrics(writerId: string): Promise<ResumeMetricsResponse> {
+    const db = getPool();
+    const result = await db.query<{
+      total_views_7d: string;
+      total_views_30d: string;
+      total_script_downloads: string;
+      projects_count: string;
+    }>(
+      `
+        SELECT
+          (SELECT COUNT(*)::text FROM resume_page_views WHERE writer_id = $1 AND viewed_at >= NOW() - INTERVAL '7 days') AS total_views_7d,
+          (SELECT COUNT(*)::text FROM resume_page_views WHERE writer_id = $1 AND viewed_at >= NOW() - INTERVAL '30 days') AS total_views_30d,
+          (SELECT COUNT(*)::text FROM script_view_events WHERE owner_user_id = $1 AND event_type = 'download') AS total_script_downloads,
+          (SELECT COUNT(*)::text FROM projects WHERE owner_user_id = $1 AND is_discoverable = TRUE) AS projects_count
+      `,
+      [writerId]
+    );
+    const row = result.rows[0];
+    return {
+      writerId,
+      totalViews7d: Number(row?.total_views_7d ?? 0),
+      totalViews30d: Number(row?.total_views_30d ?? 0),
+      totalScriptDownloads: Number(row?.total_script_downloads ?? 0),
+      verifiedPlacementsCount: 0,
+      projectsCount: Number(row?.projects_count ?? 0)
+    };
   }
 
   async listProjects(filters: ProjectFilters): Promise<Project[]> {
@@ -1029,6 +1080,34 @@ export class PgProfileProjectRepository implements ProfileProjectRepository {
     const row = result.rows[0];
     return row ? mapDraft(row) : null;
   }
+}
+
+type ProfileRow = {
+  writer_id: string;
+  display_name: string;
+  bio: string;
+  genres: string[];
+  demographics: string[];
+  representation_status: "represented" | "unrepresented" | "seeking_rep";
+  headshot_url: string;
+  custom_profile_url: string;
+  is_searchable: boolean;
+  resume_public: boolean;
+};
+
+function mapProfile(row: ProfileRow): WriterProfile {
+  return {
+    id: row.writer_id,
+    displayName: row.display_name,
+    bio: row.bio,
+    genres: row.genres,
+    demographics: row.demographics,
+    representationStatus: row.representation_status,
+    headshotUrl: row.headshot_url,
+    customProfileUrl: row.custom_profile_url,
+    isSearchable: row.is_searchable,
+    resumePublic: row.resume_public
+  };
 }
 
 function mapProject(row: {

--- a/services/script-storage-service/src/index.ts
+++ b/services/script-storage-service/src/index.ts
@@ -11,6 +11,7 @@ import {
   ScriptFileRegistrationSchema,
   ScriptRegisterRequestSchema,
   ScriptRegisterResponseSchema,
+  ScriptViewEventCreateRequestSchema,
   ScriptUploadSessionRequestSchema,
   ScriptUploadSessionResponseSchema,
   ScriptViewRequestSchema,
@@ -277,6 +278,34 @@ export function buildServer(options: ScriptStorageServiceOptions = {}): FastifyI
     });
 
     return reply.send(responsePayload);
+  });
+
+  server.get<{ Params: { writerId: string } }>("/internal/writers/:writerId/public-scripts", async (req) => {
+    const scripts = await repo.listPublicScripts(req.params.writerId);
+    return {
+      scripts: scripts.map((script) => ({
+        scriptId: script.scriptId,
+        ownerUserId: script.ownerUserId,
+        filename: script.filename,
+        contentType: script.contentType,
+        size: script.size,
+        registeredAt: script.registeredAt,
+        viewerPath: `/projects/${encodeURIComponent(script.scriptId)}/viewer`,
+        viewerUrl: `/projects/${encodeURIComponent(script.scriptId)}/viewer`
+      }))
+    };
+  });
+
+  server.post<{ Params: { scriptId: string } }>("/internal/scripts/:scriptId/view-event", async (req, reply) => {
+    const parsed = ScriptViewEventCreateRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: "invalid_payload", details: parsed.error.flatten() });
+    }
+    const recorded = await repo.recordScriptViewEvent(req.params.scriptId, parsed.data);
+    if (!recorded) {
+      return reply.status(404).send({ error: "script_not_found" });
+    }
+    return reply.status(201).send({ recorded: true });
   });
 
   server.post<{ Params: { scriptId: string } }>("/internal/scripts/:scriptId/approve-viewer", async (req, reply) => {

--- a/services/script-storage-service/src/repository.ts
+++ b/services/script-storage-service/src/repository.ts
@@ -1,5 +1,6 @@
 import { getPool } from "@script-manifest/db";
-import type { ScriptFileRegistration, ScriptVisibility } from "@script-manifest/contracts";
+import type { ScriptFileRegistration, ScriptViewEventCreateRequest, ScriptVisibility } from "@script-manifest/contracts";
+import { randomUUID } from "node:crypto";
 
 export type ScriptRecord = ScriptFileRegistration & {
   visibility: ScriptVisibility;
@@ -14,6 +15,8 @@ export interface ScriptStorageRepository {
   updateVisibility(scriptId: string, visibility: ScriptVisibility): Promise<void>;
   addApprovedViewer(scriptId: string, viewerId: string): Promise<void>;
   listScripts(): Promise<ScriptRecord[]>;
+  listPublicScripts(ownerUserId: string): Promise<ScriptRecord[]>;
+  recordScriptViewEvent(scriptId: string, input: ScriptViewEventCreateRequest): Promise<boolean>;
 }
 
 // ── PostgreSQL implementation ─────────────────────────────────────────────
@@ -110,6 +113,27 @@ export class PgScriptStorageRepository implements ScriptStorageRepository {
     );
     return rows.map(mapRow);
   }
+
+  async listPublicScripts(ownerUserId: string): Promise<ScriptRecord[]> {
+    const { rows } = await getPool().query(
+      "SELECT * FROM scripts WHERE owner_user_id = $1 AND visibility = 'public' ORDER BY registered_at DESC",
+      [ownerUserId]
+    );
+    return rows.map(mapRow);
+  }
+
+  async recordScriptViewEvent(scriptId: string, input: ScriptViewEventCreateRequest): Promise<boolean> {
+    const script = await this.getScript(scriptId);
+    if (!script) return false;
+    await getPool().query(
+      `
+        INSERT INTO script_view_events (id, script_id, owner_user_id, viewer_user_id, event_type, occurred_at)
+        VALUES ($1, $2, $3, $4, $5, COALESCE($6::timestamptz, NOW()))
+      `,
+      [`sve_${randomUUID()}`, scriptId, script.ownerUserId, input.viewerUserId ?? null, input.eventType, input.occurredAt ?? null]
+    );
+    return true;
+  }
 }
 
 // ── In-memory implementation (for tests) ─────────────────────────────────
@@ -159,6 +183,14 @@ export class MemoryScriptStorageRepository implements ScriptStorageRepository {
 
   async listScripts(): Promise<ScriptRecord[]> {
     return Array.from(this.scripts.values());
+  }
+
+  async listPublicScripts(ownerUserId: string): Promise<ScriptRecord[]> {
+    return Array.from(this.scripts.values()).filter((script) => script.ownerUserId === ownerUserId && script.visibility === "public");
+  }
+
+  async recordScriptViewEvent(scriptId: string, _input: ScriptViewEventCreateRequest): Promise<boolean> {
+    return this.scripts.has(scriptId);
   }
 }
 

--- a/services/submission-tracking-service/src/index.test.ts
+++ b/services/submission-tracking-service/src/index.test.ts
@@ -456,3 +456,46 @@ test("submission tracking enforces placement visibility by writer", async (t) =>
   });
   assert.equal(forbiddenDetail.statusCode, 403);
 });
+
+test("verified placements endpoint returns only verified writer placements with server badge labels", async (t) => {
+  const memoryRepo = new MemorySubmissionTrackingRepository();
+  const server = buildServer({ logger: false, repository: memoryRepo });
+  t.after(async () => {
+    await server.close();
+  });
+
+  const verifiedSubmission = await server.inject({
+    method: "POST",
+    url: "/internal/submissions",
+    headers: { "x-auth-user-id": "writer_01" },
+    payload: { projectId: "project_01", competitionId: "comp_verified", status: "pending" }
+  });
+  const pendingSubmission = await server.inject({
+    method: "POST",
+    url: "/internal/submissions",
+    headers: { "x-auth-user-id": "writer_01" },
+    payload: { projectId: "project_02", competitionId: "comp_pending", status: "pending" }
+  });
+  const historicalSubmission = await memoryRepo.createHistoricalPlacement({
+    projectId: "project_03",
+    competitionId: "comp_hist",
+    competitionNameFreeform: "Historical Comp",
+    status: "winner",
+    placementDate: "2026-01-01T00:00:00.000Z",
+    sourceNote: "legacy import",
+    evidenceItems: [],
+    recordedByUserId: "writer_01"
+  });
+
+  const verifiedPlacement = await server.inject({ method: "POST", url: `/internal/submissions/${verifiedSubmission.json().submission.id}/placements`, headers: { "x-auth-user-id": "writer_01" }, payload: { status: "finalist" } });
+  await server.inject({ method: "POST", url: `/internal/submissions/${pendingSubmission.json().submission.id}/placements`, headers: { "x-auth-user-id": "writer_01" }, payload: { status: "semifinalist" } });
+  await server.inject({ method: "POST", url: `/internal/placements/${verifiedPlacement.json().placement.id}/verify`, payload: { verificationState: "verified" } });
+  await memoryRepo.updatePlacementVerification(historicalSubmission.placement.id, { verificationState: "verified" });
+
+  const response = await server.inject({ method: "GET", url: "/internal/writers/writer_01/verified-placements" });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.json().placements.length, 2);
+  assert.deepEqual(response.json().placements.map((placement: { badgeLabel: string }) => placement.badgeLabel).sort(), ["Historical — Verified", "Verified"]);
+  assert.equal(response.json().placements.every((placement: { verificationState: string }) => placement.verificationState === "verified"), true);
+});

--- a/services/submission-tracking-service/src/index.ts
+++ b/services/submission-tracking-service/src/index.ts
@@ -369,6 +369,14 @@ export function buildServer(options: SubmissionTrackingOptions = {}): FastifyIns
     return reply.send({ placements: filteredPlacements });
   });
 
+  server.get<{ Params: { writerId: string } }>("/internal/writers/:writerId/verified-placements", async (req) => {
+    const { writerId } = req.params;
+    const placements = (await repository.listPlacements({ writerId, verificationState: "verified" }))
+      .map(({ placement, submission }) => toPlacementListItem(PlacementSchema.parse(placement), SubmissionSchema.parse(submission)))
+      .filter((placement) => placement.verificationState === "verified");
+    return { placements };
+  });
+
   server.get<{ Params: { placementId: string } }>("/internal/placements/:placementId", async (req, reply) => {
     const { placementId } = req.params;
     const placement = await repository.getPlacement(placementId);
@@ -429,8 +437,9 @@ function toPlacementDetail(placement: Placement): Placement & { badgeLabel: stri
   return { ...placement, badgeLabel: placementBadgeLabel(placement) };
 }
 
-function placementBadgeLabel(placement: Placement): string {
+export function placementBadgeLabel(placement: Placement): string {
   if (placement.importSource === "recovered_csv") return "Recovered";
+  if (placement.isHistorical && placement.verificationState === "verified") return "Historical — Verified";
   if (placement.verificationState === "verified") return "Verified";
   if (placement.verificationState === "rejected") return "Rejected";
   if (placement.isHistorical) return "Unverified — Historical";


### PR DESCRIPTION
## Summary
- add resume sharing contracts, migration, and profile aggregation endpoints
- expose verified placements/public scripts/view metrics through services and gateway
- add public writer resume page plus profile metrics/toggle controls

## Verification
- pnpm migrate
- pnpm typecheck
- pnpm lint (0 errors; existing warnings remain)
- pnpm --filter @script-manifest/profile-project-service test
- pnpm --filter @script-manifest/script-storage-service test
- pnpm --filter @script-manifest/submission-tracking-service test
- pnpm --filter @script-manifest/api-gateway test
- pnpm --filter @script-manifest/writer-web test
- lsp_diagnostics on changed TS/TSX files

Linear: CHAOS-1809