### PR TITLE
docs(CHAOS-1030): refresh auth-flow docs after localStorage removal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ All services expose: `GET /health` (deep), `GET /health/live` (liveness), `GET /
 
 ### Auth Flow
 
-Frontend stores session in localStorage (`script_manifest_session`). Requests include `Authorization: Bearer <token>`. Gateway validates via identity service and propagates `x-auth-user-id`.
+Browser session token lives in an HttpOnly cookie (`sm_session`) set by the writer-web BFF. Browser requests hit the writer-web BFF proxy (`apps/writer-web/app/api/v1/_proxy.ts`), which reads the cookie and forwards `Authorization: Bearer <token>` to the gateway. Frontend session/user state is held in the `AuthProvider` React context (`apps/writer-web/app/lib/AuthProvider.tsx`), which fetches `/api/v1/auth/me` via SWR — there is no localStorage session cache. Gateway validates the token via identity service and propagates `x-auth-user-id` downstream.
 
 ### Contracts
 

--- a/docs/phase-1/oauth-signin-user-manual.md
+++ b/docs/phase-1/oauth-signin-user-manual.md
@@ -35,5 +35,5 @@ To enable real Google OAuth:
 
 - Provider support: `google` (OpenID Connect with PKCE).
 - Scopes requested: `openid email profile`.
-- Session handling stays the same as email/password (`script_manifest_session` in local storage).
+- Session handling stays the same as email/password: the session token is stored in the HttpOnly `sm_session` cookie set by the writer-web BFF, and frontend user state is read from the `AuthProvider` React context (`/api/v1/auth/me`).
 - The gateway and frontend proxy routes are provider-agnostic (`:provider` / `[provider]`), so no gateway changes are needed to switch providers.


### PR DESCRIPTION
## Summary

[CHAOS-1030](https://linear.app/fullchaos/issue/CHAOS-1030) ("Replace localStorage session cache with React context + /auth/me fetch") was filed in March 2026, but the actual code migration **already shipped** in PR #377 ("fix(auth): remove localStorage session, add server-backed AuthProvider").

Verification across the repo:

```
grep -rn --include='*.ts' --include='*.tsx' \
  -E '(readStoredSession|writeStoredSession|refreshSession|SESSION_STORAGE_KEY)' \
  apps/ packages/ services/
# (no matches)

grep -rn -E 'localStorage\.(getItem|setItem|removeItem).*[sS]ession' \
  apps/ services/ packages/
# (no matches)
```

Current state in `apps/writer-web/app/lib/authSession.ts` is 5 lines, exporting only `formatUserLabel`. `AuthProvider.tsx` is the live React context that fetches `/api/v1/auth/me` via SWR, mounted in `app/components/providers.tsx`. The session token lives in the HttpOnly `sm_session` cookie set by the writer-web BFF.

The only remaining loose ends were two active docs that still described the old localStorage model. This PR updates them.

## Changes

- **CLAUDE.md** `### Auth Flow` — rewrite to describe the BFF cookie + AuthProvider context architecture.
- **docs/phase-1/oauth-signin-user-manual.md** — update session-handling note so OAuth and email/password share the same (cookie-based) description.

Historical artifacts under `docs/phase-5/` (proxy-layer-audit.md, poc-direct-gateway.ts) are intentionally **not** touched — they document past state.

## Verification

- `git diff --stat` → 2 files, 2 insertions(+), 2 deletions(-).
- No code changes; no test/typecheck impact.
- Doc edits factually verified against current source (`authSession.ts`, `AuthProvider.tsx`, `_proxy.ts`, `api/v1/auth/me/route.ts`).

Closes CHAOS-1030.