### PR TITLE
sec(CHAOS-1798): harden privileged trust controls

### DIFF
--- a/apps/writer-web/app/profile/page.tsx
+++ b/apps/writer-web/app/profile/page.tsx
@@ -236,7 +236,7 @@ export default function ProfilePage() {
       ) : null}
 
       {writerId && isLoading ? (
-        <article className="panel">
+        <article id="data-export" className="panel">
           <div className="stack">
             <SkeletonText />
             <SkeletonText className="mt-4" />

--- a/apps/writer-web/app/settings/account/page.test.tsx
+++ b/apps/writer-web/app/settings/account/page.test.tsx
@@ -16,4 +16,19 @@ describe("AccountSettingsPage", () => {
     expect(screen.getByText("Account Settings")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "sign in" })).toHaveAttribute("href", "/signin");
   });
+
+  it("makes export, portability, and deletion controls discoverable to signed-in writers", () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: "writer_01", email: "writer@example.com", displayName: "Writer One", role: "writer" },
+      loading: false,
+    });
+
+    render(<AccountSettingsPage />);
+
+    expect(screen.getByText("Data Rights & Portability")).toBeInTheDocument();
+    expect(screen.getByText(/download CSV or ZIP copies/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Export your data" })).toHaveAttribute("href", "/profile#data-export");
+    expect(screen.getByRole("link", { name: "Import recovered history" })).toHaveAttribute("href", "/profile/import");
+    expect(screen.getByRole("button", { name: "Delete Account" })).toBeInTheDocument();
+  });
 });

--- a/apps/writer-web/app/settings/account/page.tsx
+++ b/apps/writer-web/app/settings/account/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type FormEvent } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { refreshAuth, useAuth } from "../../lib/AuthProvider";
 
@@ -12,7 +12,7 @@ export default function AccountSettingsPage() {
   const [error, setError] = useState("");
   const [deleted, setDeleted] = useState(false);
 
-  async function handleDelete(e: FormEvent<HTMLFormElement>) {
+  async function handleDelete(e: { preventDefault: () => void }) {
     e.preventDefault();
     setError("");
     setSubmitting(true);
@@ -98,6 +98,28 @@ export default function AccountSettingsPage() {
           <p className="text-foreground-secondary text-sm">
             Display name: <strong>{user?.displayName}</strong>
           </p>
+        </div>
+
+        <hr className="border-border/50" />
+
+        <div className="stack">
+          <h2 className="text-lg font-semibold text-foreground">Data Rights & Portability</h2>
+          <p className="text-foreground-secondary text-sm">
+            Download CSV or ZIP copies of your profile, projects, scripts, submissions, placements,
+            and access history from your portable proof page.
+          </p>
+          <p className="text-foreground-secondary text-sm">
+            If you are moving in from another tracker, import recovered history so your record stays
+            portable and writer-controlled.
+          </p>
+          <div className="inline-form">
+            <Link href="/profile#data-export" className="btn btn-secondary no-underline">
+              Export your data
+            </Link>
+            <Link href="/profile/import" className="btn btn-secondary no-underline">
+              Import recovered history
+            </Link>
+          </div>
         </div>
 
         <hr className="border-border/50" />

--- a/compose.yml
+++ b/compose.yml
@@ -552,6 +552,7 @@ services:
       COMPETITION_DIRECTORY_SERVICE_URL: "http://competition-directory-service:4002"
       PROFILE_SERVICE_URL: "http://profile-project-service:4001"
       KAFKA_BROKERS: "redpanda:9092"
+      SERVICE_TOKEN_SECRET: "local-dev-token-secret"
     command: >
       sh -lc "/workspace/scripts/pnpm-install-once.sh /workspace && pnpm --filter @script-manifest/ranking-service dev"
     depends_on:

--- a/docs/trust/audit-coverage-matrix.md
+++ b/docs/trust/audit-coverage-matrix.md
@@ -1,0 +1,16 @@
+# Privileged Audit Coverage Matrix
+
+| Area | Action | Route group | Audit action | Test file |
+|---|---|---|---|---|
+| Provider review | approve/reject provider | coverage marketplace | `provider.review` | `services/coverage-marketplace-service/src/index.test.ts` |
+| Coverage disputes | resolve dispute | coverage marketplace | `coverage.dispute.resolve` | `services/coverage-marketplace-service/src/index.test.ts` |
+| Feedback disputes | resolve review dispute | feedback exchange | `feedback.dispute.resolve` | `services/feedback-exchange-service/src/index.test.ts` |
+| Ranking prestige | edit competition prestige | ranking | `ranking.prestige.update` | `services/ranking-service/src/index.test.ts` |
+| Ranking recompute | trigger recompute | ranking | `ranking.recompute` | `services/ranking-service/src/index.test.ts` |
+| Ranking flags | resolve suspicious activity | ranking | `ranking.flag.resolve` | `services/ranking-service/src/index.test.ts` |
+| Ranking appeals | resolve appeal | ranking | `ranking.appeal.resolve` | `services/ranking-service/src/index.test.ts` |
+| Competition moderation | visibility/access/cancel | competition directory | `competition.moderate` | `services/competition-directory-service/src/index.test.ts` |
+| Admin notifications | broadcast/direct/template | notification service | `notification.admin.send` | `services/notification-service/src/admin-routes.test.ts` |
+| Feature flags | create/update/delete | identity/admin | `feature_flag.create`, `feature_flag.update`, `feature_flag.delete` | `services/identity-service/src/feature-flag-routes.test.ts` |
+| User suspension | suspend/reactivate user | identity/admin | `user.suspend` | `services/identity-service/src/suspension-routes.test.ts` |
+| IP blocks | create/delete IP block | identity/admin | `security.ip_block.update` | `services/identity-service/src/ip-block-routes.test.ts` |

--- a/packages/service-utils/src/auditEvents.ts
+++ b/packages/service-utils/src/auditEvents.ts
@@ -1,0 +1,18 @@
+export const PRIVILEGED_AUDIT_ACTIONS = [
+  "provider.review",
+  "coverage.dispute.resolve",
+  "feedback.dispute.resolve",
+  "ranking.prestige.update",
+  "ranking.recompute",
+  "ranking.flag.resolve",
+  "ranking.appeal.resolve",
+  "competition.moderate",
+  "notification.admin.send",
+  "feature_flag.create",
+  "feature_flag.update",
+  "feature_flag.delete",
+  "user.suspend",
+  "security.ip_block.update"
+] as const;
+
+export type PrivilegedAuditAction = (typeof PRIVILEGED_AUDIT_ACTIONS)[number];

--- a/packages/service-utils/src/index.ts
+++ b/packages/service-utils/src/index.ts
@@ -15,3 +15,4 @@ export { registerHealthRoutes, type RegisterHealthRoutesOptions, type HealthChec
 export { BaseMemoryRepository } from "./testing/BaseMemoryRepository.js";
 export { getKafkaClient, _resetKafkaClient } from "./kafka.js";
 export { makeServiceHeaders, verifyInternalToken, requireServiceToken, requireAdminServiceToken, resolveServiceSecret } from "./serviceHeaders.js";
+export { PRIVILEGED_AUDIT_ACTIONS, type PrivilegedAuditAction } from "./auditEvents.js";

--- a/packages/service-utils/test/auditEvents.test.ts
+++ b/packages/service-utils/test/auditEvents.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { PRIVILEGED_AUDIT_ACTIONS } from "../src/auditEvents.js";
+
+test("privileged audit taxonomy covers PMF trust actions", () => {
+  assert.ok(PRIVILEGED_AUDIT_ACTIONS.includes("provider.review"));
+  assert.ok(PRIVILEGED_AUDIT_ACTIONS.includes("coverage.dispute.resolve"));
+  assert.ok(PRIVILEGED_AUDIT_ACTIONS.includes("feedback.dispute.resolve"));
+  assert.ok(PRIVILEGED_AUDIT_ACTIONS.includes("ranking.prestige.update"));
+  assert.ok(PRIVILEGED_AUDIT_ACTIONS.includes("ranking.recompute"));
+  assert.ok(PRIVILEGED_AUDIT_ACTIONS.includes("ranking.flag.resolve"));
+  assert.ok(PRIVILEGED_AUDIT_ACTIONS.includes("ranking.appeal.resolve"));
+  assert.ok(PRIVILEGED_AUDIT_ACTIONS.includes("competition.moderate"));
+  assert.ok(PRIVILEGED_AUDIT_ACTIONS.includes("notification.admin.send"));
+  assert.ok(PRIVILEGED_AUDIT_ACTIONS.includes("feature_flag.create"));
+  assert.ok(PRIVILEGED_AUDIT_ACTIONS.includes("feature_flag.update"));
+  assert.ok(PRIVILEGED_AUDIT_ACTIONS.includes("feature_flag.delete"));
+  assert.ok(PRIVILEGED_AUDIT_ACTIONS.includes("user.suspend"));
+  assert.ok(PRIVILEGED_AUDIT_ACTIONS.includes("security.ip_block.update"));
+});

--- a/packages/service-utils/test/index.test.ts
+++ b/packages/service-utils/test/index.test.ts
@@ -34,6 +34,7 @@ describe("service-utils index re-exports", () => {
     "requireServiceToken",
     "requireAdminServiceToken",
     "resolveServiceSecret",
+    "PRIVILEGED_AUDIT_ACTIONS",
     "publishSearchSyncEvent",
     "disconnectSearchSyncProducer",
   ];

--- a/services/api-gateway/src/helpers.test.ts
+++ b/services/api-gateway/src/helpers.test.ts
@@ -337,15 +337,13 @@ test("getUserAuthFromToken returns user id and role", async () => {
   assert.deepEqual(result, { userId: "admin_1", role: "admin" });
 });
 
-test("resolveAdminByRole allows header and admin role only", async () => {
-  const headerResult = await resolveAdminByRole(
-    (async () => {
-      throw new Error("requestFn should not be called when x-admin-user-id is present");
-    }) as typeof request,
+test("resolveAdminByRole verifies authorization and ignores forged admin headers", async () => {
+  const forgedHeaderResult = await resolveAdminByRole(
+    (async () => jsonResponse({ user: { id: "writer_auth", role: "writer" } }, 200)) as typeof request,
     "http://identity",
-    { "x-admin-user-id": "forwarded_admin" }
+    { authorization: "Bearer writer_token", "x-admin-user-id": "forged_admin" }
   );
-  assert.equal(headerResult, "forwarded_admin");
+  assert.equal(forgedHeaderResult, null);
 
   const adminResult = await resolveAdminByRole(
     (async () => jsonResponse({ user: { id: "admin_auth", role: "admin" } }, 200)) as typeof request,

--- a/services/api-gateway/src/helpers.ts
+++ b/services/api-gateway/src/helpers.ts
@@ -221,11 +221,6 @@ export async function resolveAdminByRole(
   headers: Record<string, unknown>,
   logger?: AuthLogger
 ): Promise<string | null> {
-  const headerAdminUserId = readHeaderValue(headers, "x-admin-user-id");
-  if (headerAdminUserId) {
-    return headerAdminUserId;
-  }
-
   const authorization = readHeaderValue(headers, "authorization");
   const auth = await getUserAuthFromToken(requestFn, identityServiceBase, authorization, logger);
   if (auth?.role === "admin") {

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -68,7 +68,7 @@ export async function buildServer(options: ApiGatewayOptions = {}): Promise<Fast
   // prevent external callers from impersonating users via resolveUserId().
   server.addHook("preValidation", (req, _reply, done) => {
     delete (req.headers as Record<string, unknown>)["x-auth-user-id"];
-    // Defense-in-depth: only trust x-admin-user-id from the internal BFF path.
+    delete (req.headers as Record<string, unknown>)["x-admin-user-id"];
     delete (req.headers as Record<string, unknown>)["x-partner-user-id"];
     delete (req.headers as Record<string, unknown>)["x-service-token"];
     done();

--- a/services/competition-directory-service/src/index.test.ts
+++ b/services/competition-directory-service/src/index.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { Competition, CompetitionAccessType, CompetitionFilters, CompetitionRecommendation, CompetitionVisibility, Project } from "@script-manifest/contracts";
 import { buildServer } from "./index.js";
-import type { CompetitionDirectoryRepository } from "./repository.js";
+import type { CompetitionAuditLogEntry, CompetitionAuditLogInput, CompetitionDirectoryRepository } from "./repository.js";
 import { request } from "undici";
 
 type RequestResult = Awaited<ReturnType<typeof request>>;
@@ -21,6 +21,7 @@ class MemoryCompetitionDirectoryRepository implements CompetitionDirectoryReposi
   private readonly competitions = new Map<string, Competition>();
   private readonly dismissed = new Set<string>();
   private readonly pinned = new Set<string>();
+  auditLog: CompetitionAuditLogEntry[] = [];
 
   constructor() {
     this.competitions.set("comp_001", {
@@ -184,6 +185,12 @@ class MemoryCompetitionDirectoryRepository implements CompetitionDirectoryReposi
     this.competitions.set(id, updated);
     return updated;
   }
+
+  async createAuditLogEntry(input: CompetitionAuditLogInput): Promise<CompetitionAuditLogEntry> {
+    const entry = { id: `audit_${this.auditLog.length + 1}`, createdAt: new Date().toISOString(), ...input };
+    this.auditLog.push(entry);
+    return entry;
+  }
 }
 
 test("competition directory filters seeded competitions", async (t) => {
@@ -286,9 +293,10 @@ test("competition deadline reminder publishes notification event", async (t) => 
 });
 
 test("competition admin curation route requires x-admin-user-id header", async (t) => {
+  const repository = new MemoryCompetitionDirectoryRepository();
   const server = buildServer({
     logger: false,
-    repository: new MemoryCompetitionDirectoryRepository(),
+    repository,
     requestFn: (async () => textResponse({ ok: true }, 201)) as typeof request
   });
   t.after(async () => {
@@ -325,6 +333,7 @@ test("competition admin curation route requires x-admin-user-id header", async (
     }
   });
   assert.equal(allowed.statusCode, 201);
+  assert.ok(repository.auditLog.some((entry) => entry.action === "competition.moderate" && entry.targetId === "comp_admin_1" && entry.adminUserId === "admin_writer"));
 });
 
 test("recommended competitions require project owner and support dismiss and pin overrides", async (t) => {

--- a/services/competition-directory-service/src/index.ts
+++ b/services/competition-directory-service/src/index.ts
@@ -203,7 +203,9 @@ export function buildServer(options: CompetitionDirectoryOptions = {}): FastifyI
       });
     }
 
-    return upsertCompetition(parsedBody.data, repository, reply);
+    const result = await upsertCompetition(parsedBody.data, repository, reply);
+    await repository.createAuditLogEntry({ adminUserId, action: "competition.moderate", targetType: "competition", targetId: parsedBody.data.id, details: { action: "create" } });
+    return result;
   });
 
   server.put<{ Params: { competitionId: string } }>("/internal/admin/competitions/:competitionId", async (req, reply) => {
@@ -224,7 +226,9 @@ export function buildServer(options: CompetitionDirectoryOptions = {}): FastifyI
       });
     }
 
-    return upsertCompetition(parsedBody.data, repository, reply);
+    const result = await upsertCompetition(parsedBody.data, repository, reply);
+    await repository.createAuditLogEntry({ adminUserId, action: "competition.moderate", targetType: "competition", targetId: competitionId, details: { action: "update" } });
+    return result;
   });
 
   server.post<{ Params: { competitionId: string } }>("/internal/admin/competitions/:competitionId/cancel", async (req, reply) => {
@@ -238,6 +242,7 @@ export function buildServer(options: CompetitionDirectoryOptions = {}): FastifyI
     if (!competition) {
       return reply.status(404).send({ error: "not_found_or_already_cancelled" });
     }
+    await repository.createAuditLogEntry({ adminUserId, action: "competition.moderate", targetType: "competition", targetId: competitionId, details: { action: "cancel" } });
 
     return reply.send({ competition, cancelled: true });
   });
@@ -258,6 +263,7 @@ export function buildServer(options: CompetitionDirectoryOptions = {}): FastifyI
     if (!competition) {
       return reply.status(404).send({ error: "not_found" });
     }
+    await repository.createAuditLogEntry({ adminUserId, action: "competition.moderate", targetType: "competition", targetId: competitionId, details: { action: "visibility", visibility: parsed.data.visibility } });
 
     return reply.send({ competition });
   });
@@ -278,6 +284,7 @@ export function buildServer(options: CompetitionDirectoryOptions = {}): FastifyI
     if (!competition) {
       return reply.status(404).send({ error: "not_found" });
     }
+    await repository.createAuditLogEntry({ adminUserId, action: "competition.moderate", targetType: "competition", targetId: competitionId, details: { action: "access_type", accessType: parsed.data.accessType } });
 
     return reply.send({ competition });
   });

--- a/services/competition-directory-service/src/pgRepository.ts
+++ b/services/competition-directory-service/src/pgRepository.ts
@@ -1,8 +1,9 @@
+import { randomUUID } from "node:crypto";
 import { getPool, runMigrations, toFtsPrefixQuery } from "@script-manifest/db";
 import type { Competition, CompetitionAccessType, CompetitionFilters, CompetitionVisibility, Project, SaveCompetitionRequest, SavedCompetition } from "@script-manifest/contracts";
 import { publishSearchSyncEvent } from "@script-manifest/service-utils";
 import { searchCompetitions as typesenseSearch, type CompetitionDocument } from "@script-manifest/search";
-import type { CompetitionDirectoryRepository, DueCompetitionReminderDispatch, FeeTier, PrestigeTier, RecommendationInput } from "./repository.js";
+import type { CompetitionAuditLogEntry, CompetitionAuditLogInput, CompetitionDirectoryRepository, DueCompetitionReminderDispatch, FeeTier, PrestigeTier, RecommendationInput } from "./repository.js";
 
 const typesenseEnabled = process.env.TYPESENSE_ENABLED === "true";
 
@@ -156,6 +157,45 @@ export class PgCompetitionDirectoryRepository implements CompetitionDirectoryRep
       return;
     }
     await runMigrations(getPool());
+    await getPool().query(`
+      CREATE TABLE IF NOT EXISTS competition_audit_log (
+        id TEXT PRIMARY KEY,
+        admin_user_id TEXT NOT NULL,
+        action TEXT NOT NULL,
+        target_type TEXT NOT NULL,
+        target_id TEXT NOT NULL,
+        details JSONB,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+  }
+
+  async createAuditLogEntry(input: CompetitionAuditLogInput): Promise<CompetitionAuditLogEntry> {
+    const id = `audit_${randomUUID()}`;
+    const result = await getPool().query<{
+      id: string;
+      admin_user_id: string;
+      action: CompetitionAuditLogEntry["action"];
+      target_type: string;
+      target_id: string;
+      details: Record<string, unknown> | null;
+      created_at: Date;
+    }>(
+      `INSERT INTO competition_audit_log (id, admin_user_id, action, target_type, target_id, details)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id, admin_user_id, action, target_type, target_id, details, created_at`,
+      [id, input.adminUserId, input.action, input.targetType, input.targetId, input.details ?? null]
+    );
+    const row = result.rows[0]!;
+    return {
+      id: row.id,
+      adminUserId: row.admin_user_id,
+      action: row.action,
+      targetType: row.target_type,
+      targetId: row.target_id,
+      details: row.details ?? undefined,
+      createdAt: row.created_at.toISOString()
+    };
   }
 
   async healthCheck(): Promise<{ database: boolean }> {

--- a/services/competition-directory-service/src/repository.ts
+++ b/services/competition-directory-service/src/repository.ts
@@ -1,5 +1,16 @@
 import type { Competition, CompetitionAccessType, CompetitionFilters, CompetitionVisibility, Project, SaveCompetitionRequest, SavedCompetition } from "@script-manifest/contracts";
+import type { PrivilegedAuditAction } from "@script-manifest/service-utils";
 import type { FeeTier, PrestigeTier, RecommendationInput } from "./recommendationEngine.js";
+
+export type CompetitionAuditLogInput = {
+  adminUserId: string;
+  action: PrivilegedAuditAction;
+  targetType: string;
+  targetId: string;
+  details?: Record<string, unknown>;
+};
+
+export type CompetitionAuditLogEntry = CompetitionAuditLogInput & { id: string; createdAt: string };
 
 export type DueCompetitionReminderDispatch = {
   id: string;
@@ -39,6 +50,7 @@ export interface CompetitionDirectoryRepository extends CompetitionReminderDispa
   cancelCompetition(id: string): Promise<Competition | null>;
   updateVisibility(id: string, visibility: CompetitionVisibility): Promise<Competition | null>;
   updateAccessType(id: string, accessType: CompetitionAccessType): Promise<Competition | null>;
+  createAuditLogEntry(input: CompetitionAuditLogInput): Promise<CompetitionAuditLogEntry>;
 }
 
 export type { FeeTier, PrestigeTier, RecommendationInput };

--- a/services/coverage-marketplace-service/src/index.test.ts
+++ b/services/coverage-marketplace-service/src/index.test.ts
@@ -36,7 +36,7 @@ function adminServiceHeaders(): Record<string, string> {
     "content-type": "application/json"
   };
 }
-import type { CoverageMarketplaceRepository } from "./repository.js";
+import type { CoverageAuditLogEntry, CoverageAuditLogInput, CoverageMarketplaceRepository } from "./repository.js";
 import { MemoryPaymentGateway } from "./paymentGateway.js";
 import { MemoryUserPaymentProfileRepository } from "./userPaymentProfileRepository.js";
 import { createScheduler } from "./scheduler.js";
@@ -50,6 +50,7 @@ class MemoryCoverageMarketplaceRepository extends BaseMemoryRepository implement
   private disputes = new Map<string, CoverageDispute>();
   private providerReviews = new Map<string, CoverageProviderReview>();
   private disputeEvents = new Map<string, CoverageDisputeEvent>();
+  auditLog: CoverageAuditLogEntry[] = [];
   private paymentRetries = new Map<string, {
     id: string;
     orderId: string;
@@ -509,6 +510,12 @@ class MemoryCoverageMarketplaceRepository extends BaseMemoryRepository implement
   getRetryEntries() {
     return Array.from(this.paymentRetries.values());
   }
+
+  async createAuditLogEntry(input: CoverageAuditLogInput): Promise<CoverageAuditLogEntry> {
+    const entry = { id: this.createId("audit"), createdAt: new Date().toISOString(), ...input };
+    this.auditLog.push(entry);
+    return entry;
+  }
 }
 
 function createServer() {
@@ -704,7 +711,7 @@ test("list providers returns array", async (t) => {
 });
 
 test("admin provider review queue and review decisions work", async (t) => {
-  const { server } = createServer();
+  const { server, repo } = createServer();
   t.after(() => server.close());
 
   const createRes = await server.inject({
@@ -751,6 +758,7 @@ test("admin provider review queue and review decisions work", async (t) => {
   assert.equal(reviewRes.statusCode, 200);
   assert.equal(reviewRes.json().provider.status, "suspended");
   assert.equal(reviewRes.json().review.decision, "suspended");
+  assert.ok(repo.auditLog.some((entry) => entry.action === "provider.review" && entry.targetId === provider.id && entry.adminUserId === "admin_01"));
 });
 
 // ── Service Tests ────────────────────────────────────────────────────
@@ -1817,6 +1825,7 @@ test("resolve dispute with refund works", async (t) => {
   assert.equal(res.statusCode, 200);
   assert.equal(res.json().dispute.status, "resolved_refund");
   assert.equal(gateway.refunds.length, 1);
+  assert.ok(repo.auditLog.some((entry) => entry.action === "coverage.dispute.resolve" && entry.targetId === dispute.id && entry.adminUserId === "admin_01"));
 });
 
 test("resolve dispute with no refund completes order and logs events", async (t) => {

--- a/services/coverage-marketplace-service/src/index.ts
+++ b/services/coverage-marketplace-service/src/index.ts
@@ -358,6 +358,13 @@ export function buildServer(options: CoverageMarketplaceServiceOptions = {}): Fa
     }
 
     const updatedProvider = await repository.updateProviderStatus(provider.id, nextStatus);
+    await repository.createAuditLogEntry({
+      adminUserId: authUserId,
+      action: "provider.review",
+      targetType: "coverage_provider",
+      targetId: provider.id,
+      details: { decision: input.decision, nextStatus }
+    });
     return reply.send({ provider: updatedProvider, review });
   });
 
@@ -1012,6 +1019,13 @@ export function buildServer(options: CoverageMarketplaceServiceOptions = {}): Fa
     if (!resolved) {
       return reply.status(409).send({ error: "dispute_not_resolvable" });
     }
+    await repository.createAuditLogEntry({
+      adminUserId: authUserId,
+      action: "coverage.dispute.resolve",
+      targetType: "coverage_dispute",
+      targetId: disputeId,
+      details: { status: parsed.data.status, refundAmountCents: parsed.data.refundAmountCents ?? null }
+    });
     if (!order) {
       return reply.send({ dispute: resolved });
     }

--- a/services/coverage-marketplace-service/src/pgRepository.ts
+++ b/services/coverage-marketplace-service/src/pgRepository.ts
@@ -26,7 +26,7 @@ import type {
   CoverageDisputeEvent,
   CoverageDisputeStatus
 } from "@script-manifest/contracts";
-import type { CoverageMarketplaceRepository } from "./repository.js";
+import type { CoverageAuditLogEntry, CoverageAuditLogInput, CoverageMarketplaceRepository } from "./repository.js";
 
 export class PgCoverageMarketplaceRepository implements CoverageMarketplaceRepository {
   async init(): Promise<void> {
@@ -34,6 +34,45 @@ export class PgCoverageMarketplaceRepository implements CoverageMarketplaceRepos
       return;
     }
     await ensureCoverageMarketplaceTables();
+    await getPool().query(`
+      CREATE TABLE IF NOT EXISTS coverage_audit_log (
+        id TEXT PRIMARY KEY,
+        admin_user_id TEXT NOT NULL,
+        action TEXT NOT NULL,
+        target_type TEXT NOT NULL,
+        target_id TEXT NOT NULL,
+        details JSONB,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+  }
+
+  async createAuditLogEntry(input: CoverageAuditLogInput): Promise<CoverageAuditLogEntry> {
+    const id = `audit_${randomUUID()}`;
+    const result = await getPool().query<{
+      id: string;
+      admin_user_id: string;
+      action: CoverageAuditLogEntry["action"];
+      target_type: string;
+      target_id: string;
+      details: Record<string, unknown> | null;
+      created_at: Date;
+    }>(
+      `INSERT INTO coverage_audit_log (id, admin_user_id, action, target_type, target_id, details)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id, admin_user_id, action, target_type, target_id, details, created_at`,
+      [id, input.adminUserId, input.action, input.targetType, input.targetId, input.details ?? null]
+    );
+    const row = result.rows[0]!;
+    return {
+      id: row.id,
+      adminUserId: row.admin_user_id,
+      action: row.action,
+      targetType: row.target_type,
+      targetId: row.target_id,
+      details: row.details ?? undefined,
+      createdAt: row.created_at.toISOString()
+    };
   }
 
   async healthCheck(): Promise<{ database: boolean }> {

--- a/services/coverage-marketplace-service/src/repository.ts
+++ b/services/coverage-marketplace-service/src/repository.ts
@@ -21,6 +21,17 @@ import type {
   CoverageDisputeEvent,
   CoverageDisputeStatus
 } from "@script-manifest/contracts";
+import type { PrivilegedAuditAction } from "@script-manifest/service-utils";
+
+export type CoverageAuditLogInput = {
+  adminUserId: string;
+  action: PrivilegedAuditAction;
+  targetType: string;
+  targetId: string;
+  details?: Record<string, unknown>;
+};
+
+export type CoverageAuditLogEntry = CoverageAuditLogInput & { id: string; createdAt: string };
 
 export interface CoverageMarketplaceRepository {
   init(): Promise<void>;
@@ -110,4 +121,6 @@ export interface CoverageMarketplaceRepository {
     payload: unknown;
   }): Promise<{ id: string; alreadyProcessed: boolean }>;
   updateWebhookLogStatus(id: string, status: string, errorMessage?: string): Promise<void>;
+
+  createAuditLogEntry(input: CoverageAuditLogInput): Promise<CoverageAuditLogEntry>;
 }

--- a/services/feedback-exchange-service/src/index.test.ts
+++ b/services/feedback-exchange-service/src/index.test.ts
@@ -16,7 +16,7 @@ import type {
 } from "@script-manifest/contracts";
 import { BaseMemoryRepository, signServiceToken } from "@script-manifest/service-utils";
 import { buildServer } from "./index.js";
-import type { FeedbackExchangeRepository } from "./repository.js";
+import type { FeedbackAuditLogEntry, FeedbackAuditLogInput, FeedbackExchangeRepository } from "./repository.js";
 
 const SERVICE_SECRET = randomBytes(32).toString("hex");
 
@@ -36,6 +36,7 @@ class MemoryFeedbackExchangeRepository extends BaseMemoryRepository implements F
   private strikes = new Map<string, { userId: string; reason: string; active: boolean; expiresAt: Date }[]>();
   private suspensions = new Set<string>();
   private disputes = new Map<string, FeedbackDispute>();
+  auditLog: FeedbackAuditLogEntry[] = [];
   // Tokens
   async getBalance(userId: string): Promise<number> {
     let credits = 0;
@@ -347,6 +348,12 @@ class MemoryFeedbackExchangeRepository extends BaseMemoryRepository implements F
       if (review.listingId === listingId && review.reviewerUserId === reviewerUserId) return true;
     }
     return false;
+  }
+
+  async createAuditLogEntry(input: FeedbackAuditLogInput): Promise<FeedbackAuditLogEntry> {
+    const entry = { id: this.createId("audit"), createdAt: new Date().toISOString(), ...input };
+    this.auditLog.push(entry);
+    return entry;
   }
 }
 
@@ -820,7 +827,7 @@ test("dispute creation and no duplicates", async (t) => {
 });
 
 test("resolve dispute for filer strikes reviewer and refunds", async (t) => {
-  const { server } = createServer();
+  const { server, repo } = createServer();
   t.after(() => server.close());
 
   // Setup complete flow
@@ -873,6 +880,7 @@ test("resolve dispute for filer strikes reviewer and refunds", async (t) => {
   });
   assert.equal(resolveRes.statusCode, 200);
   assert.equal(resolveRes.json().dispute.status, "resolved_for_filer");
+  assert.ok(repo.auditLog.some((entry) => entry.action === "feedback.dispute.resolve" && entry.targetId === disputeId && entry.adminUserId === "admin_01"));
 
   // Check writer_02 got a strike
   const repRes = await server.inject({

--- a/services/feedback-exchange-service/src/index.ts
+++ b/services/feedback-exchange-service/src/index.ts
@@ -470,6 +470,13 @@ export function buildServer(options: FeedbackExchangeServiceOptions = {}): Fasti
     if (!resolved) {
       return reply.status(409).send({ error: "dispute_not_resolvable" });
     }
+    await repository.createAuditLogEntry({
+      adminUserId: authUserId,
+      action: "feedback.dispute.resolve",
+      targetType: "feedback_dispute",
+      targetId: disputeId,
+      details: { status: parsed.data.status }
+    });
 
     // If resolved for filer: strike reviewer + refund token
     if (parsed.data.status === "resolved_for_filer") {

--- a/services/feedback-exchange-service/src/repository.ts
+++ b/services/feedback-exchange-service/src/repository.ts
@@ -15,6 +15,17 @@ import type {
   TokenTransaction,
   TokenTransactionReason
 } from "@script-manifest/contracts";
+import type { PrivilegedAuditAction } from "@script-manifest/service-utils";
+
+export type FeedbackAuditLogInput = {
+  adminUserId: string;
+  action: PrivilegedAuditAction;
+  targetType: string;
+  targetId: string;
+  details?: Record<string, unknown>;
+};
+
+export type FeedbackAuditLogEntry = FeedbackAuditLogInput & { id: string; createdAt: string };
 
 const SYSTEM_USER_ID = "SYSTEM";
 
@@ -80,6 +91,7 @@ export interface FeedbackExchangeRepository {
 
   // Abuse
   hasDuplicateReview(listingId: string, reviewerUserId: string): Promise<boolean>;
+  createAuditLogEntry(input: FeedbackAuditLogInput): Promise<FeedbackAuditLogEntry>;
 }
 
 export class PgFeedbackExchangeRepository implements FeedbackExchangeRepository {
@@ -88,6 +100,17 @@ export class PgFeedbackExchangeRepository implements FeedbackExchangeRepository 
       return;
     }
     await ensureFeedbackExchangeTables();
+    await getPool().query(`
+      CREATE TABLE IF NOT EXISTS feedback_audit_log (
+        id TEXT PRIMARY KEY,
+        admin_user_id TEXT NOT NULL,
+        action TEXT NOT NULL,
+        target_type TEXT NOT NULL,
+        target_id TEXT NOT NULL,
+        details JSONB,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
   }
 
   async healthCheck(): Promise<{ database: boolean }> {
@@ -559,6 +582,34 @@ export class PgFeedbackExchangeRepository implements FeedbackExchangeRepository 
       [listingId, reviewerUserId]
     );
     return Number(result.rows[0]?.count ?? 0) > 0;
+  }
+
+  async createAuditLogEntry(input: FeedbackAuditLogInput): Promise<FeedbackAuditLogEntry> {
+    const id = `audit_${randomUUID()}`;
+    const result = await getPool().query<{
+      id: string;
+      admin_user_id: string;
+      action: FeedbackAuditLogEntry["action"];
+      target_type: string;
+      target_id: string;
+      details: Record<string, unknown> | null;
+      created_at: Date;
+    }>(
+      `INSERT INTO feedback_audit_log (id, admin_user_id, action, target_type, target_id, details)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id, admin_user_id, action, target_type, target_id, details, created_at`,
+      [id, input.adminUserId, input.action, input.targetType, input.targetId, input.details ?? null]
+    );
+    const row = result.rows[0]!;
+    return {
+      id: row.id,
+      adminUserId: row.admin_user_id,
+      action: row.action,
+      targetType: row.target_type,
+      targetId: row.target_id,
+      details: row.details ?? undefined,
+      createdAt: row.created_at.toISOString()
+    };
   }
 }
 

--- a/services/identity-service/src/feature-flag-routes.ts
+++ b/services/identity-service/src/feature-flag-routes.ts
@@ -47,7 +47,7 @@ export function registerFeatureFlagRoutes(
 
     await adminRepo.createAuditLogEntry({
       adminUserId: adminId,
-      action: "create_feature_flag",
+      action: "feature_flag.create",
       targetType: "feature_flag",
       targetId: flag.key,
       details: { description: flag.description }
@@ -74,7 +74,7 @@ export function registerFeatureFlagRoutes(
 
     await adminRepo.createAuditLogEntry({
       adminUserId: adminId,
-      action: "update_feature_flag",
+      action: "feature_flag.update",
       targetType: "feature_flag",
       targetId: updated.key,
       details: parsed.data
@@ -96,7 +96,7 @@ export function registerFeatureFlagRoutes(
 
     await adminRepo.createAuditLogEntry({
       adminUserId: adminId,
-      action: "delete_feature_flag",
+      action: "feature_flag.delete",
       targetType: "feature_flag",
       targetId: req.params.key
     });

--- a/services/identity-service/src/ip-block-routes.test.ts
+++ b/services/identity-service/src/ip-block-routes.test.ts
@@ -415,7 +415,7 @@ test("IP block creates audit log entry", async () => {
     });
 
     const auditLog = await adminRepo.listAuditLogEntries({ page: 1, limit: 50 });
-    assert.ok(auditLog.entries.some((e) => e.action === "add_ip_block"));
+    assert.ok(auditLog.entries.some((e) => e.action === "security.ip_block.update"));
   } finally {
     cleanup();
   }
@@ -433,7 +433,7 @@ test("IP block removal creates audit log entry", async () => {
     });
 
     const auditLog = await adminRepo.listAuditLogEntries({ page: 1, limit: 50 });
-    assert.ok(auditLog.entries.some((e) => e.action === "remove_ip_block"));
+    assert.ok(auditLog.entries.some((e) => e.action === "security.ip_block.update"));
   } finally {
     cleanup();
   }

--- a/services/identity-service/src/ip-block-routes.ts
+++ b/services/identity-service/src/ip-block-routes.ts
@@ -55,7 +55,7 @@ export function registerIpBlockRoutes(
     // Audit log
     await adminRepo.createAuditLogEntry({
       adminUserId: adminId,
-      action: "add_ip_block",
+      action: "security.ip_block.update",
       targetType: "ip",
       targetId: parsed.data.ipAddress,
       details: {
@@ -82,7 +82,7 @@ export function registerIpBlockRoutes(
     // Audit log
     await adminRepo.createAuditLogEntry({
       adminUserId: adminId,
-      action: "remove_ip_block",
+      action: "security.ip_block.update",
       targetType: "ip_block",
       targetId: req.params.id,
       details: {}

--- a/services/identity-service/src/suspension-routes.test.ts
+++ b/services/identity-service/src/suspension-routes.test.ts
@@ -392,7 +392,7 @@ test("suspension creates audit log entry", async () => {
     });
 
     const auditLog = await adminRepo.listAuditLogEntries({ page: 1, limit: 50 });
-    assert.ok(auditLog.entries.some((e) => e.action === "suspend_user" && e.targetId === "user_1"));
+    assert.ok(auditLog.entries.some((e) => e.action === "user.suspend" && e.targetId === "user_1"));
   } finally {
     cleanup();
   }
@@ -409,7 +409,7 @@ test("ban creates audit log entry", async () => {
     });
 
     const auditLog = await adminRepo.listAuditLogEntries({ page: 1, limit: 50 });
-    assert.ok(auditLog.entries.some((e) => e.action === "ban_user" && e.targetId === "user_1"));
+    assert.ok(auditLog.entries.some((e) => e.action === "user.suspend" && e.targetId === "user_1"));
   } finally {
     cleanup();
   }
@@ -427,7 +427,7 @@ test("unsuspend creates audit log entry", async () => {
     });
 
     const auditLog = await adminRepo.listAuditLogEntries({ page: 1, limit: 50 });
-    assert.ok(auditLog.entries.some((e) => e.action === "unsuspend_user" && e.targetId === "user_1"));
+    assert.ok(auditLog.entries.some((e) => e.action === "user.suspend" && e.targetId === "user_1"));
   } finally {
     cleanup();
   }

--- a/services/identity-service/src/suspension-routes.ts
+++ b/services/identity-service/src/suspension-routes.ts
@@ -36,7 +36,7 @@ export function registerSuspensionRoutes(
     // Audit log
     await adminRepo.createAuditLogEntry({
       adminUserId: adminId,
-      action: "suspend_user",
+      action: "user.suspend",
       targetType: "user",
       targetId,
       details: {
@@ -77,7 +77,7 @@ export function registerSuspensionRoutes(
     // Audit log
     await adminRepo.createAuditLogEntry({
       adminUserId: adminId,
-      action: "ban_user",
+      action: "user.suspend",
       targetType: "user",
       targetId,
       details: {
@@ -112,7 +112,7 @@ export function registerSuspensionRoutes(
     // Audit log
     await adminRepo.createAuditLogEntry({
       adminUserId: adminId,
-      action: "unsuspend_user",
+      action: "user.suspend",
       targetType: "user",
       targetId,
       details: {

--- a/services/notification-service/src/admin-repository.ts
+++ b/services/notification-service/src/admin-repository.ts
@@ -8,6 +8,17 @@ import type {
   CreateNotificationTemplateRequest,
   SendBroadcastRequest
 } from "@script-manifest/contracts";
+import type { PrivilegedAuditAction } from "@script-manifest/service-utils";
+
+export type NotificationAuditLogInput = {
+  adminUserId: string;
+  action: PrivilegedAuditAction;
+  targetType: string;
+  targetId: string;
+  details?: Record<string, unknown>;
+};
+
+export type NotificationAuditLogEntry = NotificationAuditLogInput & { id: string; createdAt: string };
 
 // ── Interface ──────────────────────────────────────────────────────
 
@@ -21,6 +32,7 @@ export interface NotificationAdminRepository {
   listBroadcasts(params: { status?: BroadcastStatus; page: number; limit: number }): Promise<{ broadcasts: NotificationBroadcast[]; total: number }>;
   updateBroadcastStatus(id: string, status: BroadcastStatus, recipientCount?: number): Promise<boolean>;
   getUserIdsByAudience(audience: string): Promise<string[]>;
+  createAuditLogEntry(input: NotificationAuditLogInput): Promise<NotificationAuditLogEntry>;
 }
 
 // ── Helpers ────────────────────────────────────────────────────────
@@ -34,6 +46,7 @@ function toISOString(val: unknown): string {
 export class MemoryNotificationAdminRepository implements NotificationAdminRepository {
   private templates: NotificationTemplate[] = [];
   private broadcasts: NotificationBroadcast[] = [];
+  auditLog: NotificationAuditLogEntry[] = [];
   private users: Array<{ id: string; role: string }> = [];
 
   constructor(users?: Array<{ id: string; role: string }>) {
@@ -130,6 +143,12 @@ export class MemoryNotificationAdminRepository implements NotificationAdminRepos
     }
     return true;
   }
+
+  async createAuditLogEntry(input: NotificationAuditLogInput): Promise<NotificationAuditLogEntry> {
+    const entry = { id: randomUUID(), createdAt: new Date().toISOString(), ...input };
+    this.auditLog.push(entry);
+    return entry;
+  }
 }
 
 // ── PostgreSQL Implementation ─────────────────────────────────────
@@ -191,6 +210,45 @@ function mapBroadcast(row: BroadcastRow): NotificationBroadcast {
 export class PgNotificationAdminRepository implements NotificationAdminRepository {
   async init(): Promise<void> {
     // Tables are managed by migration 015
+    await getPool().query(`
+      CREATE TABLE IF NOT EXISTS notification_audit_log (
+        id TEXT PRIMARY KEY,
+        admin_user_id TEXT NOT NULL,
+        action TEXT NOT NULL,
+        target_type TEXT NOT NULL,
+        target_id TEXT NOT NULL,
+        details JSONB,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+  }
+
+  async createAuditLogEntry(input: NotificationAuditLogInput): Promise<NotificationAuditLogEntry> {
+    const id = randomUUID();
+    const result = await getPool().query<{
+      id: string;
+      admin_user_id: string;
+      action: NotificationAuditLogEntry["action"];
+      target_type: string;
+      target_id: string;
+      details: Record<string, unknown> | null;
+      created_at: Date;
+    }>(
+      `INSERT INTO notification_audit_log (id, admin_user_id, action, target_type, target_id, details)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id, admin_user_id, action, target_type, target_id, details, created_at`,
+      [id, input.adminUserId, input.action, input.targetType, input.targetId, input.details ?? null]
+    );
+    const row = result.rows[0]!;
+    return {
+      id: row.id,
+      adminUserId: row.admin_user_id,
+      action: row.action,
+      targetType: row.target_type,
+      targetId: row.target_id,
+      details: row.details ?? undefined,
+      createdAt: row.created_at.toISOString()
+    };
   }
 
   async getUserIdsByAudience(audience: string): Promise<string[]> {

--- a/services/notification-service/src/admin-routes.test.ts
+++ b/services/notification-service/src/admin-routes.test.ts
@@ -82,6 +82,7 @@ function createServer() {
   return {
     server,
     memoryRepo,
+    adminRepo,
     cleanup: async () => {
       await server.close();
       if (originalSecret !== undefined) {
@@ -96,7 +97,7 @@ function createServer() {
 // ── Template Tests ──────────────────────────────────────────────
 
 test("POST /internal/admin/notifications/templates creates a template", async (t) => {
-  const { server, cleanup } = createServer();
+  const { server, adminRepo, cleanup } = createServer();
   t.after(cleanup);
 
   const res = await server.inject({
@@ -116,6 +117,7 @@ test("POST /internal/admin/notifications/templates creates a template", async (t
   assert.ok(body.template.id);
   assert.equal(body.template.name, "Welcome Email");
   assert.equal(body.template.status, "active");
+  assert.ok(adminRepo.auditLog.some((entry) => entry.action === "notification.admin.send" && entry.targetId === body.template.id));
 });
 
 test("POST /internal/admin/notifications/templates returns 403 without admin auth", async (t) => {
@@ -195,7 +197,7 @@ test("GET /internal/admin/notifications/templates returns 403 without admin auth
 // ── Broadcast Tests ─────────────────────────────────────────────
 
 test("POST /internal/admin/notifications/broadcast fans out events to all users", async (t) => {
-  const { server, memoryRepo, cleanup } = createServer();
+  const { server, memoryRepo, adminRepo, cleanup } = createServer();
   t.after(cleanup);
 
   const res = await server.inject({
@@ -220,6 +222,7 @@ test("POST /internal/admin/notifications/broadcast fans out events to all users"
     const count = await memoryRepo.getUnreadCount(user.id);
     assert.equal(count, 1, `expected 1 unread notification for ${user.id}`);
   }
+  assert.ok(adminRepo.auditLog.some((entry) => entry.action === "notification.admin.send" && entry.targetId === body.broadcast.id));
 });
 
 test("POST /internal/admin/notifications/broadcast fans out only to matching role", async (t) => {
@@ -283,7 +286,7 @@ test("POST /internal/admin/notifications/broadcast returns 400 for invalid paylo
 // ── Direct Notification Tests ───────────────────────────────────
 
 test("POST /internal/admin/notifications/direct sends to specific user", async (t) => {
-  const { server, cleanup } = createServer();
+  const { server, adminRepo, cleanup } = createServer();
   t.after(cleanup);
 
   const res = await server.inject({
@@ -302,6 +305,7 @@ test("POST /internal/admin/notifications/direct sends to specific user", async (
   assert.equal(body.broadcast.audience, "user:user_42");
   assert.equal(body.broadcast.recipientCount, 1);
   assert.equal(body.broadcast.status, "sent");
+  assert.ok(adminRepo.auditLog.some((entry) => entry.action === "notification.admin.send" && entry.details?.audience === "user:user_42"));
 });
 
 test("POST /internal/admin/notifications/direct returns 403 without admin auth", async (t) => {

--- a/services/notification-service/src/admin-routes.ts
+++ b/services/notification-service/src/admin-routes.ts
@@ -49,6 +49,7 @@ export function registerNotificationAdminRoutes(server: FastifyInstance, adminRe
     }
 
     const template = await adminRepo.createTemplate({ ...parsed.data, createdBy: adminId });
+    await adminRepo.createAuditLogEntry({ adminUserId: adminId, action: "notification.admin.send", targetType: "notification_template", targetId: template.id, details: { action: "template.create" } });
     return reply.status(201).send({ template });
   });
 
@@ -81,6 +82,7 @@ export function registerNotificationAdminRoutes(server: FastifyInstance, adminRe
       );
     }
     await adminRepo.updateBroadcastStatus(broadcast.id, "sent", recipientCount);
+    await adminRepo.createAuditLogEntry({ adminUserId: adminId, action: "notification.admin.send", targetType: "notification_broadcast", targetId: broadcast.id, details: { audience: parsed.data.audience, recipientCount } });
 
     return reply.status(201).send({
       broadcast: {
@@ -119,6 +121,7 @@ export function registerNotificationAdminRoutes(server: FastifyInstance, adminRe
       );
     }
     await adminRepo.updateBroadcastStatus(broadcast.id, "sent", recipientCount);
+    await adminRepo.createAuditLogEntry({ adminUserId: adminId, action: "notification.admin.send", targetType: "notification_broadcast", targetId: broadcast.id, details: { audience, recipientCount } });
 
     return reply.status(201).send({
       broadcast: {

--- a/services/notification-service/src/index.test.ts
+++ b/services/notification-service/src/index.test.ts
@@ -5,6 +5,7 @@ import { signServiceToken } from "@script-manifest/service-utils";
 import type { NotificationEventEnvelope } from "@script-manifest/contracts";
 import { buildServer } from "./index.js";
 import type { NotificationRepository } from "./repository.js";
+import { MemoryNotificationAdminRepository } from "./admin-repository.js";
 
 class MemoryNotificationRepository implements NotificationRepository {
   private readonly events: NotificationEventEnvelope[] = [];
@@ -65,7 +66,8 @@ function createServer() {
   process.env.SERVICE_TOKEN_SECRET = SERVICE_SECRET;
 
   const memoryRepo = new MemoryNotificationRepository();
-  const server = buildServer({ logger: false, repository: memoryRepo });
+  const adminRepository = new MemoryNotificationAdminRepository();
+  const server = buildServer({ logger: false, repository: memoryRepo, adminRepository });
 
   return {
     server,

--- a/services/ranking-service/src/index.test.ts
+++ b/services/ranking-service/src/index.test.ts
@@ -15,9 +15,10 @@ import type {
   TierDesignation,
   WriterBadge
 } from "@script-manifest/contracts";
-import { BaseMemoryRepository } from "@script-manifest/service-utils";
+import { BaseMemoryRepository, signServiceToken } from "@script-manifest/service-utils";
 import { buildServer } from "./index.js";
 import type { RankingRepository, WriterScoreRow, PlacementScoreRow } from "./repository.js";
+import type { RankingAuditLogInput, RankingAuditLogEntry } from "./repository.js";
 import { request } from "undici";
 
 type RequestResult = Awaited<ReturnType<typeof request>>;
@@ -32,6 +33,26 @@ function jsonResponse(payload: unknown, statusCode = 200): RequestResult {
   } as RequestResult;
 }
 
+const TEST_SERVICE_TOKEN_SECRET = "ranking-test-secret";
+
+function adminServiceHeaders(adminUserId = "admin_01"): Record<string, string> {
+  return {
+    "x-auth-user-id": adminUserId,
+    "x-service-token": signServiceToken({ sub: adminUserId, role: "admin" }, TEST_SERVICE_TOKEN_SECRET)
+  };
+}
+
+async function withServiceTokenSecret<T>(fn: () => T | Promise<T>): Promise<T> {
+  const previous = process.env.SERVICE_TOKEN_SECRET;
+  process.env.SERVICE_TOKEN_SECRET = TEST_SERVICE_TOKEN_SECRET;
+  try {
+    return await fn();
+  } finally {
+    if (previous === undefined) delete process.env.SERVICE_TOKEN_SECRET;
+    else process.env.SERVICE_TOKEN_SECRET = previous;
+  }
+}
+
 // ── MemoryRankingRepository ─────────────────────────────────────────
 
 class MemoryRankingRepository extends BaseMemoryRepository implements RankingRepository {
@@ -42,6 +63,7 @@ class MemoryRankingRepository extends BaseMemoryRepository implements RankingRep
   snapshots: Array<{ writerId: string; totalScore: number; date: string }> = [];
   flags: AntiGamingFlag[] = [];
   appeals: RankingAppeal[] = [];
+  auditLog: RankingAuditLogEntry[] = [];
   // Prestige
   async getPrestige(competitionId: string) { return this.prestige.get(competitionId) ?? null; }
   async upsertPrestige(competitionId: string, tier: PrestigeTier, multiplier: number) {
@@ -148,6 +170,12 @@ class MemoryRankingRepository extends BaseMemoryRepository implements RankingRep
     a.resolutionNote = resolutionNote;
     return a;
   }
+
+  async createAuditLogEntry(input: RankingAuditLogInput) {
+    const entry: RankingAuditLogEntry = { id: this.createId("audit"), createdAt: new Date().toISOString(), ...input };
+    this.auditLog.push(entry);
+    return entry;
+  }
 }
 
 // ── Helper to build test server ─────────────────────────────────────
@@ -202,28 +230,38 @@ test("methodology endpoint returns scoring constants", async (t) => {
   assert.equal(body.timeDecayHalfLifeDays, 365);
 });
 
-test("prestige upsert requires auth", async (t) => {
+test("prestige upsert requires admin service token", async (t) => {
   const { server } = createTestServer();
   t.after(() => server.close());
 
-  const res = await server.inject({
+  const missingToken = await server.inject({
     method: "PUT",
     url: "/internal/prestige/comp_1",
+    headers: { "x-auth-user-id": "admin_01" },
     payload: { tier: "elite", multiplier: 2.0 }
   });
-  assert.equal(res.statusCode, 403);
+  assert.equal(missingToken.statusCode, 403);
+
+  const writerToken = await withServiceTokenSecret(() => signServiceToken({ sub: "writer_01", role: "writer" }, TEST_SERVICE_TOKEN_SECRET));
+  const wrongRole = await server.inject({
+    method: "PUT",
+    url: "/internal/prestige/comp_1",
+    headers: { "x-auth-user-id": "writer_01", "x-service-token": writerToken },
+    payload: { tier: "elite", multiplier: 2.0 }
+  });
+  assert.equal(wrongRole.statusCode, 403);
 });
 
 test("prestige upsert stores and retrieves config", async (t) => {
   const { server, repo } = createTestServer();
   t.after(() => server.close());
 
-  const res = await server.inject({
+  const res = await withServiceTokenSecret(() => server.inject({
     method: "PUT",
     url: "/internal/prestige/comp_1",
-    headers: { "x-auth-user-id": "admin_01" },
+    headers: adminServiceHeaders(),
     payload: { tier: "elite", multiplier: 2.0 }
-  });
+  }));
   assert.equal(res.statusCode, 200);
 
   const getRes = await server.inject({ method: "GET", url: "/internal/prestige/comp_1" });
@@ -231,6 +269,7 @@ test("prestige upsert stores and retrieves config", async (t) => {
   const config = getRes.json().prestige;
   assert.equal(config.tier, "elite");
   assert.equal(config.multiplier, 2);
+  assert.ok(repo.auditLog.some((entry) => entry.action === "ranking.prestige.update" && entry.targetId === "comp_1" && entry.adminUserId === "admin_01"));
 });
 
 test("full recompute flow computes scores and assigns ranks", async (t) => {
@@ -266,11 +305,11 @@ test("full recompute flow computes scores and assigns ranks", async (t) => {
   const { server, repo } = createTestServer({ requestFn });
   t.after(() => server.close());
 
-  const res = await server.inject({
+  const res = await withServiceTokenSecret(() => server.inject({
     method: "POST",
     url: "/internal/recompute",
-    headers: { "x-auth-user-id": "admin_01" }
-  });
+    headers: adminServiceHeaders()
+  }));
 
   assert.equal(res.statusCode, 200);
   const body = res.json();
@@ -293,10 +332,25 @@ test("full recompute flow computes scores and assigns ranks", async (t) => {
   assert.ok(w1.totalScore > 0);
   assert.ok(w1.badges.length > 0);
 
+  assert.ok(repo.auditLog.some((entry) => entry.action === "ranking.recompute" && entry.adminUserId === "admin_01"));
+
   // Check badges endpoint
   const badgeRes = await server.inject({ method: "GET", url: "/internal/writers/w1/badges" });
   assert.equal(badgeRes.statusCode, 200);
   assert.ok(badgeRes.json().badges.length > 0);
+});
+
+test("full recompute requires admin service token", async (t) => {
+  const { server } = createTestServer();
+  t.after(() => server.close());
+
+  const res = await server.inject({
+    method: "POST",
+    url: "/internal/recompute",
+    headers: { "x-auth-user-id": "admin_01" }
+  });
+
+  assert.equal(res.statusCode, 403);
 });
 
 test("leaderboard tier filter works", async (t) => {
@@ -327,7 +381,7 @@ test("leaderboard trending sort works", async (t) => {
 });
 
 test("appeal creation and resolution", async (t) => {
-  const { server, events } = createTestServer();
+  const { server, repo, events } = createTestServer();
   t.after(() => server.close());
 
   // Create appeal
@@ -355,6 +409,7 @@ test("appeal creation and resolution", async (t) => {
   });
   assert.equal(resolveRes.statusCode, 200);
   assert.equal(resolveRes.json().appeal.status, "upheld");
+  assert.ok(repo.auditLog.some((entry) => entry.action === "ranking.appeal.resolve" && entry.targetId === appeal.id && entry.adminUserId === "admin_01"));
 
   // Notification sent
   assert.equal(events.length, 1);
@@ -395,6 +450,7 @@ test("anti-gaming flag resolve", async (t) => {
   });
   assert.equal(res.statusCode, 200);
   assert.equal(res.json().flag.status, "dismissed");
+  assert.ok(repo.auditLog.some((entry) => entry.action === "ranking.flag.resolve" && entry.targetId === flag.id && entry.adminUserId === "admin_01"));
 });
 
 test("incremental recompute returns 202", async (t) => {
@@ -445,11 +501,11 @@ test("duplicate submissions create anti-gaming flags during recompute", async (t
   const { server, repo } = createTestServer({ requestFn });
   t.after(() => server.close());
 
-  const res = await server.inject({
+  const res = await withServiceTokenSecret(() => server.inject({
     method: "POST",
     url: "/internal/recompute",
-    headers: { "x-auth-user-id": "admin_01" }
-  });
+    headers: adminServiceHeaders()
+  }));
 
   assert.equal(res.statusCode, 200);
   assert.equal(res.json().flagsCreated, 1);

--- a/services/ranking-service/src/index.ts
+++ b/services/ranking-service/src/index.ts
@@ -1,7 +1,7 @@
 import { type FastifyInstance } from "fastify";
 import { randomUUID } from "node:crypto";
 import { Counter } from "prom-client";
-import { bootstrapService, registerMetrics, registerSentryErrorHandler, setupErrorReporting, validateRequiredEnv, isMainModule, publishNotificationEvent, createFastifyServer } from "@script-manifest/service-utils";
+import { bootstrapService, registerMetrics, registerSentryErrorHandler, setupErrorReporting, validateRequiredEnv, isMainModule, publishNotificationEvent, createFastifyServer, requireAdminServiceToken } from "@script-manifest/service-utils";
 import { healthCheck } from "@script-manifest/db";
 import {
   CompetitionPrestigeUpsertRequestSchema,
@@ -159,18 +159,28 @@ export function buildServer(options: RankingServiceOptions = {}): FastifyInstanc
   });
 
   server.put<{ Params: { competitionId: string } }>("/internal/prestige/:competitionId", async (req, reply) => {
-    const userId = req.headers["x-auth-user-id"] as string | undefined;
-    if (!userId) return reply.status(403).send({ error: "forbidden" });
+    const adminId = requireAdminServiceToken(req.headers as Record<string, unknown>);
+    if (!adminId) return reply.status(403).send({ error: "forbidden" });
     const { competitionId } = req.params;
     const parsed = CompetitionPrestigeUpsertRequestSchema.safeParse(req.body);
     if (!parsed.success) return reply.status(400).send({ error: "invalid_payload" });
     const config = await repo.upsertPrestige(competitionId, parsed.data.tier, parsed.data.multiplier);
+    await repo.createAuditLogEntry({
+      adminUserId: adminId,
+      action: "ranking.prestige.update",
+      targetType: "competition",
+      targetId: competitionId,
+      details: { tier: parsed.data.tier, multiplier: parsed.data.multiplier }
+    });
     return { prestige: config };
   });
 
   // ── Recompute ──
 
-  server.post("/internal/recompute", async (_req, reply) => {
+  server.post("/internal/recompute", async (req, reply) => {
+    const adminId = requireAdminServiceToken(req.headers as Record<string, unknown>);
+    if (!adminId) return reply.status(403).send({ error: "forbidden" });
+
     const now = new Date().toISOString();
 
     // 1. Fetch all submissions
@@ -322,6 +332,14 @@ export function buildServer(options: RankingServiceOptions = {}): FastifyInstanc
 
     await repo.bulkUpsertWriterScores(scoreRows);
 
+    await repo.createAuditLogEntry({
+      adminUserId: adminId,
+      action: "ranking.recompute",
+      targetType: "ranking",
+      targetId: "full",
+      details: { writerCount: totalWriters, placementCount: placements.length }
+    });
+
     // 9. Duplicate submission detection
     const dupes = detectDuplicateSubmissions(
       submissions.map((s) => ({ writerId: s.writerId, competitionId: s.competitionId, projectId: s.projectId }))
@@ -388,6 +406,13 @@ export function buildServer(options: RankingServiceOptions = {}): FastifyInstanc
     if (!parsed.success) return reply.status(400).send({ error: "invalid_payload" });
     const appeal = await repo.resolveAppeal(appealId, userId, parsed.data.status, parsed.data.resolutionNote);
     if (!appeal) return reply.status(404).send({ error: "not_found" });
+    await repo.createAuditLogEntry({
+      adminUserId: userId,
+      action: "ranking.appeal.resolve",
+      targetType: "ranking_appeal",
+      targetId: appealId,
+      details: { status: parsed.data.status }
+    });
 
     try {
       await publisher({
@@ -421,6 +446,13 @@ export function buildServer(options: RankingServiceOptions = {}): FastifyInstanc
     if (!parsed.success) return reply.status(400).send({ error: "invalid_payload" });
     const flag = await repo.resolveFlag(flagId, userId, parsed.data.status);
     if (!flag) return reply.status(404).send({ error: "not_found" });
+    await repo.createAuditLogEntry({
+      adminUserId: userId,
+      action: "ranking.flag.resolve",
+      targetType: "anti_gaming_flag",
+      targetId: flagId,
+      details: { status: parsed.data.status }
+    });
     return { flag };
   });
 

--- a/services/ranking-service/src/repository.ts
+++ b/services/ranking-service/src/repository.ts
@@ -13,6 +13,20 @@ import type {
   WriterBadge
 } from "@script-manifest/contracts";
 import { ensureRankingTables, getPool } from "@script-manifest/db";
+import type { PrivilegedAuditAction } from "@script-manifest/service-utils";
+
+export type RankingAuditLogInput = {
+  adminUserId: string;
+  action: PrivilegedAuditAction;
+  targetType: string;
+  targetId: string;
+  details?: Record<string, unknown>;
+};
+
+export type RankingAuditLogEntry = RankingAuditLogInput & {
+  id: string;
+  createdAt: string;
+};
 
 export type WriterScoreRow = {
   writerId: string;
@@ -86,6 +100,9 @@ export interface RankingRepository {
   getAppeal(appealId: string): Promise<RankingAppeal | null>;
   listAppeals(status?: RankingAppealStatus): Promise<RankingAppeal[]>;
   resolveAppeal(appealId: string, resolvedByUserId: string, status: "upheld" | "rejected", resolutionNote: string): Promise<RankingAppeal | null>;
+
+  // Audit
+  createAuditLogEntry(input: RankingAuditLogInput): Promise<RankingAuditLogEntry>;
 }
 
 // ── PostgreSQL implementation ────────────────────────────────────────
@@ -96,6 +113,18 @@ export class PgRankingRepository implements RankingRepository {
       return;
     }
     await ensureRankingTables();
+    await getPool().query(`
+      CREATE TABLE IF NOT EXISTS ranking_audit_log (
+        id TEXT PRIMARY KEY,
+        admin_user_id TEXT NOT NULL,
+        action TEXT NOT NULL,
+        target_type TEXT NOT NULL,
+        target_id TEXT NOT NULL,
+        details JSONB,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+    await getPool().query(`CREATE INDEX IF NOT EXISTS idx_ranking_audit_created ON ranking_audit_log(created_at DESC)`);
   }
 
   async healthCheck(): Promise<{ database: boolean }> {
@@ -510,6 +539,17 @@ export class PgRankingRepository implements RankingRepository {
     );
     return rows[0] ? mapAppeal(rows[0]) : null;
   }
+
+  async createAuditLogEntry(input: RankingAuditLogInput): Promise<RankingAuditLogEntry> {
+    const id = `audit_${randomUUID()}`;
+    const { rows } = await getPool().query(
+      `INSERT INTO ranking_audit_log (id, admin_user_id, action, target_type, target_id, details)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id, admin_user_id, action, target_type, target_id, details, created_at`,
+      [id, input.adminUserId, input.action, input.targetType, input.targetId, input.details ?? null]
+    );
+    return mapAuditLogEntry(rows[0]);
+  }
 }
 
 // ── Row mappers ──────────────────────────────────────────────────────
@@ -586,5 +626,17 @@ function mapAppeal(row: Record<string, unknown>): RankingAppeal {
     resolvedByUserId: (row.resolved_by_user_id as string) ?? null,
     createdAt: (row.created_at as Date).toISOString(),
     updatedAt: (row.updated_at as Date).toISOString()
+  };
+}
+
+function mapAuditLogEntry(row: Record<string, unknown>): RankingAuditLogEntry {
+  return {
+    id: row.id as string,
+    adminUserId: row.admin_user_id as string,
+    action: row.action as RankingAuditLogEntry["action"],
+    targetType: row.target_type as string,
+    targetId: row.target_id as string,
+    details: (row.details as Record<string, unknown> | null) ?? undefined,
+    createdAt: (row.created_at as Date).toISOString()
   };
 }

--- a/tests/integration/compose/submission-ranking-flow.test.ts
+++ b/tests/integration/compose/submission-ranking-flow.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { signServiceToken } from "@script-manifest/service-utils";
 import {
   API_BASE_URL,
   COMPETITION_SERVICE_BASE_URL,
@@ -10,6 +11,17 @@ import {
   makeUnique,
   registerUser
 } from "./helpers.js";
+
+const SERVICE_TOKEN_SECRET = process.env.SERVICE_TOKEN_SECRET ?? "local-dev-token-secret";
+const ADMIN_USER_ID = "integration-admin";
+
+function adminServiceHeaders(): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-auth-user-id": ADMIN_USER_ID,
+    "x-service-token": signServiceToken({ sub: ADMIN_USER_ID, role: "admin" }, SERVICE_TOKEN_SECRET)
+  };
+}
 
 test("compose flow: submission placement drives ranking recompute", async () => {
   const session = await registerUser("ranking-writer");
@@ -105,7 +117,7 @@ test("compose flow: submission placement drives ranking recompute", async () => 
     `${RANKING_SERVICE_BASE_URL}/internal/recompute`,
     {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: adminServiceHeaders(),
       body: JSON.stringify({})
     },
     200

--- a/tests/integration/compose/submission-ranking-flow.test.ts
+++ b/tests/integration/compose/submission-ranking-flow.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
 import test from "node:test";
-import { signServiceToken } from "@script-manifest/service-utils";
 import {
   API_BASE_URL,
   COMPETITION_SERVICE_BASE_URL,
@@ -15,11 +15,27 @@ import {
 const SERVICE_TOKEN_SECRET = process.env.SERVICE_TOKEN_SECRET ?? "local-dev-token-secret";
 const ADMIN_USER_ID = "integration-admin";
 
+function base64url(data: string | Buffer): string {
+  const buffer = typeof data === "string" ? Buffer.from(data) : data;
+  return buffer.toString("base64url");
+}
+
+function signAdminServiceToken(): string {
+  const header = base64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const now = Math.floor(Date.now() / 1000);
+  const payload = base64url(JSON.stringify({ sub: ADMIN_USER_ID, role: "admin", iat: now, exp: now + 300 }));
+  const signature = createHmac("sha256", SERVICE_TOKEN_SECRET)
+    .update(`${header}.${payload}`)
+    .digest();
+
+  return `${header}.${payload}.${base64url(signature)}`;
+}
+
 function adminServiceHeaders(): Record<string, string> {
   return {
     "content-type": "application/json",
     "x-auth-user-id": ADMIN_USER_ID,
-    "x-service-token": signServiceToken({ sub: ADMIN_USER_ID, role: "admin" }, SERVICE_TOKEN_SECRET)
+    "x-service-token": signAdminServiceToken()
   };
 }
 


### PR DESCRIPTION
## Summary
- centralize privileged audit taxonomy and document coverage for trust-sensitive actions
- harden gateway/admin service-token handling against forged privileged headers
- add privileged audit writes across ranking, identity, coverage, feedback, competition, and notification admin workflows
- expose writer data rights and portability links in account settings

## Linear
- CHAOS-1798
- CHAOS-1799
- CHAOS-1800

## Verification
- pnpm --filter @script-manifest/service-utils test -- auditEvents.test.ts
- pnpm --filter @script-manifest/api-gateway test -- src/helpers.test.ts
- pnpm --filter @script-manifest/ranking-service test -- src/index.test.ts
- pnpm --filter @script-manifest/writer-web test -- app/settings/account/page.test.tsx app/profile/page.test.tsx
- pnpm --filter @script-manifest/identity-service test -- src/feature-flag-routes.test.ts src/suspension-routes.test.ts src/ip-block-routes.test.ts
- pnpm --filter @script-manifest/coverage-marketplace-service test -- src/index.test.ts
- pnpm --filter @script-manifest/feedback-exchange-service test -- src/index.test.ts
- pnpm --filter @script-manifest/competition-directory-service test -- src/index.test.ts
- pnpm --filter @script-manifest/notification-service test -- src/admin-routes.test.ts
- package builds for service-utils, api-gateway, ranking-service, writer-web, competition-directory-service, coverage-marketplace-service, feedback-exchange-service, identity-service, notification-service
- browser smoke: signed-in /settings/account shows Data Rights & Portability with export/import links