### PR TITLE
test(CHAOS-1814): ratchet services.functions threshold back to 35

### DIFF
--- a/.github/coverage-thresholds.json
+++ b/.github/coverage-thresholds.json
@@ -1,7 +1,7 @@
 {
   "services": {
     "lines": 25,
-    "functions": 33,
+    "functions": 35,
     "statements": 25,
     "branches": 48
   },


### PR DESCRIPTION
## Summary

Re-ratchet `services.functions` from **33 → 35**. [CHAOS-1364](https://linear.app/fullchaos/issue/CHAOS-1364) had lowered it as a stopgap to unblock nightly when an observed value of 33.17% was tripping the gate.

## Evidence

Fresh local run on a clean checkout via the canonical pipeline:

```
pnpm run test:coverage:services
```

(Run on Node 24 due to a local Node 26 + c8 + yargs incompatibility; CI uses Node 25 so this matches the CI runtime semantically.)

Output:

```
Statements   : 31.9% (22635/70940)
Branches     : 59.58% (2195/3684)
Functions    : 40.47% (544/1344)
Lines        : 31.9% (22635/70940)
```

All services unit tests pass.

Threshold runner confirms zero failures against the new baseline:

```
node scripts/ci/coverage-thresholds.mjs \
  --baseline .github/coverage-thresholds.json \
  --services-summary .coverage/services/coverage-summary.json \
  --web-summary apps/writer-web/coverage/coverage-summary.json

# failures: []
```

## Headroom

`services.functions` actual: **40.47%** → new floor **35%** leaves **~5.47 points** of jitter margin before the nightly gate would re-block. Other `services.*` metrics left at their current floors — this PR is scoped to the specific recovery the ticket calls out.

## Refs

- CHAOS-1364 (the original ratchet-down)

Closes CHAOS-1814.