### PR TITLE
test(CHAOS-1815): full writer-web branch coverage recovery (46→72)

### DIFF
--- a/.github/coverage-thresholds.json
+++ b/.github/coverage-thresholds.json
@@ -9,6 +9,6 @@
     "lines": 48,
     "functions": 50,
     "statements": 48,
-    "branches": 46
+    "branches": 55
   }
 }

--- a/.github/coverage-thresholds.json
+++ b/.github/coverage-thresholds.json
@@ -6,9 +6,9 @@
     "branches": 48
   },
   "web": {
-    "lines": 48,
-    "functions": 50,
-    "statements": 48,
-    "branches": 55
+    "lines": 75,
+    "functions": 70,
+    "statements": 75,
+    "branches": 68
   }
 }

--- a/apps/writer-web/app/admin/rankings/page.test.tsx
+++ b/apps/writer-web/app/admin/rankings/page.test.tsx
@@ -120,4 +120,677 @@ describe("AdminRankingsPage", () => {
       expect(appealsGetCount).toBeGreaterThan(countBeforeMutation);
     });
   });
+
+  it("renders generic error fallback when appeals error is not an ApiError", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => {
+        throw new TypeError("network down");
+      })
+    );
+    renderPage();
+    await screen.findByText("Failed to load appeals.");
+  });
+
+  it("renders 'all' filter label and switches to under_review filter", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal("fetch", makeDefaultFetch());
+    renderPage();
+
+    await screen.findByText("No appeals found");
+    // Default 'all' is shown
+    expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Under Review" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Under Review" }));
+    await screen.findByText("No appeals found");
+
+    await user.click(screen.getByRole("button", { name: "Open" }));
+    await screen.findByText("No appeals found");
+  });
+
+  it("renders appeal with resolution note and hides resolve button when not open/under_review", async () => {
+    const upheldAppeal = {
+      ...mockAppeal,
+      id: "appeal_upheld",
+      status: "upheld",
+      resolutionNote: "Confirmed bug in scoring",
+    };
+    vi.stubGlobal("fetch", makeDefaultFetch([upheldAppeal]));
+    renderPage();
+
+    await screen.findByText("Confirmed bug in scoring");
+    expect(screen.queryByRole("button", { name: /^resolve$/i })).not.toBeInTheDocument();
+  });
+
+  it("renders 'under_review' label inside status badge", async () => {
+    const reviewAppeal = { ...mockAppeal, id: "a2", status: "under_review" };
+    vi.stubGlobal("fetch", makeDefaultFetch([reviewAppeal]));
+    renderPage();
+
+    await screen.findByText("Under Review");
+    // Resolve button visible for under_review
+    expect(screen.getByRole("button", { name: /^resolve$/i })).toBeInTheDocument();
+  });
+
+  it("shows error toast when appeal resolve fails", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url.includes("/resolve") && method === "POST") {
+        return jsonResponse({ message: "Cannot resolve" }, 422);
+      }
+      if (url.includes("/appeals")) return jsonResponse({ appeals: [mockAppeal] });
+      if (url.includes("/flags")) return jsonResponse({ flags: [] });
+      if (url.includes("/prestige")) return jsonResponse({ entries: [] });
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+
+    await screen.findByText("Incorrect ranking score");
+    await user.click(screen.getByRole("button", { name: /^resolve$/i }));
+    await user.click(screen.getByRole("button", { name: /submit decision/i }));
+
+    await screen.findByText("Cannot resolve");
+  });
+
+  it("shows generic error toast (non-ApiError) when appeal resolve throws", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url.includes("/resolve") && method === "POST") {
+        throw new TypeError("network");
+      }
+      if (url.includes("/appeals")) return jsonResponse({ appeals: [mockAppeal] });
+      if (url.includes("/flags")) return jsonResponse({ flags: [] });
+      if (url.includes("/prestige")) return jsonResponse({ entries: [] });
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+
+    await screen.findByText("Incorrect ranking score");
+    await user.click(screen.getByRole("button", { name: /^resolve$/i }));
+    await user.click(screen.getByRole("button", { name: /submit decision/i }));
+
+    await screen.findByText("Failed to resolve appeal.");
+  });
+
+  it("allows changing appeal decision to rejected and editing resolution note", async () => {
+    const user = userEvent.setup();
+    let lastBody: string | null = null;
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url.includes("/resolve") && method === "POST") {
+        lastBody = String(init?.body ?? "");
+        return jsonResponse({ appeal: { ...mockAppeal, status: "rejected" } });
+      }
+      if (url.includes("/appeals")) return jsonResponse({ appeals: [mockAppeal] });
+      if (url.includes("/flags")) return jsonResponse({ flags: [] });
+      if (url.includes("/prestige")) return jsonResponse({ entries: [] });
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+
+    await screen.findByText("Incorrect ranking score");
+    await user.click(screen.getByRole("button", { name: /^resolve$/i }));
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    await user.selectOptions(select, "rejected");
+    const textarea = screen.getByPlaceholderText(/explain the reasoning/i);
+    await user.type(textarea, "no merit");
+    await user.click(screen.getByRole("button", { name: /submit decision/i }));
+
+    await waitFor(() => {
+      expect(lastBody).toContain("rejected");
+      expect(lastBody).toContain("no merit");
+    });
+  });
+
+  it("cancels appeal modal without firing resolve", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/appeals")) return jsonResponse({ appeals: [mockAppeal] });
+      if (url.includes("/flags")) return jsonResponse({ flags: [] });
+      if (url.includes("/prestige")) return jsonResponse({ entries: [] });
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+
+    await screen.findByText("Incorrect ranking score");
+    await user.click(screen.getByRole("button", { name: /^resolve$/i }));
+    expect(screen.getByText("Resolve Appeal")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.filter(([, init]) =>
+          (init?.method ?? "GET").toUpperCase() === "POST"
+        ).length
+      ).toBe(0);
+    });
+  });
+
+  it("switches to flags tab and shows empty state", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal("fetch", makeDefaultFetch());
+    renderPage();
+    await screen.findByText("Rankings administration");
+
+    await user.click(screen.getByRole("button", { name: "Anti-Gaming Flags" }));
+    await screen.findByText("No flags found");
+  });
+
+  it("renders flags loading state when switching to flags tab", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/flags")) {
+          // Never resolves
+          return new Promise(() => {}) as unknown as Response;
+        }
+        if (url.includes("/appeals")) return jsonResponse({ appeals: [] });
+        if (url.includes("/prestige")) return jsonResponse({ entries: [] });
+        return jsonResponse({});
+      })
+    );
+    renderPage();
+    await screen.findByText("Rankings administration");
+
+    await user.click(screen.getByRole("button", { name: "Anti-Gaming Flags" }));
+    // The flags loading shows SkeletonCard; we don't directly assert it, but ensure "No flags found" doesn't appear
+    await waitFor(() => {
+      expect(screen.queryByText("No flags found")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows flags ApiError message and non-ApiError fallback", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/flags")) return jsonResponse({ message: "Flags forbidden" }, 403);
+        if (url.includes("/appeals")) return jsonResponse({ appeals: [] });
+        if (url.includes("/prestige")) return jsonResponse({ entries: [] });
+        return jsonResponse({});
+      })
+    );
+    renderPage();
+    await screen.findByText("Rankings administration");
+
+    await user.click(screen.getByRole("button", { name: "Anti-Gaming Flags" }));
+    await screen.findByText("Flags forbidden");
+  });
+
+  it("shows flags non-ApiError fallback when network throws", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/flags")) {
+          throw new TypeError("offline");
+        }
+        if (url.includes("/appeals")) return jsonResponse({ appeals: [] });
+        if (url.includes("/prestige")) return jsonResponse({ entries: [] });
+        return jsonResponse({});
+      })
+    );
+    renderPage();
+    await screen.findByText("Rankings administration");
+    await user.click(screen.getByRole("button", { name: "Anti-Gaming Flags" }));
+    await screen.findByText("Failed to load flags.");
+  });
+
+  it("renders flag with mapped reason and shows resolve button for open flag", async () => {
+    const user = userEvent.setup();
+    const flag = {
+      id: "flag_1",
+      writerId: "w1",
+      reason: "duplicate_submission",
+      details: "Same script submitted twice",
+      status: "open",
+      resolvedByUserId: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/flags")) return jsonResponse({ flags: [flag] });
+        if (url.includes("/appeals")) return jsonResponse({ appeals: [] });
+        if (url.includes("/prestige")) return jsonResponse({ entries: [] });
+        return jsonResponse({});
+      })
+    );
+    renderPage();
+    await screen.findByText("Rankings administration");
+    await user.click(screen.getByRole("button", { name: "Anti-Gaming Flags" }));
+
+    await screen.findByText("Duplicate Submission");
+    expect(screen.getByText("Same script submitted twice")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^resolve$/i })).toBeInTheDocument();
+  });
+
+  it("renders flag with unmapped reason fallback and hides resolve for non-open", async () => {
+    const user = userEvent.setup();
+    const flag = {
+      id: "flag_2",
+      writerId: "w2",
+      reason: "unknown_reason_xyz",
+      details: "something weird",
+      status: "dismissed",
+      resolvedByUserId: "admin_1",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/flags")) return jsonResponse({ flags: [flag] });
+        if (url.includes("/appeals")) return jsonResponse({ appeals: [] });
+        if (url.includes("/prestige")) return jsonResponse({ entries: [] });
+        return jsonResponse({});
+      })
+    );
+    renderPage();
+    await screen.findByText("Rankings administration");
+    await user.click(screen.getByRole("button", { name: "Anti-Gaming Flags" }));
+
+    await screen.findByText("unknown_reason_xyz");
+    expect(screen.queryByRole("button", { name: /^resolve$/i })).not.toBeInTheDocument();
+  });
+
+  it("changes flag filter to confirmed", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal("fetch", makeDefaultFetch());
+    renderPage();
+    await screen.findByText("Rankings administration");
+    await user.click(screen.getByRole("button", { name: "Anti-Gaming Flags" }));
+    await user.click(screen.getByRole("button", { name: "Confirmed" }));
+    await screen.findByText("No flags found");
+  });
+
+  it("resolves a flag successfully (with decision change to confirmed)", async () => {
+    const user = userEvent.setup();
+    const flag = {
+      id: "flag_x",
+      writerId: "wx",
+      reason: "suspicious_pattern",
+      details: "weird voting pattern",
+      status: "open",
+      resolvedByUserId: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    let lastBody: string | null = null;
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url.includes("/flags/") && url.includes("/resolve") && method === "POST") {
+        lastBody = String(init?.body ?? "");
+        return jsonResponse({ flag: { ...flag, status: "confirmed" } });
+      }
+      if (url.includes("/flags")) return jsonResponse({ flags: [flag] });
+      if (url.includes("/appeals")) return jsonResponse({ appeals: [] });
+      if (url.includes("/prestige")) return jsonResponse({ entries: [] });
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("Rankings administration");
+    await user.click(screen.getByRole("button", { name: "Anti-Gaming Flags" }));
+
+    await screen.findByText("Suspicious Pattern");
+    await user.click(screen.getByRole("button", { name: /^resolve$/i }));
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    await user.selectOptions(select, "confirmed");
+    await user.click(screen.getByRole("button", { name: /submit decision/i }));
+
+    await waitFor(() => {
+      expect(lastBody).toContain("confirmed");
+    });
+  });
+
+  it("shows error toast when flag resolve fails (ApiError)", async () => {
+    const user = userEvent.setup();
+    const flag = {
+      id: "flag_e",
+      writerId: "we",
+      reason: "manual_admin",
+      details: "details",
+      status: "open",
+      resolvedByUserId: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (url.includes("/flags/") && url.includes("/resolve") && method === "POST") {
+          return jsonResponse({ message: "Flag locked" }, 409);
+        }
+        if (url.includes("/flags")) return jsonResponse({ flags: [flag] });
+        if (url.includes("/appeals")) return jsonResponse({ appeals: [] });
+        if (url.includes("/prestige")) return jsonResponse({ entries: [] });
+        return jsonResponse({});
+      })
+    );
+    renderPage();
+    await screen.findByText("Rankings administration");
+    await user.click(screen.getByRole("button", { name: "Anti-Gaming Flags" }));
+    await screen.findByText("Manual Admin");
+    await user.click(screen.getByRole("button", { name: /^resolve$/i }));
+    await user.click(screen.getByRole("button", { name: /submit decision/i }));
+
+    await screen.findByText("Flag locked");
+  });
+
+  it("shows generic flag resolve error when fetch throws", async () => {
+    const user = userEvent.setup();
+    const flag = {
+      id: "flag_e2",
+      writerId: "we2",
+      reason: "manual_admin",
+      details: "details",
+      status: "open",
+      resolvedByUserId: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (url.includes("/flags/") && url.includes("/resolve") && method === "POST") {
+          throw new TypeError("net");
+        }
+        if (url.includes("/flags")) return jsonResponse({ flags: [flag] });
+        if (url.includes("/appeals")) return jsonResponse({ appeals: [] });
+        if (url.includes("/prestige")) return jsonResponse({ entries: [] });
+        return jsonResponse({});
+      })
+    );
+    renderPage();
+    await screen.findByText("Rankings administration");
+    await user.click(screen.getByRole("button", { name: "Anti-Gaming Flags" }));
+    await screen.findByText("Manual Admin");
+    await user.click(screen.getByRole("button", { name: /^resolve$/i }));
+    await user.click(screen.getByRole("button", { name: /submit decision/i }));
+
+    await screen.findByText("Failed to resolve flag.");
+  });
+
+  it("renders prestige tab empty state", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal("fetch", makeDefaultFetch());
+    renderPage();
+    await screen.findByText("Rankings administration");
+
+    await user.click(screen.getByRole("button", { name: "Prestige" }));
+    await screen.findByText("No prestige entries");
+  });
+
+  it("shows prestige ApiError message", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/prestige")) return jsonResponse({ message: "Prestige denied" }, 403);
+        if (url.includes("/appeals")) return jsonResponse({ appeals: [] });
+        if (url.includes("/flags")) return jsonResponse({ flags: [] });
+        return jsonResponse({});
+      })
+    );
+    renderPage();
+    await screen.findByText("Rankings administration");
+    await user.click(screen.getByRole("button", { name: "Prestige" }));
+    await screen.findByText("Prestige denied");
+  });
+
+  it("shows prestige generic error fallback when fetch throws", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/prestige")) throw new TypeError("net");
+        if (url.includes("/appeals")) return jsonResponse({ appeals: [] });
+        if (url.includes("/flags")) return jsonResponse({ flags: [] });
+        return jsonResponse({});
+      })
+    );
+    renderPage();
+    await screen.findByText("Rankings administration");
+    await user.click(screen.getByRole("button", { name: "Prestige" }));
+    await screen.findByText("Failed to load prestige data.");
+  });
+
+  it("renders prestige entries table and edits an entry", async () => {
+    const user = userEvent.setup();
+    const entry = {
+      competitionId: "comp_1",
+      tier: "notable",
+      multiplier: 1.5,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    let lastBody: string | null = null;
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url.includes("/prestige/") && method === "PUT") {
+        lastBody = String(init?.body ?? "");
+        return jsonResponse({ entry: { ...entry, tier: "elite", multiplier: 2 } });
+      }
+      if (url.includes("/prestige")) return jsonResponse({ entries: [entry] });
+      if (url.includes("/appeals")) return jsonResponse({ appeals: [] });
+      if (url.includes("/flags")) return jsonResponse({ flags: [] });
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("Rankings administration");
+    await user.click(screen.getByRole("button", { name: "Prestige" }));
+
+    await screen.findByText("comp_1");
+    expect(screen.getByText("Notable")).toBeInTheDocument();
+    expect(screen.getByText("1.5x")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^edit$/i }));
+    const tierSelect = screen.getByRole("combobox") as HTMLSelectElement;
+    await user.selectOptions(tierSelect, "elite");
+    const multInput = screen.getByRole("spinbutton") as HTMLInputElement;
+    await user.clear(multInput);
+    await user.type(multInput, "2");
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(lastBody).toContain("elite");
+      expect(lastBody).toContain("2");
+    });
+  });
+
+  it("shows error toast on prestige save (ApiError)", async () => {
+    const user = userEvent.setup();
+    const entry = {
+      competitionId: "comp_err",
+      tier: "standard",
+      multiplier: 1,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (url.includes("/prestige/") && method === "PUT") {
+          return jsonResponse({ message: "Prestige conflict" }, 409);
+        }
+        if (url.includes("/prestige")) return jsonResponse({ entries: [entry] });
+        if (url.includes("/appeals")) return jsonResponse({ appeals: [] });
+        if (url.includes("/flags")) return jsonResponse({ flags: [] });
+        return jsonResponse({});
+      })
+    );
+    renderPage();
+    await screen.findByText("Rankings administration");
+    await user.click(screen.getByRole("button", { name: "Prestige" }));
+    await screen.findByText("comp_err");
+    await user.click(screen.getByRole("button", { name: /^edit$/i }));
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+    await screen.findByText("Prestige conflict");
+  });
+
+  it("shows generic error on prestige save when fetch throws", async () => {
+    const user = userEvent.setup();
+    const entry = {
+      competitionId: "comp_err2",
+      tier: "standard",
+      multiplier: 1,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (url.includes("/prestige/") && method === "PUT") {
+          throw new TypeError("net");
+        }
+        if (url.includes("/prestige")) return jsonResponse({ entries: [entry] });
+        if (url.includes("/appeals")) return jsonResponse({ appeals: [] });
+        if (url.includes("/flags")) return jsonResponse({ flags: [] });
+        return jsonResponse({});
+      })
+    );
+    renderPage();
+    await screen.findByText("Rankings administration");
+    await user.click(screen.getByRole("button", { name: "Prestige" }));
+    await screen.findByText("comp_err2");
+    await user.click(screen.getByRole("button", { name: /^edit$/i }));
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+    await screen.findByText("Failed to update prestige.");
+  });
+
+  it("opens recompute confirmation modal and recomputes successfully", async () => {
+    const user = userEvent.setup();
+    let recomputeCalls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (url.includes("/recompute") && method === "POST") {
+          recomputeCalls++;
+          return jsonResponse({ message: "ok" });
+        }
+        if (url.includes("/prestige")) return jsonResponse({ entries: [] });
+        if (url.includes("/appeals")) return jsonResponse({ appeals: [] });
+        if (url.includes("/flags")) return jsonResponse({ flags: [] });
+        return jsonResponse({});
+      })
+    );
+    renderPage();
+    await screen.findByText("Rankings administration");
+    await user.click(screen.getByRole("button", { name: "Prestige" }));
+    await user.click(screen.getByRole("button", { name: /recompute rankings/i }));
+    await user.click(screen.getByRole("button", { name: /confirm recompute/i }));
+
+    await waitFor(() => {
+      expect(recomputeCalls).toBe(1);
+    });
+  });
+
+  it("shows error toast on recompute (ApiError)", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (url.includes("/recompute") && method === "POST") {
+          return jsonResponse({ message: "Recompute blocked" }, 500);
+        }
+        if (url.includes("/prestige")) return jsonResponse({ entries: [] });
+        if (url.includes("/appeals")) return jsonResponse({ appeals: [] });
+        if (url.includes("/flags")) return jsonResponse({ flags: [] });
+        return jsonResponse({});
+      })
+    );
+    renderPage();
+    await screen.findByText("Rankings administration");
+    await user.click(screen.getByRole("button", { name: "Prestige" }));
+    await user.click(screen.getByRole("button", { name: /recompute rankings/i }));
+    await user.click(screen.getByRole("button", { name: /confirm recompute/i }));
+
+    await screen.findByText("Recompute blocked");
+  });
+
+  it("shows generic error on recompute when fetch throws", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input, init) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (url.includes("/recompute") && method === "POST") {
+          throw new TypeError("net");
+        }
+        if (url.includes("/prestige")) return jsonResponse({ entries: [] });
+        if (url.includes("/appeals")) return jsonResponse({ appeals: [] });
+        if (url.includes("/flags")) return jsonResponse({ flags: [] });
+        return jsonResponse({});
+      })
+    );
+    renderPage();
+    await screen.findByText("Rankings administration");
+    await user.click(screen.getByRole("button", { name: "Prestige" }));
+    await user.click(screen.getByRole("button", { name: /recompute rankings/i }));
+    await user.click(screen.getByRole("button", { name: /confirm recompute/i }));
+
+    await screen.findByText("Failed to recompute rankings.");
+  });
+
+  it("cancels recompute modal without firing recompute", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/prestige")) return jsonResponse({ entries: [] });
+      if (url.includes("/appeals")) return jsonResponse({ appeals: [] });
+      if (url.includes("/flags")) return jsonResponse({ flags: [] });
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("Rankings administration");
+    await user.click(screen.getByRole("button", { name: "Prestige" }));
+    await user.click(screen.getByRole("button", { name: /recompute rankings/i }));
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.filter(([url, init]) =>
+          String(url).includes("/recompute") &&
+          (init?.method ?? "GET").toUpperCase() === "POST"
+        ).length
+      ).toBe(0);
+    });
+  });
 });

--- a/apps/writer-web/app/admin/security/page.test.tsx
+++ b/apps/writer-web/app/admin/security/page.test.tsx
@@ -98,4 +98,610 @@ describe("AdminSecurityPage", () => {
       expect(blocksGetCount).toBeGreaterThan(countBeforeMutation);
     });
   });
+
+  // ── Add Block Form Validation ──────────────────────────────────
+
+  it("shows error toast when IP is empty on add block", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => jsonResponse({ blocks: [], total: 0 }))
+    );
+    renderPage();
+    await screen.findByText("No blocked IPs");
+
+    await user.click(screen.getByRole("button", { name: /block ip/i }));
+    expect(await screen.findByText(/ip address and reason are required/i)).toBeInTheDocument();
+  });
+
+  it("shows error toast when reason is empty but IP is filled", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => jsonResponse({ blocks: [], total: 0 }))
+    );
+    renderPage();
+    await screen.findByText("No blocked IPs");
+
+    await user.type(screen.getByPlaceholderText(/192.168/), "5.5.5.5");
+    await user.click(screen.getByRole("button", { name: /block ip/i }));
+    expect(await screen.findByText(/ip address and reason are required/i)).toBeInTheDocument();
+  });
+
+  it("shows error toast when IP is only whitespace", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => jsonResponse({ blocks: [], total: 0 }))
+    );
+    renderPage();
+    await screen.findByText("No blocked IPs");
+
+    await user.type(screen.getByPlaceholderText(/192.168/), "   ");
+    await user.type(screen.getByPlaceholderText(/brute force/i), "spam");
+    await user.click(screen.getByRole("button", { name: /block ip/i }));
+    expect(await screen.findByText(/ip address and reason are required/i)).toBeInTheDocument();
+  });
+
+  // ── Add Block Success Paths ──────────────────────────────────
+
+  it("submits add block without expires hours and shows success toast", async () => {
+    const user = userEvent.setup();
+    const postBody: Array<unknown> = [];
+
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url.includes("/ip-blocks") && method === "POST") {
+        postBody.push(JSON.parse(init?.body as string));
+        return jsonResponse({ block: mockBlock });
+      }
+      if (url.includes("/ip-blocks")) {
+        return jsonResponse({ blocks: [], total: 0 });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("No blocked IPs");
+
+    await user.type(screen.getByPlaceholderText(/192.168/), "9.9.9.9");
+    await user.type(screen.getByPlaceholderText(/brute force/i), "abuse");
+    await user.click(screen.getByRole("button", { name: /block ip/i }));
+
+    await waitFor(() => {
+      expect(postBody.length).toBeGreaterThan(0);
+    });
+    expect(postBody[0]).toEqual({ ipAddress: "9.9.9.9", reason: "abuse" });
+    await screen.findByText(/ip address blocked successfully/i);
+  });
+
+  it("submits add block with expiresInHours when valid number > 0", async () => {
+    const user = userEvent.setup();
+    const postBodies: Array<Record<string, unknown>> = [];
+
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url.includes("/ip-blocks") && method === "POST") {
+        postBodies.push(JSON.parse(init?.body as string));
+        return jsonResponse({ block: mockBlock });
+      }
+      if (url.includes("/ip-blocks")) {
+        return jsonResponse({ blocks: [], total: 0 });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("No blocked IPs");
+
+    await user.type(screen.getByPlaceholderText(/192.168/), "8.8.8.8");
+    await user.type(screen.getByPlaceholderText(/leave empty/i), "24");
+    await user.type(screen.getByPlaceholderText(/brute force/i), "spam");
+    await user.click(screen.getByRole("button", { name: /block ip/i }));
+
+    await waitFor(() => {
+      expect(postBodies.length).toBeGreaterThan(0);
+    });
+    expect(postBodies[0]).toEqual({ ipAddress: "8.8.8.8", reason: "spam", expiresInHours: 24 });
+  });
+
+  it("omits expiresInHours when value is zero", async () => {
+    const user = userEvent.setup();
+    const postBodies: Array<Record<string, unknown>> = [];
+
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url.includes("/ip-blocks") && method === "POST") {
+        postBodies.push(JSON.parse(init?.body as string));
+        return jsonResponse({ block: mockBlock });
+      }
+      if (url.includes("/ip-blocks")) {
+        return jsonResponse({ blocks: [], total: 0 });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("No blocked IPs");
+
+    await user.type(screen.getByPlaceholderText(/192.168/), "7.7.7.7");
+    await user.type(screen.getByPlaceholderText(/brute force/i), "spam");
+    const hoursInput = screen.getByPlaceholderText(/leave empty/i);
+    await user.type(hoursInput, "0");
+    await user.click(screen.getByRole("button", { name: /block ip/i }));
+
+    await waitFor(() => {
+      expect(postBodies.length).toBeGreaterThan(0);
+    });
+    expect(postBodies[0]).not.toHaveProperty("expiresInHours");
+  });
+
+  // ── Add Block Error Paths ────────────────────────────────────
+
+  it("shows ApiError message on add block failure", async () => {
+    const user = userEvent.setup();
+
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url.includes("/ip-blocks") && method === "POST") {
+        return jsonResponse({ message: "IP already blocked" }, 409);
+      }
+      return jsonResponse({ blocks: [], total: 0 });
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("No blocked IPs");
+
+    await user.type(screen.getByPlaceholderText(/192.168/), "1.1.1.1");
+    await user.type(screen.getByPlaceholderText(/brute force/i), "spam");
+    await user.click(screen.getByRole("button", { name: /block ip/i }));
+
+    expect(await screen.findByText("IP already blocked")).toBeInTheDocument();
+  });
+
+  it("shows fallback error message on add block non-ApiError failure", async () => {
+    const user = userEvent.setup();
+
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url.includes("/ip-blocks") && method === "POST") {
+        throw new TypeError("network down");
+      }
+      return jsonResponse({ blocks: [], total: 0 });
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("No blocked IPs");
+
+    await user.type(screen.getByPlaceholderText(/192.168/), "1.1.1.1");
+    await user.type(screen.getByPlaceholderText(/brute force/i), "spam");
+    await user.click(screen.getByRole("button", { name: /block ip/i }));
+
+    expect(await screen.findByText(/failed to add ip block/i)).toBeInTheDocument();
+  });
+
+  // ── Remove Block Error Paths ─────────────────────────────────
+
+  it("shows ApiError message on remove block failure", async () => {
+    const user = userEvent.setup();
+
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url.includes("/ip-blocks/") && method === "DELETE") {
+        return jsonResponse({ message: "Not allowed" }, 403);
+      }
+      if (url.includes("/ip-blocks") && method === "GET") {
+        return jsonResponse({ blocks: [mockBlock], total: 1 });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("1.2.3.4");
+
+    await user.click(screen.getByRole("button", { name: /remove/i }));
+    expect(await screen.findByText("Not allowed")).toBeInTheDocument();
+  });
+
+  it("shows fallback message on remove block non-ApiError failure", async () => {
+    const user = userEvent.setup();
+
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url.includes("/ip-blocks/") && method === "DELETE") {
+        throw new TypeError("network gone");
+      }
+      if (url.includes("/ip-blocks") && method === "GET") {
+        return jsonResponse({ blocks: [mockBlock], total: 1 });
+      }
+      return jsonResponse({}, 404);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("1.2.3.4");
+
+    await user.click(screen.getByRole("button", { name: /remove/i }));
+    expect(await screen.findByText(/failed to remove ip block/i)).toBeInTheDocument();
+  });
+
+  // ── Block list rendering branches ────────────────────────────
+
+  it("shows fallback message when blocks fetch fails with non-ApiError", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => {
+        throw new TypeError("network unreachable");
+      })
+    );
+    renderPage();
+
+    expect(await screen.findByText(/failed to load ip blocks/i)).toBeInTheDocument();
+  });
+
+  it("renders Auto badge for auto-blocked entries and Expires for entries with expiresAt", async () => {
+    const autoBlock = {
+      ...mockBlock,
+      id: "block_auto",
+      ipAddress: "10.0.0.1",
+      autoBlocked: true,
+      expiresAt: "2099-01-01T00:00:00.000Z"
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => jsonResponse({ blocks: [autoBlock], total: 1 }))
+    );
+    renderPage();
+
+    await screen.findByText("10.0.0.1");
+    expect(screen.getByText("Auto")).toBeInTheDocument();
+    // "Expires <date>" appears next to the block row (not the form label "Expires in (hours, optional)")
+    expect(screen.getByText(/^Expires \d/)).toBeInTheDocument();
+    expect(screen.queryByText("Permanent")).not.toBeInTheDocument();
+  });
+
+  it("renders Permanent badge when expiresAt is null and not auto-blocked", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => jsonResponse({ blocks: [mockBlock], total: 1 }))
+    );
+    renderPage();
+
+    await screen.findByText("1.2.3.4");
+    expect(screen.getByText("Permanent")).toBeInTheDocument();
+    expect(screen.queryByText("Auto")).not.toBeInTheDocument();
+  });
+
+  // ── Pagination ───────────────────────────────────────────────
+
+  it("disables Previous on first page and enables Next when more pages exist", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () =>
+        jsonResponse({ blocks: [mockBlock], total: 60 })
+      )
+    );
+    renderPage();
+    await screen.findByText("1.2.3.4");
+
+    const prev = screen.getByRole("button", { name: /previous/i });
+    const next = screen.getByRole("button", { name: /next/i });
+    expect(prev).toBeDisabled();
+    expect(next).toBeEnabled();
+    expect(screen.getByText(/Page 1 of 3/)).toBeInTheDocument();
+  });
+
+  it("advances to next page on Next click and disables Next on last page", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const match = /page=(\d+)/.exec(url);
+      const page = match ? Number(match[1]) : 1;
+      return jsonResponse({
+        blocks: [{ ...mockBlock, id: `b_${page}`, ipAddress: `10.0.0.${page}` }],
+        total: 40
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("10.0.0.1");
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await screen.findByText("10.0.0.2");
+    expect(screen.getByText(/Page 2 of 2/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /next/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /previous/i })).toBeEnabled();
+  });
+
+  it("goes back to previous page on Previous click", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const match = /page=(\d+)/.exec(url);
+      const page = match ? Number(match[1]) : 1;
+      return jsonResponse({
+        blocks: [{ ...mockBlock, id: `b_${page}`, ipAddress: `10.0.0.${page}` }],
+        total: 40
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("10.0.0.1");
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await screen.findByText("10.0.0.2");
+    await user.click(screen.getByRole("button", { name: /previous/i }));
+    await screen.findByText("10.0.0.1");
+  });
+
+  // ── Suspension search ───────────────────────────────────────
+
+  it("shows error toast when searching suspensions with empty userId", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => jsonResponse({ blocks: [], total: 0 }))
+    );
+    renderPage();
+    await screen.findByText("No blocked IPs");
+
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+    expect(await screen.findByText(/enter a user id to search/i)).toBeInTheDocument();
+  });
+
+  it("triggers search on Enter key in user ID input", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/suspensions")) {
+        return jsonResponse({ suspensions: [] });
+      }
+      return jsonResponse({ blocks: [], total: 0 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("No blocked IPs");
+
+    const input = screen.getByPlaceholderText(/user_abc123/);
+    await user.type(input, "user_xyz");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      const called = fetchMock.mock.calls.some(([arg]) =>
+        String(arg).includes("/suspensions")
+      );
+      expect(called).toBe(true);
+    });
+  });
+
+  it("renders empty state when searched user has no suspensions", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/suspensions")) {
+        return jsonResponse({ suspensions: [] });
+      }
+      return jsonResponse({ blocks: [], total: 0 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("No blocked IPs");
+
+    await user.type(screen.getByPlaceholderText(/user_abc123/), "user_xyz");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+
+    expect(await screen.findByText(/no suspensions found/i)).toBeInTheDocument();
+  });
+
+  it("renders empty state when 404 suspensions response treated as empty array", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/suspensions")) {
+        return jsonResponse({ message: "not found" }, 404);
+      }
+      return jsonResponse({ blocks: [], total: 0 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("No blocked IPs");
+
+    await user.type(screen.getByPlaceholderText(/user_abc123/), "user_404");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+
+    expect(await screen.findByText(/no suspensions found/i)).toBeInTheDocument();
+  });
+
+  it("shows ApiError message when suspensions fetch fails with non-404", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/suspensions")) {
+        return jsonResponse({ message: "Forbidden suspensions" }, 403);
+      }
+      return jsonResponse({ blocks: [], total: 0 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("No blocked IPs");
+
+    await user.type(screen.getByPlaceholderText(/user_abc123/), "user_403");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+
+    expect(await screen.findByText("Forbidden suspensions")).toBeInTheDocument();
+  });
+
+  it("shows fallback message when suspensions fetch fails with non-ApiError", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/suspensions")) {
+        throw new TypeError("net err");
+      }
+      return jsonResponse({ blocks: [], total: 0 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("No blocked IPs");
+
+    await user.type(screen.getByPlaceholderText(/user_abc123/), "user_net");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+
+    expect(await screen.findByText(/failed to load suspensions/i)).toBeInTheDocument();
+  });
+
+  // ── Suspension rendering branches ────────────────────────────
+
+  it("renders Lifted badge when suspension has liftedAt", async () => {
+    const user = userEvent.setup();
+    const suspension = {
+      id: "sus_1",
+      userId: "user_1",
+      reason: "Repeated abuse",
+      suspendedBy: "admin",
+      durationDays: 7,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2026-01-08T00:00:00.000Z",
+      liftedAt: "2026-01-05T00:00:00.000Z",
+      liftedBy: "mod_42",
+      createdAt: "2026-01-01T00:00:00.000Z"
+    };
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/suspensions")) {
+        return jsonResponse({ suspensions: [suspension] });
+      }
+      return jsonResponse({ blocks: [], total: 0 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("No blocked IPs");
+
+    await user.type(screen.getByPlaceholderText(/user_abc123/), "user_1");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+
+    await screen.findByText("Repeated abuse");
+    expect(screen.getByText("Lifted")).toBeInTheDocument();
+    expect(screen.getByText(/7 days/)).toBeInTheDocument();
+    expect(screen.getByText(/Lifted .* by mod_42/)).toBeInTheDocument();
+  });
+
+  it("renders Active (Temporary) when no liftedAt but expiresAt set", async () => {
+    const user = userEvent.setup();
+    const suspension = {
+      id: "sus_2",
+      userId: "user_2",
+      reason: "Spam wave",
+      suspendedBy: "admin",
+      durationDays: 3,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2026-01-04T00:00:00.000Z",
+      liftedAt: null,
+      liftedBy: null,
+      createdAt: "2026-01-01T00:00:00.000Z"
+    };
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/suspensions")) {
+        return jsonResponse({ suspensions: [suspension] });
+      }
+      return jsonResponse({ blocks: [], total: 0 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("No blocked IPs");
+
+    await user.type(screen.getByPlaceholderText(/user_abc123/), "user_2");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+
+    await screen.findByText("Spam wave");
+    expect(screen.getByText("Active (Temporary)")).toBeInTheDocument();
+    // The "Started ... | Expires ..." paragraph contains "| Expires"
+    expect(screen.getByText(/\| Expires /)).toBeInTheDocument();
+  });
+
+  it("renders Active (Permanent) when no liftedAt and no expiresAt and Permanent duration", async () => {
+    const user = userEvent.setup();
+    const suspension = {
+      id: "sus_3",
+      userId: "user_3",
+      reason: "Severe ToS breach",
+      suspendedBy: "admin",
+      durationDays: null,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: null,
+      liftedAt: null,
+      liftedBy: null,
+      createdAt: "2026-01-01T00:00:00.000Z"
+    };
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/suspensions")) {
+        return jsonResponse({ suspensions: [suspension] });
+      }
+      return jsonResponse({ blocks: [], total: 0 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("No blocked IPs");
+
+    await user.type(screen.getByPlaceholderText(/user_abc123/), "user_3");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+
+    await screen.findByText("Severe ToS breach");
+    expect(screen.getByText("Active (Permanent)")).toBeInTheDocument();
+    expect(screen.getByText(/Duration: Permanent/)).toBeInTheDocument();
+  });
+
+  it("falls back to 'system' when liftedBy is null on a lifted suspension", async () => {
+    const user = userEvent.setup();
+    const suspension = {
+      id: "sus_4",
+      userId: "user_4",
+      reason: "Auto-lifted",
+      suspendedBy: "admin",
+      durationDays: 1,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: null,
+      liftedAt: "2026-01-02T00:00:00.000Z",
+      liftedBy: null,
+      createdAt: "2026-01-01T00:00:00.000Z"
+    };
+    const fetchMock = vi.fn<typeof fetch>(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/suspensions")) {
+        return jsonResponse({ suspensions: [suspension] });
+      }
+      return jsonResponse({ blocks: [], total: 0 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPage();
+    await screen.findByText("No blocked IPs");
+
+    await user.type(screen.getByPlaceholderText(/user_abc123/), "user_4");
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+
+    await screen.findByText("Auto-lifted");
+    expect(screen.getByText(/by system/)).toBeInTheDocument();
+  });
 });

--- a/apps/writer-web/app/competitions/page.test.tsx
+++ b/apps/writer-web/app/competitions/page.test.tsx
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SWRConfig } from "swr";
 import type { ReactElement } from "react";
 import { mockUseAuth } from "../../vitest.setup";
 import { ToastProvider } from "../components/toast";
+import * as toastModule from "../components/toast";
 import { fetcher } from "../lib/fetcher";
 import CompetitionsPage from "./page";
 
@@ -187,6 +188,684 @@ describe("CompetitionsPage", () => {
       actorUserId: "writer_01",
       deadlineAt: "2030-06-01T00:00:00.000Z",
       message: "Submission closes soon"
+    });
+  });
+});
+
+describe("CompetitionsPage — branch coverage", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({
+      user: {
+        id: "writer_01",
+        email: "writer@example.com",
+        displayName: "Writer One",
+        role: "writer",
+        emailVerified: true,
+      },
+      loading: false,
+    });
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  function makeFetch(opts: {
+    competitions?: unknown[];
+    savedCompetitions?: unknown[];
+    overrides?: (url: string, init?: RequestInit) => Response | null | undefined;
+  } = {}) {
+    const competitions = opts.competitions ?? [];
+    const savedCompetitions = opts.savedCompetitions ?? [];
+    const mock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const ov = opts.overrides?.(url, init ?? undefined);
+      if (ov) return ov;
+      if (url.startsWith("/api/v1/competitions?")) return jsonResponse({ competitions });
+      if (url === "/api/v1/writers/me/saved-competitions") return jsonResponse({ savedCompetitions });
+      if (url === "/api/v1/onboarding-progress") return jsonResponse({ ok: true });
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", mock);
+    return mock;
+  }
+
+  it("renders 'Sign in for reminders' badge when user is null and skips saved-competitions fetch", async () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: false });
+    const fetchMock = makeFetch();
+    renderWithProviders(<CompetitionsPage />);
+
+    expect(screen.getByText("Sign in for reminders")).toBeInTheDocument();
+
+    // saved-competitions key is null when not signed in → no fetch for it
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    expect(
+      fetchMock.mock.calls.find(([input]) => String(input) === "/api/v1/writers/me/saved-competitions")
+    ).toBeUndefined();
+  });
+
+  it("renders 'Reminders enabled' badge when signed in", async () => {
+    makeFetch();
+    renderWithProviders(<CompetitionsPage />);
+    expect(screen.getByText("Reminders enabled")).toBeInTheDocument();
+  });
+
+  it("shows 'Start exploring competitions' empty state before any search", async () => {
+    // Force SWR key to never resolve until user interacts; data === undefined → hasSearched=false
+    // Default key has no filters, so the fetch will fire. To keep data undefined briefly,
+    // we simulate a slow response by returning an empty list and asserting hasSearched flips after.
+    makeFetch({ competitions: [] });
+    renderWithProviders(<CompetitionsPage />);
+
+    // After fetch resolves, data is defined → hasSearched=true → "No matches found"
+    await screen.findByText("No matches found");
+  });
+
+  it("shows skeleton while loading", async () => {
+    let resolveFn: ((value: Response) => void) | null = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.startsWith("/api/v1/competitions?")) {
+          return new Promise<Response>((res) => {
+            resolveFn = res;
+          });
+        }
+        return jsonResponse({});
+      })
+    );
+
+    renderWithProviders(<CompetitionsPage />);
+
+    // Skeleton placeholder rendered while loading (no aria-label, just exists)
+    // Searching button text confirms loading
+    expect(screen.getByRole("button", { name: "Searching..." })).toBeInTheDocument();
+
+    // Cleanup: resolve so component doesn't dangle
+    resolveFn?.(jsonResponse({ competitions: [] }));
+  });
+
+  it("surfaces ApiError message via toast when search endpoint fails", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    makeFetch({
+      overrides: (url) => {
+        if (url.startsWith("/api/v1/competitions?")) {
+          return new Response(JSON.stringify({ message: "Boom" }), {
+            status: 500,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return null;
+      },
+    });
+
+    renderWithProviders(<CompetitionsPage />);
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Boom");
+    });
+  });
+
+  it("falls back to default toast message on non-ApiError search failure", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.startsWith("/api/v1/competitions?")) {
+          // Non-JSON body so fetcher throws non-ApiError
+          return new Response("garbage", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return jsonResponse({});
+      })
+    );
+
+    renderWithProviders(<CompetitionsPage />);
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Competition search failed.");
+    });
+  });
+
+  it("buildKey: sends all trim()-ed filters when set, and ignores whitespace-only values", async () => {
+    const fetchMock = makeFetch({ competitions: [] });
+    const user = userEvent.setup();
+    renderWithProviders(<CompetitionsPage />);
+
+    await screen.findByText("No matches found");
+
+    await user.type(screen.getByLabelText("Keyword"), "  Hello  ");
+    await user.type(screen.getByLabelText("Format"), "feature");
+    await user.type(screen.getByLabelText("Genre"), "drama");
+    await user.type(screen.getByLabelText("Max fee (USD)"), "100");
+    await user.selectOptions(screen.getByLabelText("Location"), "Worldwide");
+    await user.selectOptions(screen.getByLabelText("Language"), "en");
+    // Click fee tier
+    await user.click(screen.getByRole("button", { name: "<$30" }));
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      const lastCompCall = fetchMock.mock.calls
+        .map(([input]) => String(input))
+        .filter((u) => u.startsWith("/api/v1/competitions?"))
+        .pop();
+      expect(lastCompCall).toContain("query=Hello");
+      expect(lastCompCall).toContain("format=feature");
+      expect(lastCompCall).toContain("genre=drama");
+      expect(lastCompCall).toContain("maxFeeUsd=100");
+      expect(lastCompCall).toContain("location=Worldwide");
+      expect(lastCompCall).toContain("language=en");
+      expect(lastCompCall).toContain("feeTier=low");
+    });
+  });
+
+  it("Reset button clears pending and committed filters", async () => {
+    makeFetch({ competitions: [] });
+    const user = userEvent.setup();
+    renderWithProviders(<CompetitionsPage />);
+
+    await screen.findByText("No matches found");
+
+    const keyword = screen.getByLabelText("Keyword") as HTMLInputElement;
+    await user.type(keyword, "hello");
+    expect(keyword.value).toBe("hello");
+    await user.click(screen.getByRole("button", { name: "Reset" }));
+    expect((screen.getByLabelText("Keyword") as HTMLInputElement).value).toBe("");
+  });
+
+  it("renders all deadline urgency branches: closed, urgent <=7 days, approaching <=30, comfortable >30", async () => {
+    const now = Date.now();
+    const dayMs = 86400000;
+    const competitions = [
+      // closed: deltaMs < 0
+      { id: "c_closed", title: "Closed Comp", description: "", format: "feature", genre: "drama", feeUsd: 0, deadline: new Date(now - dayMs).toISOString() },
+      // urgent: within 7 days (5 days)
+      { id: "c_week", title: "Week Comp", description: "", format: "tv", genre: "comedy", feeUsd: 50, deadline: new Date(now + 5 * dayMs - 1000).toISOString() },
+      // approaching: 20 days
+      { id: "c_month", title: "Month Comp", description: "", format: "short", genre: "horror", feeUsd: 30, deadline: new Date(now + 20 * dayMs - 1000).toISOString() },
+      // comfortable: 60 days
+      { id: "c_far", title: "Far Comp", description: "", format: "feature", genre: "sci-fi", feeUsd: 25, deadline: new Date(now + 60 * dayMs - 1000).toISOString() },
+    ];
+
+    makeFetch({ competitions });
+    renderWithProviders(<CompetitionsPage />);
+
+    await screen.findByText("Found 4 competitions.");
+
+    // Closed badge appears in the results list (calendar filters past out)
+    expect(screen.getAllByText("Closed").length).toBeGreaterThan(0);
+    // 5 days left (urgent)
+    expect(screen.getAllByText(/5 days left/).length).toBeGreaterThan(0);
+    // 20 days left (approaching)
+    expect(screen.getAllByText(/20 days left/).length).toBeGreaterThan(0);
+    // 60 days left (comfortable)
+    expect(screen.getAllByText(/60 days left/).length).toBeGreaterThan(0);
+  });
+
+  it("renders 'Due today' urgency when daysRemaining is exactly 0", async () => {
+    // To exercise the daysRemaining===0 branch, we need deltaMs >= 0 and < dayMs and ceil() === 0,
+    // which is only possible when deltaMs is EXACTLY 0. Stub Date.now to coincide with deadline.
+    const fixedDeadline = "2030-06-01T00:00:00.000Z";
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(new Date(fixedDeadline).getTime());
+
+    const competitions = [
+      { id: "c_today", title: "Today Comp", description: "", format: "feature", genre: "drama", feeUsd: 0, deadline: fixedDeadline },
+    ];
+
+    makeFetch({ competitions });
+    renderWithProviders(<CompetitionsPage />);
+
+    await screen.findByText("Found 1 competitions.");
+    expect(screen.getAllByText(/Due today/).length).toBeGreaterThan(0);
+
+    dateNowSpy.mockRestore();
+  });
+
+  it("renders 'Due in 1 day' urgency when daysRemaining is exactly 1", async () => {
+    const dateNow = new Date("2030-05-31T00:00:00.000Z").getTime();
+    const deadline = new Date(dateNow + 12 * 60 * 60 * 1000).toISOString(); // 12 hours later → ceil = 1
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(dateNow);
+
+    const competitions = [
+      { id: "c_1day", title: "OneDay Comp", description: "", format: "feature", genre: "drama", feeUsd: 0, deadline },
+    ];
+
+    makeFetch({ competitions });
+    renderWithProviders(<CompetitionsPage />);
+
+    await screen.findByText("Found 1 competitions.");
+    expect(screen.getAllByText(/Due in 1 day/).length).toBeGreaterThan(0);
+
+    dateNowSpy.mockRestore();
+  });
+
+  it("renders 'No upcoming deadlines' empty state when all competitions have past deadlines", async () => {
+    const competitions = [
+      { id: "c_old", title: "Old Comp", description: "", format: "feature", genre: "drama", feeUsd: 0, deadline: "2000-01-01T00:00:00.000Z" },
+    ];
+    makeFetch({ competitions });
+    renderWithProviders(<CompetitionsPage />);
+
+    await screen.findByText("Found 1 competitions.");
+    expect(screen.getByText("No upcoming deadlines")).toBeInTheDocument();
+  });
+
+  it("renders Free badge for $0 fee competitions and entry fee badge for paid", async () => {
+    const competitions = [
+      { id: "free_c", title: "Free Comp", description: "Free entry", format: "feature", genre: "drama", feeUsd: 0, deadline: "2030-12-01T00:00:00.000Z" },
+      { id: "paid_c", title: "Paid Comp", description: "Paid entry", format: "feature", genre: "drama", feeUsd: 50, deadline: "2030-12-01T00:00:00.000Z" },
+    ];
+    makeFetch({ competitions });
+    renderWithProviders(<CompetitionsPage />);
+
+    await screen.findByText("Found 2 competitions.");
+    // "Free" appears in the fee-tier filter button group too, so just assert it exists
+    expect(screen.getAllByText("Free").length).toBeGreaterThan(0);
+    expect(screen.getByText("$50 entry fee")).toBeInTheDocument();
+  });
+
+  it("renders location and language badges when present", async () => {
+    const competitions = [
+      {
+        id: "loc_lang",
+        title: "Located Comp",
+        description: "",
+        format: "feature",
+        genre: "drama",
+        feeUsd: 0,
+        deadline: "2030-12-01T00:00:00.000Z",
+        location: "US/Canada",
+        language: "en",
+      },
+    ];
+    makeFetch({ competitions });
+    renderWithProviders(<CompetitionsPage />);
+
+    await screen.findByText("Found 1 competitions.");
+    // Both location (dropdown option) and language (dropdown option) values repeat in filters,
+    // so use getAllByText and assert at least one rendered badge.
+    expect(screen.getAllByText("US/Canada").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("en").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("Save button text flips between Save and Saved based on savedCompetitionIds", async () => {
+    const competitions = [
+      { id: "comp_save", title: "Savable", description: "", format: "feature", genre: "drama", feeUsd: 0, deadline: "2030-12-01T00:00:00.000Z" },
+    ];
+    makeFetch({
+      competitions,
+      savedCompetitions: [{ competitionId: "comp_save", remindDaysBefore: [14, 7, 1] }],
+    });
+    renderWithProviders(<CompetitionsPage />);
+
+    await screen.findByText("Found 1 competitions.");
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Saved" })).toBeInTheDocument();
+    });
+  });
+
+  it("toggleSavedCompetition POSTs when not yet saved and toasts success", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    const competitions = [
+      { id: "comp_to_save", title: "ToSave", description: "", format: "feature", genre: "drama", feeUsd: 0, deadline: "2030-12-01T00:00:00.000Z" },
+    ];
+    let method: string | undefined;
+    makeFetch({
+      competitions,
+      overrides: (url, init) => {
+        if (url === "/api/v1/competitions/comp_to_save/save") {
+          method = (init?.method ?? "GET").toUpperCase();
+          return jsonResponse({ ok: true });
+        }
+        return null;
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<CompetitionsPage />);
+    await screen.findByText("Found 1 competitions.");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(method).toBe("POST");
+      expect(toastSuccess).toHaveBeenCalledWith("Saved ToSave.");
+    });
+  });
+
+  it("toggleSavedCompetition DELETEs when already saved", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    const competitions = [
+      { id: "comp_unsave", title: "ToUnsave", description: "", format: "feature", genre: "drama", feeUsd: 0, deadline: "2030-12-01T00:00:00.000Z" },
+    ];
+    let method: string | undefined;
+    makeFetch({
+      competitions,
+      savedCompetitions: [{ competitionId: "comp_unsave", remindDaysBefore: [14, 7, 1] }],
+      overrides: (url, init) => {
+        if (url === "/api/v1/competitions/comp_unsave/save") {
+          method = (init?.method ?? "GET").toUpperCase();
+          return jsonResponse({ ok: true });
+        }
+        return null;
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<CompetitionsPage />);
+    await screen.findByText("Found 1 competitions.");
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Saved" })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: "Saved" }));
+
+    await waitFor(() => {
+      expect(method).toBe("DELETE");
+      expect(toastSuccess).toHaveBeenCalledWith("Removed ToUnsave.");
+    });
+  });
+
+  it("toggleSavedCompetition surfaces server body.error when response is not ok", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    const competitions = [
+      { id: "comp_bad", title: "Bad", description: "", format: "feature", genre: "drama", feeUsd: 0, deadline: "2030-12-01T00:00:00.000Z" },
+    ];
+    makeFetch({
+      competitions,
+      overrides: (url) => {
+        if (url === "/api/v1/competitions/comp_bad/save") {
+          return new Response(JSON.stringify({ error: "Quota exceeded" }), {
+            status: 429,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return null;
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<CompetitionsPage />);
+    await screen.findByText("Found 1 competitions.");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Quota exceeded");
+    });
+  });
+
+  it("toggleSavedCompetition falls back to default error when body has no error field", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    const competitions = [
+      { id: "comp_b2", title: "Bad2", description: "", format: "feature", genre: "drama", feeUsd: 0, deadline: "2030-12-01T00:00:00.000Z" },
+    ];
+    makeFetch({
+      competitions,
+      overrides: (url) => {
+        if (url === "/api/v1/competitions/comp_b2/save") {
+          return new Response("not json", { status: 500, headers: { "content-type": "text/plain" } });
+        }
+        return null;
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<CompetitionsPage />);
+    await screen.findByText("Found 1 competitions.");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Save update failed.");
+    });
+  });
+
+  it("toggleSavedCompetition toasts caught Error.message on network failure", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    const competitions = [
+      { id: "comp_net", title: "Net", description: "", format: "feature", genre: "drama", feeUsd: 0, deadline: "2030-12-01T00:00:00.000Z" },
+    ];
+    makeFetch({
+      competitions,
+      overrides: (url) => {
+        if (url === "/api/v1/competitions/comp_net/save") {
+          throw new Error("network down");
+        }
+        return null;
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<CompetitionsPage />);
+    await screen.findByText("Found 1 competitions.");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("network down");
+    });
+  });
+
+  it("toggleSavedCompetition refuses when user is not signed in", async () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: false });
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    makeFetch({});
+    renderWithProviders(<CompetitionsPage />);
+    // No "Save" button visible when signed out. Branch is exercised only if user can call.
+    // Since the guard is unreachable from UI when signed out, no DOM assertion needed.
+    // Just ensure the page renders the signed-out badge:
+    expect(screen.getByText("Sign in for reminders")).toBeInTheDocument();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("sendReminder shows 'Target user ID is required.' when blanked out", async () => {
+    const competitions = [
+      { id: "comp_tu", title: "Target User Test", description: "", format: "feature", genre: "drama", feeUsd: 0, deadline: "2030-12-01T00:00:00.000Z" },
+    ];
+    makeFetch({ competitions });
+
+    const user = userEvent.setup();
+    renderWithProviders(<CompetitionsPage />);
+    await screen.findByText("Found 1 competitions.");
+
+    await user.click(screen.getByRole("button", { name: "Set reminder" }));
+    const dialog = await screen.findByRole("dialog", { name: "Set deadline reminder" });
+    const targetInput = within(dialog).getByLabelText("Target user ID") as HTMLInputElement;
+    await user.clear(targetInput);
+
+    const submitBtn = within(dialog).getByRole("button", { name: "Send reminder" });
+    const form = submitBtn.closest("form")!;
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+    await screen.findByText("Target user ID is required.");
+    // status starts with no "Error:" prefix so .status-note class applies (non-error)
+    const status = screen.getByText("Target user ID is required.");
+    expect(status.className).toContain("status-note");
+  });
+
+  it("sendReminder shows 'Error: ...' status from server when response is not ok", async () => {
+    const competitions = [
+      { id: "comp_err", title: "Err Comp", description: "", format: "feature", genre: "drama", feeUsd: 0, deadline: "2030-12-01T00:00:00.000Z" },
+    ];
+    makeFetch({
+      competitions,
+      overrides: (url) => {
+        if (url === "/api/v1/competitions/comp_err/deadline-reminders") {
+          return new Response(JSON.stringify({ error: "Reminders unavailable" }), {
+            status: 503,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return null;
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<CompetitionsPage />);
+    await screen.findByText("Found 1 competitions.");
+
+    await user.click(screen.getByRole("button", { name: "Set reminder" }));
+    const dialog = await screen.findByRole("dialog", { name: "Set deadline reminder" });
+    await user.click(within(dialog).getByRole("button", { name: "Send reminder" }));
+
+    const errStatus = await screen.findByText("Error: Reminders unavailable");
+    expect(errStatus.className).toContain("status-error");
+  });
+
+  it("sendReminder shows fallback error when response is not ok and body has no error", async () => {
+    const competitions = [
+      { id: "comp_e2", title: "Err Comp 2", description: "", format: "feature", genre: "drama", feeUsd: 0, deadline: "2030-12-01T00:00:00.000Z" },
+    ];
+    makeFetch({
+      competitions,
+      overrides: (url) => {
+        if (url === "/api/v1/competitions/comp_e2/deadline-reminders") {
+          return new Response(JSON.stringify({}), {
+            status: 500,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return null;
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<CompetitionsPage />);
+    await screen.findByText("Found 1 competitions.");
+
+    await user.click(screen.getByRole("button", { name: "Set reminder" }));
+    const dialog = await screen.findByRole("dialog", { name: "Set deadline reminder" });
+    await user.click(within(dialog).getByRole("button", { name: "Send reminder" }));
+
+    await screen.findByText("Reminder request failed.");
+  });
+
+  it("sendReminder catch path toasts thrown Error message", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    const competitions = [
+      { id: "comp_throw", title: "Throw Comp", description: "", format: "feature", genre: "drama", feeUsd: 0, deadline: "2030-12-01T00:00:00.000Z" },
+    ];
+    makeFetch({
+      competitions,
+      overrides: (url) => {
+        if (url === "/api/v1/competitions/comp_throw/deadline-reminders") {
+          throw new Error("net err");
+        }
+        return null;
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<CompetitionsPage />);
+    await screen.findByText("Found 1 competitions.");
+
+    await user.click(screen.getByRole("button", { name: "Set reminder" }));
+    const dialog = await screen.findByRole("dialog", { name: "Set deadline reminder" });
+    await user.click(within(dialog).getByRole("button", { name: "Send reminder" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("net err");
+    });
+  });
+
+  it("clicking fee tier buttons toggles their selected class", async () => {
+    makeFetch({ competitions: [] });
+    const user = userEvent.setup();
+    renderWithProviders(<CompetitionsPage />);
+    await screen.findByText("No matches found");
+
+    const freeBtn = screen.getByRole("button", { name: "Free" });
+    expect(freeBtn.className).toContain("btn-secondary");
+    await user.click(freeBtn);
+    expect(screen.getByRole("button", { name: "Free" }).className).toContain("btn-primary");
+  });
+
+  it("pingOnboarding does not fire when user is null", async () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: false });
+    const fetchMock = makeFetch();
+    renderWithProviders(<CompetitionsPage />);
+
+    // Give effects a tick
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+
+    expect(
+      fetchMock.mock.calls.find(([input, init]) => {
+        const url = typeof input === "string" ? input : String(input);
+        return url === "/api/v1/onboarding-progress" && (init?.method ?? "GET").toUpperCase() === "PATCH";
+      })
+    ).toBeUndefined();
+  });
+
+  it("pingOnboarding fires once when user is signed in", async () => {
+    const fetchMock = makeFetch();
+    renderWithProviders(<CompetitionsPage />);
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.find(([input, init]) => {
+          const url = typeof input === "string" ? input : String(input);
+          return url === "/api/v1/onboarding-progress" && (init?.method ?? "GET").toUpperCase() === "PATCH";
+        })
+      ).toBeDefined();
     });
   });
 });

--- a/apps/writer-web/app/competitions/page.test.tsx
+++ b/apps/writer-web/app/competitions/page.test.tsx
@@ -265,15 +265,16 @@ describe("CompetitionsPage — branch coverage", () => {
   });
 
   it("shows skeleton while loading", async () => {
-    let resolveFn: ((value: Response) => void) | null = null;
+    let resolveResponse!: (value: Response) => void;
+    const pendingResponse = new Promise<Response>((resolve) => {
+      resolveResponse = resolve;
+    });
     vi.stubGlobal(
       "fetch",
       vi.fn<typeof fetch>(async (input) => {
         const url = typeof input === "string" ? input : input.toString();
         if (url.startsWith("/api/v1/competitions?")) {
-          return new Promise<Response>((res) => {
-            resolveFn = res;
-          });
+          return pendingResponse;
         }
         return jsonResponse({});
       })
@@ -286,7 +287,7 @@ describe("CompetitionsPage — branch coverage", () => {
     expect(screen.getByRole("button", { name: "Searching..." })).toBeInTheDocument();
 
     // Cleanup: resolve so component doesn't dangle
-    resolveFn?.(jsonResponse({ competitions: [] }));
+    resolveResponse(jsonResponse({ competitions: [] }));
   });
 
   it("surfaces ApiError message via toast when search endpoint fails", async () => {

--- a/apps/writer-web/app/components/ResumeMetricsWidget.test.tsx
+++ b/apps/writer-web/app/components/ResumeMetricsWidget.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { SWRConfig } from "swr";
+import type { WriterProfile, ResumeMetricsResponse } from "@script-manifest/contracts";
+import { ResumeMetricsWidget } from "./ResumeMetricsWidget";
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0, shouldRetryOnError: false }}>
+      {children}
+    </SWRConfig>
+  );
+}
+
+function makeProfile(overrides: Partial<WriterProfile> = {}): WriterProfile {
+  return {
+    id: "writer_test",
+    displayName: "Test Writer",
+    bio: "",
+    genres: [],
+    demographics: [],
+    representationStatus: "unrepresented",
+    headshotUrl: "",
+    customProfileUrl: "",
+    isSearchable: true,
+    ...overrides,
+  };
+}
+
+function mockFetchResume(metrics: ResumeMetricsResponse | null) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+    if (metrics === null) {
+      return { ok: false, status: 404, json: async () => ({}) } as Response;
+    }
+    return { ok: true, json: async () => ({ metrics }) } as Response;
+  });
+}
+
+describe("ResumeMetricsWidget", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("renders zero fallbacks when SWR has no data yet", () => {
+    mockFetchResume(null);
+    render(<ResumeMetricsWidget profile={makeProfile()} />, { wrapper: Wrapper });
+
+    // All four metrics fall back to 0 via the `?? 0` branches before fetch resolves.
+    expect(screen.getByText("0 views · 7d")).toBeInTheDocument();
+    expect(screen.getByText("0 views · 30d")).toBeInTheDocument();
+    expect(screen.getByText("0 script downloads")).toBeInTheDocument();
+    expect(screen.getByText("0 verified placements")).toBeInTheDocument();
+  });
+
+  it("renders real metrics once SWR resolves", async () => {
+    mockFetchResume({
+      totalViews7d: 12,
+      totalViews30d: 47,
+      totalScriptDownloads: 3,
+      verifiedPlacementsCount: 1,
+    });
+
+    render(<ResumeMetricsWidget profile={makeProfile()} />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("12 views · 7d")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("47 views · 30d")).toBeInTheDocument();
+    expect(screen.getByText("3 script downloads")).toBeInTheDocument();
+    expect(screen.getByText("1 verified placements")).toBeInTheDocument();
+  });
+
+  it("falls back to profile.id when customProfileUrl is empty", () => {
+    mockFetchResume(null);
+    render(
+      <ResumeMetricsWidget profile={makeProfile({ id: "writer_42", customProfileUrl: "" })} />,
+      { wrapper: Wrapper },
+    );
+
+    const link = screen.getByRole("link", { name: /open resume/i }) as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("/writers/writer_42");
+  });
+
+  it("uses customProfileUrl as a relative handle when it is not a full URL", () => {
+    mockFetchResume(null);
+    render(
+      <ResumeMetricsWidget
+        profile={makeProfile({ id: "writer_42", customProfileUrl: "favorite-writer" })}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    const link = screen.getByRole("link", { name: /open resume/i }) as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("/writers/favorite-writer");
+  });
+
+  it("uses customProfileUrl verbatim when it is a full http URL", () => {
+    mockFetchResume(null);
+    render(
+      <ResumeMetricsWidget
+        profile={makeProfile({ customProfileUrl: "https://example.com/me" })}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    const link = screen.getByRole("link", { name: /open resume/i }) as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("https://example.com/me");
+  });
+
+  it("copies a relative share link with origin prepended on click", async () => {
+    mockFetchResume(null);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(
+      <ResumeMetricsWidget profile={makeProfile({ id: "writer_99", customProfileUrl: "" })} />,
+      { wrapper: Wrapper },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /copy share link/i }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledTimes(1);
+    });
+
+    expect(writeText.mock.calls[0]?.[0]).toBe(`${window.location.origin}/writers/writer_99`);
+  });
+
+  it("copies the absolute share link verbatim when customProfileUrl is a full URL", async () => {
+    mockFetchResume(null);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(
+      <ResumeMetricsWidget
+        profile={makeProfile({ customProfileUrl: "https://example.com/me" })}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /copy share link/i }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledTimes(1);
+    });
+
+    expect(writeText.mock.calls[0]?.[0]).toBe("https://example.com/me");
+  });
+});

--- a/apps/writer-web/app/components/ResumeMetricsWidget.test.tsx
+++ b/apps/writer-web/app/components/ResumeMetricsWidget.test.tsx
@@ -60,10 +60,12 @@ describe("ResumeMetricsWidget", () => {
 
   it("renders real metrics once SWR resolves", async () => {
     mockFetchResume({
+      writerId: "writer_test",
       totalViews7d: 12,
       totalViews30d: 47,
       totalScriptDownloads: 3,
       verifiedPlacementsCount: 1,
+      projectsCount: 5,
     });
 
     render(<ResumeMetricsWidget profile={makeProfile()} />, { wrapper: Wrapper });

--- a/apps/writer-web/app/feedback/page.test.tsx
+++ b/apps/writer-web/app/feedback/page.test.tsx
@@ -193,3 +193,918 @@ describe("FeedbackPage", () => {
     expect(screen.getByText("Sign in to see your listings")).toBeInTheDocument();
   });
 });
+
+const dayMs = 24 * 60 * 60 * 1000;
+
+function deadlineIn(days: number) {
+  return new Date(Date.now() + days * dayMs).toISOString();
+}
+
+function feedbackListing(overrides: Partial<typeof sampleListing> = {}) {
+  return {
+    ...sampleListing,
+    ...overrides,
+  };
+}
+
+const sampleReview = {
+  id: "review_1",
+  listingId: "listing_1",
+  reviewerUserId: baseUser.id,
+  status: "in_progress",
+  createdAt: "2026-02-06T00:00:00.000Z",
+  updatedAt: "2026-02-06T00:00:00.000Z",
+};
+
+function feedbackReview(overrides: Partial<typeof sampleReview> = {}) {
+  return {
+    ...sampleReview,
+    ...overrides,
+  };
+}
+
+const sampleProject = {
+  id: "project_1",
+  ownerUserId: baseUser.id,
+  title: "Project One",
+  genre: "drama",
+  format: "feature",
+  logline: null,
+  synopsis: null,
+  visibility: "private",
+  createdAt: "2026-02-06T00:00:00.000Z",
+  updatedAt: "2026-02-06T00:00:00.000Z",
+};
+
+const sampleDraft = {
+  id: "draft_1",
+  projectId: sampleProject.id,
+  scriptId: "script_draft_1",
+  versionLabel: "v2",
+  pageCount: 87,
+  storageKey: "scripts/script_draft_1.pdf",
+  createdAt: "2026-02-06T00:00:00.000Z",
+};
+
+type FeedbackFetchOptions = {
+  listings?: Array<ReturnType<typeof feedbackListing>>;
+  myListings?: Array<ReturnType<typeof feedbackListing>>;
+  myReviews?: Array<ReturnType<typeof feedbackReview>>;
+  balance?: number | null;
+  projects?: Array<typeof sampleProject>;
+  drafts?: Array<typeof sampleDraft>;
+  claimStatus?: number;
+  claimPayload?: unknown;
+  cancelStatus?: number;
+  cancelPayload?: unknown;
+  rateStatus?: number;
+  ratePayload?: unknown;
+  reviewSubmitStatus?: number;
+  reviewSubmitPayload?: unknown;
+  createStatus?: number;
+  createPayload?: unknown;
+  grantSignupStatus?: number;
+  grantSignupPayload?: unknown;
+};
+
+function mockFeedbackFetch(options: FeedbackFetchOptions = {}) {
+  const {
+    listings = [],
+    myListings = [],
+    myReviews = [],
+    balance = 2,
+    projects = [],
+    drafts = [],
+    claimStatus = 200,
+    claimPayload = {},
+    cancelStatus = 200,
+    cancelPayload = {},
+    rateStatus = 200,
+    ratePayload = {},
+    reviewSubmitStatus = 200,
+    reviewSubmitPayload = {},
+    createStatus = 200,
+    createPayload = { listing: feedbackListing({ id: "created_listing", ownerUserId: baseUser.id }) },
+    grantSignupStatus = 200,
+    grantSignupPayload = {},
+  } = options;
+
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method ?? "GET";
+
+    if (url.includes("/api/v1/feedback/listings/") && url.includes("/claim")) {
+      return jsonResponse(claimPayload, claimStatus);
+    }
+
+    if (url.includes("/api/v1/feedback/listings/") && url.includes("/cancel")) {
+      return jsonResponse(cancelPayload, cancelStatus);
+    }
+
+    if (url.includes("/api/v1/feedback/reviews/") && url.includes("/rate")) {
+      return jsonResponse(ratePayload, rateStatus);
+    }
+
+    if (url.includes("/api/v1/feedback/reviews/") && url.includes("/submit")) {
+      return jsonResponse(reviewSubmitPayload, reviewSubmitStatus);
+    }
+
+    if (url.includes("/api/v1/feedback/tokens/grant-signup")) {
+      return jsonResponse(grantSignupPayload, grantSignupStatus);
+    }
+
+    if (url.includes("/api/v1/feedback/tokens/balance")) {
+      return jsonResponse({ balance });
+    }
+
+    if (url.includes("/api/v1/projects/") && url.includes("/drafts")) {
+      return jsonResponse({ drafts });
+    }
+
+    if (url.includes("/api/v1/projects?")) {
+      return jsonResponse({ projects });
+    }
+
+    if (url.includes("/api/v1/feedback/reviews?")) {
+      return jsonResponse({ reviews: myReviews });
+    }
+
+    if (url.includes("/api/v1/feedback/listings?ownerUserId=")) {
+      return jsonResponse({ listings: myListings });
+    }
+
+    if (url.includes("/api/v1/feedback/listings?status=open")) {
+      return jsonResponse({ listings });
+    }
+
+    if (url.endsWith("/api/v1/feedback/listings") && method === "POST") {
+      return jsonResponse(createPayload, createStatus);
+    }
+
+    return jsonResponse({});
+  });
+}
+
+describe("FeedbackPage additional coverage", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    mockUseAuth.mockReturnValue({ user: baseUser, loading: false });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("shows loading skeletons before rendering the available empty state", async () => {
+    let resolveListings: (response: Response) => void = () => {};
+    const listingsPromise = new Promise<Response>((resolve) => {
+      resolveListings = resolve;
+    });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/v1/feedback/listings?status=open")) {
+        return listingsPromise;
+      }
+      if (url.includes("/api/v1/feedback/tokens/balance")) return jsonResponse({ balance: 1 });
+      if (url.includes("/api/v1/feedback/tokens/grant-signup")) return jsonResponse({});
+      if (url.includes("/api/v1/projects?")) return jsonResponse({ projects: [] });
+      if (url.includes("/api/v1/feedback/reviews?")) return jsonResponse({ reviews: [] });
+      if (url.includes("/api/v1/feedback/listings?ownerUserId=")) return jsonResponse({ listings: [] });
+      return jsonResponse({});
+    });
+
+    const { container } = renderWithProviders(<FeedbackPage />);
+
+    expect(container.querySelectorAll(".animate-pulse")).toHaveLength(3);
+
+    resolveListings(jsonResponse({ listings: [] }));
+
+    expect(await screen.findByText("No scripts awaiting feedback")).toBeInTheDocument();
+    expect(screen.getByText("1 token available")).toBeInTheDocument();
+  });
+
+  it("renders available listings across deadline states and hides claim for owned listings", async () => {
+    mockFeedbackFetch({
+      listings: [
+        feedbackListing({ id: "expired", title: "Expired Script", expiresAt: deadlineIn(-1), description: "Late notes", pageCount: 0 }),
+        feedbackListing({ id: "urgent", title: "Urgent Script", expiresAt: deadlineIn(2), description: "Need quick notes", pageCount: 12 }),
+        feedbackListing({ id: "approaching", title: "Approaching Script", expiresAt: deadlineIn(10), description: "Need medium notes", pageCount: 24 }),
+        feedbackListing({ id: "owned", ownerUserId: baseUser.id, title: "Owned Script", expiresAt: deadlineIn(30), description: "", pageCount: 0 }),
+      ],
+    });
+
+    renderWithProviders(<FeedbackPage />);
+
+    expect(await screen.findByText("Expired Script")).toBeInTheDocument();
+    expect(screen.getByText("Expired")).toBeInTheDocument();
+    expect(screen.getByText("2d left")).toBeInTheDocument();
+    expect(screen.getByText("10d left")).toBeInTheDocument();
+    expect(screen.getByText("30d left")).toBeInTheDocument();
+    expect(screen.getByText("12 pages")).toBeInTheDocument();
+    expect(screen.queryByText("0 pages")).not.toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Claim to review" })).toHaveLength(3);
+  });
+
+  it("claims an available listing and refreshes listings on success", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    const fetchSpy = mockFeedbackFetch({ listings: [feedbackListing()] });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await user.click(await screen.findByRole("button", { name: "Claim to review" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/api/v1/feedback/listings/listing_1/claim"),
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+    expect(toastSuccess).toHaveBeenCalledWith("Claimed! You have 7 days to submit your review.");
+  });
+
+  it("shows the claim ApiError message when claiming fails", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    mockFeedbackFetch({
+      listings: [feedbackListing()],
+      claimStatus: 409,
+      claimPayload: { message: "Listing already claimed" },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await user.click(await screen.findByRole("button", { name: "Claim to review" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Listing already claimed");
+    });
+  });
+
+  it("renders my listing lifecycle statuses and cancels open listings", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    const fetchSpy = mockFeedbackFetch({
+      myListings: [
+        feedbackListing({ id: "open_listing", ownerUserId: baseUser.id, title: "Open Listing", status: "open" }),
+        feedbackListing({ id: "claimed_listing", ownerUserId: baseUser.id, title: "Claimed Listing", status: "claimed" }),
+        feedbackListing({ id: "delivered_listing", ownerUserId: baseUser.id, title: "Delivered Listing", status: "delivered" }),
+        feedbackListing({ id: "disputed_listing", ownerUserId: baseUser.id, title: "Disputed Listing", status: "disputed" }),
+        feedbackListing({ id: "cancelled_listing", ownerUserId: baseUser.id, title: "Cancelled Listing", status: "cancelled" }),
+      ],
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await user.click(await screen.findByRole("button", { name: "My Listings" }));
+
+    expect(await screen.findByText("Open Listing")).toBeInTheDocument();
+    expect(screen.getByText("claimed")).toBeInTheDocument();
+    expect(screen.getByText("delivered")).toBeInTheDocument();
+    expect(screen.getByText("disputed")).toBeInTheDocument();
+    expect(screen.getByText("cancelled")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Cancel & refund" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/api/v1/feedback/listings/open_listing/cancel"),
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+    expect(toastSuccess).toHaveBeenCalledWith("Listing cancelled. Your token has been refunded.");
+  });
+
+  it("shows the signed-in my listings empty state", async () => {
+    mockFeedbackFetch({ myListings: [] });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await user.click(await screen.findByRole("button", { name: "My Listings" }));
+
+    expect(await screen.findByText("No listings yet")).toBeInTheDocument();
+    expect(screen.getByText("Create a listing above to request feedback on your script.")).toBeInTheDocument();
+  });
+
+  it("rates a completed listing when the matching review is present", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    const fetchSpy = mockFeedbackFetch({
+      myListings: [feedbackListing({ id: "completed_listing", ownerUserId: baseUser.id, title: "Completed Listing", status: "completed" })],
+      myReviews: [feedbackReview({ id: "review_completed", listingId: "completed_listing", status: "completed" })],
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await user.click(await screen.findByRole("button", { name: "My Listings" }));
+    await user.click(await screen.findByRole("button", { name: "Rate review" }));
+
+    expect(screen.getByRole("dialog", { name: "Rate this review" })).toBeInTheDocument();
+    await user.type(screen.getByLabelText("Score (1-5)"), "5");
+    await user.type(screen.getByLabelText("Comment (optional)"), "Thoughtful feedback.");
+    await user.click(screen.getByRole("button", { name: "Submit Rating" }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/api/v1/feedback/reviews/review_completed/rate"),
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+    expect(toastSuccess).toHaveBeenCalledWith("Rating submitted. Thank you for your feedback!");
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Rate this review" })).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows an error when a completed listing has no matching review to rate", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    mockFeedbackFetch({
+      myListings: [feedbackListing({ id: "completed_without_review", ownerUserId: baseUser.id, title: "Completed Without Review", status: "completed" })],
+      myReviews: [],
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await user.click(await screen.findByRole("button", { name: "My Listings" }));
+    await user.click(await screen.findByRole("button", { name: "Rate review" }));
+
+    expect(toastError).toHaveBeenCalledWith("Review not found for this listing.");
+  });
+});
+
+async function openCreateListingForm(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(await screen.findByRole("button", { name: "Request feedback on a script" }));
+}
+
+async function fillManualListingFields(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText("Title"), "Manual Script");
+  await user.type(screen.getByLabelText("Genre"), "drama");
+  await user.type(screen.getByLabelText("Format"), "feature");
+}
+
+async function chooseProjectDraft(user: ReturnType<typeof userEvent.setup>) {
+  await user.selectOptions(screen.getByLabelText("Project"), sampleProject.id);
+  await screen.findByRole("option", { name: "v2 (87 pp)" });
+  await user.selectOptions(screen.getByLabelText("Draft"), sampleDraft.id);
+}
+
+function modalSubmitReviewButton() {
+  const buttons = screen.getAllByRole("button", { name: "Submit Review" });
+  return buttons[buttons.length - 1]!;
+}
+
+describe("FeedbackPage form, token, and review coverage", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    mockUseAuth.mockReturnValue({ user: baseUser, loading: false });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("disables listing creation when the signed-in writer has no tokens", async () => {
+    mockFeedbackFetch({ balance: 0 });
+
+    renderWithProviders(<FeedbackPage />);
+
+    const disabledButton = await screen.findByRole("button", {
+      name: "Not enough tokens — review scripts to earn more",
+    });
+    expect(disabledButton).toBeDisabled();
+  });
+
+  it("validates the no-project create path before posting a listing", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    mockFeedbackFetch({ balance: 1, projects: [] });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await openCreateListingForm(user);
+
+    expect(screen.getByLabelText("Upload your manuscript")).toBeInTheDocument();
+    await fillManualListingFields(user);
+    await user.click(screen.getByRole("button", { name: "List for Feedback (1 token)" }));
+
+    expect(toastError).toHaveBeenCalledWith("Select a project and draft, or upload a manuscript file.");
+  });
+
+  it("shows draft picker empty and reset states when changing project selection", async () => {
+    mockFeedbackFetch({ balance: 1, projects: [sampleProject], drafts: [] });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await openCreateListingForm(user);
+
+    expect(screen.getByText("Or upload a new manuscript:")).toBeInTheDocument();
+    expect(screen.getByLabelText("Upload a new manuscript")).toBeInTheDocument();
+    expect(screen.getByText("Select a project first")).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText("Project"), sampleProject.id);
+
+    expect(await screen.findByText("No drafts — upload one on the Projects page")).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText("Project"), "");
+
+    expect(screen.getByText("Select a project first")).toBeInTheDocument();
+  });
+
+  it("creates a listing from an existing project draft and resets the form", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    const fetchSpy = mockFeedbackFetch({ balance: 1, projects: [sampleProject], drafts: [sampleDraft] });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await openCreateListingForm(user);
+    await chooseProjectDraft(user);
+    await user.type(screen.getByLabelText("Description"), "Please focus on pacing.");
+    await user.click(screen.getByRole("button", { name: "List for Feedback (1 token)" }));
+
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith("Listing created! Your script is now available for feedback.");
+    });
+    const createCall = fetchSpy.mock.calls.find(([input, init]) =>
+      String(input).endsWith("/api/v1/feedback/listings") && init?.method === "POST"
+    );
+    expect(createCall).toBeDefined();
+    expect(JSON.parse(String(createCall?.[1]?.body))).toMatchObject({
+      projectId: sampleProject.id,
+      scriptId: sampleDraft.scriptId,
+      title: sampleProject.title,
+      genre: sampleProject.genre,
+      format: sampleProject.format,
+      pageCount: sampleDraft.pageCount,
+    });
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Description")).not.toBeInTheDocument();
+    });
+  });
+
+  it("uses the insufficient-token create error message from ApiError bodies", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    mockFeedbackFetch({
+      balance: 1,
+      projects: [sampleProject],
+      drafts: [sampleDraft],
+      createStatus: 402,
+      createPayload: { message: "Payment required", error: "insufficient_tokens" },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await openCreateListingForm(user);
+    await chooseProjectDraft(user);
+    await user.click(screen.getByRole("button", { name: "List for Feedback (1 token)" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Not enough tokens. Review others' scripts to earn more.");
+    });
+  });
+
+  it("surfaces non-token create ApiError body errors", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    mockFeedbackFetch({
+      balance: 1,
+      projects: [sampleProject],
+      drafts: [sampleDraft],
+      createStatus: 400,
+      createPayload: { message: "Invalid listing", error: "bad_listing" },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await openCreateListingForm(user);
+    await chooseProjectDraft(user);
+    await user.click(screen.getByRole("button", { name: "List for Feedback (1 token)" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("bad_listing");
+    });
+  });
+
+  it("keeps the create form open when the create response has no listing", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    mockFeedbackFetch({
+      balance: 1,
+      projects: [sampleProject],
+      drafts: [sampleDraft],
+      createPayload: {},
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await openCreateListingForm(user);
+    await chooseProjectDraft(user);
+    await user.click(screen.getByRole("button", { name: "List for Feedback (1 token)" }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Description")).toBeInTheDocument();
+    });
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("shows plain Error messages thrown while creating listings", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/v1/feedback/tokens/balance")) return jsonResponse({ balance: 1 });
+      if (url.includes("/api/v1/feedback/tokens/grant-signup")) return jsonResponse({});
+      if (url.includes("/api/v1/projects/") && url.includes("/drafts")) return jsonResponse({ drafts: [sampleDraft] });
+      if (url.includes("/api/v1/projects?")) return jsonResponse({ projects: [sampleProject] });
+      if (url.includes("/api/v1/feedback/reviews?")) return jsonResponse({ reviews: [] });
+      if (url.includes("/api/v1/feedback/listings?ownerUserId=")) return jsonResponse({ listings: [] });
+      if (url.includes("/api/v1/feedback/listings?status=open")) return jsonResponse({ listings: [] });
+      if (url.endsWith("/api/v1/feedback/listings") && init?.method === "POST") {
+        throw new Error("Network offline");
+      }
+      return jsonResponse({});
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await openCreateListingForm(user);
+    await chooseProjectDraft(user);
+    await user.click(screen.getByRole("button", { name: "List for Feedback (1 token)" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Network offline");
+    });
+  });
+
+  it("uploads a new manuscript, creates project and draft records, then lists it", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/v1/scripts/upload")) return jsonResponse({ uploaded: true, objectKey: "objects/fresh-draft.pdf" });
+      if (url.includes("/api/v1/scripts/register")) return jsonResponse({ script: { scriptId: "registered_script" } });
+      if (url.endsWith("/api/v1/projects") && init?.method === "POST") {
+        return jsonResponse({ project: { ...sampleProject, id: "created_project", title: "Fresh Draft" } });
+      }
+      if (url.includes("/api/v1/projects/created_project/drafts")) return jsonResponse({ draft: { ...sampleDraft, projectId: "created_project" } });
+      if (url.endsWith("/api/v1/feedback/listings") && init?.method === "POST") {
+        return jsonResponse({ listing: feedbackListing({ id: "uploaded_listing", ownerUserId: baseUser.id }) });
+      }
+      if (url.includes("/api/v1/feedback/tokens/balance")) return jsonResponse({ balance: 1 });
+      if (url.includes("/api/v1/feedback/tokens/grant-signup")) return jsonResponse({});
+      if (url.includes("/api/v1/projects?")) return jsonResponse({ projects: [] });
+      if (url.includes("/api/v1/feedback/reviews?")) return jsonResponse({ reviews: [] });
+      if (url.includes("/api/v1/feedback/listings?ownerUserId=")) return jsonResponse({ listings: [] });
+      if (url.includes("/api/v1/feedback/listings?status=open")) return jsonResponse({ listings: [] });
+      return jsonResponse({});
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await openCreateListingForm(user);
+    await fillManualListingFields(user);
+    await user.type(screen.getByLabelText("Page count"), "101");
+    await user.upload(screen.getByLabelText("Upload your manuscript"), new File(["fade in"], "fresh-draft.pdf", { type: "" }));
+    expect(screen.getByText(/fresh-draft\.pdf/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "List for Feedback (1 token)" }));
+
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith("Listing created! Your script is now available for feedback.");
+    });
+    const uploadCall = fetchSpy.mock.calls.find(([input]) => String(input).includes("/api/v1/scripts/upload"));
+    expect((uploadCall?.[1]?.body as FormData).get("contentType")).toBe("application/octet-stream");
+    const listingCall = fetchSpy.mock.calls.find(([input, init]) =>
+      String(input).endsWith("/api/v1/feedback/listings") && init?.method === "POST"
+    );
+    expect(JSON.parse(String(listingCall?.[1]?.body))).toMatchObject({
+      projectId: "created_project",
+      scriptId: "registered_script",
+      pageCount: 101,
+    });
+  });
+
+  it("shows upload progress and upload failure details", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    let resolveUpload: (response: Response) => void = () => {};
+    const uploadPromise = new Promise<Response>((resolve) => {
+      resolveUpload = resolve;
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/v1/scripts/upload")) return uploadPromise;
+      if (url.includes("/api/v1/feedback/tokens/balance")) return jsonResponse({ balance: 1 });
+      if (url.includes("/api/v1/feedback/tokens/grant-signup")) return jsonResponse({});
+      if (url.includes("/api/v1/projects?")) return jsonResponse({ projects: [] });
+      if (url.includes("/api/v1/feedback/reviews?")) return jsonResponse({ reviews: [] });
+      if (url.includes("/api/v1/feedback/listings?ownerUserId=")) return jsonResponse({ listings: [] });
+      if (url.includes("/api/v1/feedback/listings?status=open")) return jsonResponse({ listings: [] });
+      return jsonResponse({});
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await openCreateListingForm(user);
+    await fillManualListingFields(user);
+    await user.upload(screen.getByLabelText("Upload your manuscript"), new File(["bad"], "bad.pdf", { type: "application/pdf" }));
+    await user.click(screen.getByRole("button", { name: "List for Feedback (1 token)" }));
+
+    expect(await screen.findByText("Preparing upload...")).toBeInTheDocument();
+
+    resolveUpload(jsonResponse({ detail: "Proxy refused the upload" }, 400));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Proxy refused the upload");
+    });
+  });
+
+  it("surfaces register and project creation errors during inline upload", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/v1/scripts/upload")) return jsonResponse({ uploaded: true, objectKey: "objects/file.pdf" });
+      if (url.includes("/api/v1/scripts/register")) return jsonResponse({ error: "Registration rejected" }, 400);
+      if (url.includes("/api/v1/feedback/tokens/balance")) return jsonResponse({ balance: 1 });
+      if (url.includes("/api/v1/feedback/tokens/grant-signup")) return jsonResponse({});
+      if (url.includes("/api/v1/projects?")) return jsonResponse({ projects: [] });
+      if (url.includes("/api/v1/feedback/reviews?")) return jsonResponse({ reviews: [] });
+      if (url.includes("/api/v1/feedback/listings?ownerUserId=")) return jsonResponse({ listings: [] });
+      if (url.includes("/api/v1/feedback/listings?status=open")) return jsonResponse({ listings: [] });
+      return jsonResponse({});
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await openCreateListingForm(user);
+    await fillManualListingFields(user);
+    await user.upload(screen.getByLabelText("Upload your manuscript"), new File(["bad"], "bad.pdf", { type: "application/pdf" }));
+    await user.click(screen.getByRole("button", { name: "List for Feedback (1 token)" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Registration rejected");
+    });
+  });
+
+  it("updates token balance after the signup grant mutation succeeds", async () => {
+    let balanceCalls = 0;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/v1/feedback/tokens/balance")) {
+        balanceCalls += 1;
+        return jsonResponse({ balance: balanceCalls === 1 ? 1 : 4 });
+      }
+      if (url.includes("/api/v1/feedback/tokens/grant-signup")) return jsonResponse({ granted: true });
+      if (url.includes("/api/v1/projects?")) return jsonResponse({ projects: [] });
+      if (url.includes("/api/v1/feedback/reviews?")) return jsonResponse({ reviews: [] });
+      if (url.includes("/api/v1/feedback/listings?ownerUserId=")) return jsonResponse({ listings: [] });
+      if (url.includes("/api/v1/feedback/listings?status=open")) return jsonResponse({ listings: [] });
+      return jsonResponse({});
+    });
+
+    renderWithProviders(<FeedbackPage />);
+
+    expect(await screen.findByText("4 tokens available")).toBeInTheDocument();
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/feedback/tokens/grant-signup"),
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("keeps rendering when the signup token grant fails", async () => {
+    const fetchSpy = mockFeedbackFetch({ balance: 1, grantSignupStatus: 500, grantSignupPayload: { message: "Grant failed" } });
+
+    renderWithProviders(<FeedbackPage />);
+
+    expect(await screen.findByText("Give feedback, get feedback")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Request feedback on a script" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/api/v1/feedback/tokens/grant-signup"),
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+  });
+
+  it("shows the my reviews sign-in guard and signed-in empty state", async () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: false });
+    mockFeedbackFetch({ listings: [] });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await user.click(await screen.findByRole("button", { name: "My Reviews" }));
+    expect(screen.getByText("Sign in to see your reviews")).toBeInTheDocument();
+
+    cleanup();
+    vi.restoreAllMocks();
+    mockUseAuth.mockReturnValue({ user: baseUser, loading: false });
+    mockFeedbackFetch({ myReviews: [] });
+    renderWithProviders(<FeedbackPage />);
+
+    await user.click(await screen.findByRole("button", { name: "My Reviews" }));
+    expect(await screen.findByText("No reviews yet")).toBeInTheDocument();
+  });
+
+  it("submits an in-progress review from the my reviews tab", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    const fetchSpy = mockFeedbackFetch({
+      listings: [feedbackListing({ id: "listing_1", title: "Reviewable Script", reviewDeadline: deadlineIn(2) })],
+      myReviews: [feedbackReview({ id: "review_in_progress", listingId: "listing_1", status: "in_progress" })],
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await user.click(await screen.findByRole("button", { name: "My Reviews" }));
+    expect(await screen.findByText("Reviewable Script")).toBeInTheDocument();
+    expect(screen.getByText("In Progress")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Read script" })).toHaveAttribute("href", "/projects/script_1/viewer");
+
+    await user.click(screen.getByRole("button", { name: "Submit Review" }));
+    const scores = screen.getAllByLabelText("Score (1-5)");
+    const comments = screen.getAllByLabelText("Comment");
+    for (const score of scores) {
+      await user.type(score, "4");
+    }
+    for (const comment of comments) {
+      await user.type(comment, "Strong execution.");
+    }
+    await user.type(screen.getByLabelText("Overall comment"), "Polish the ending.");
+    await user.click(modalSubmitReviewButton());
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/api/v1/feedback/reviews/review_in_progress/submit"),
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+    expect(toastSuccess).toHaveBeenCalledWith("Review submitted! Your token has been released.");
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Submit Review" })).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders submitted reviews by listing id when listing details are unavailable", async () => {
+    mockFeedbackFetch({
+      listings: [],
+      myListings: [],
+      myReviews: [feedbackReview({ id: "review_missing", listingId: "missing_listing", status: "submitted" })],
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await user.click(await screen.findByRole("button", { name: "My Reviews" }));
+
+    expect(await screen.findByText("missing_listing")).toBeInTheDocument();
+    expect(screen.getByText("submitted")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Read script" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Submit Review" })).not.toBeInTheDocument();
+  });
+
+  it("shows submit review ApiError messages", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    mockFeedbackFetch({
+      listings: [feedbackListing({ id: "listing_1", title: "Reviewable Script" })],
+      myReviews: [feedbackReview({ id: "review_error", listingId: "listing_1", status: "in_progress" })],
+      reviewSubmitStatus: 400,
+      reviewSubmitPayload: { message: "Scores are incomplete" },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await user.click(await screen.findByRole("button", { name: "My Reviews" }));
+    await user.click(await screen.findByRole("button", { name: "Submit Review" }));
+    for (const score of screen.getAllByLabelText("Score (1-5)")) {
+      await user.type(score, "3");
+    }
+    for (const comment of screen.getAllByLabelText("Comment")) {
+      await user.type(comment, "Needs work.");
+    }
+    await user.click(modalSubmitReviewButton());
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Scores are incomplete");
+    });
+  });
+
+  it("shows rating ApiError messages", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    mockFeedbackFetch({
+      myListings: [feedbackListing({ id: "completed_error", ownerUserId: baseUser.id, title: "Completed Error", status: "completed" })],
+      myReviews: [feedbackReview({ id: "review_rate_error", listingId: "completed_error", status: "completed" })],
+      rateStatus: 400,
+      ratePayload: { message: "Rating window closed" },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<FeedbackPage />);
+
+    await user.click(await screen.findByRole("button", { name: "My Listings" }));
+    await user.click(await screen.findByRole("button", { name: "Rate review" }));
+    await user.type(screen.getByLabelText("Score (1-5)"), "2");
+    await user.click(screen.getByRole("button", { name: "Submit Rating" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Rating window closed");
+    });
+  });
+});

--- a/apps/writer-web/app/feedback/page.test.tsx
+++ b/apps/writer-web/app/feedback/page.test.tsx
@@ -995,7 +995,7 @@ describe("FeedbackPage form, token, and review coverage", () => {
       info: vi.fn(),
     } as ReturnType<typeof toastModule.useToast>);
     const fetchSpy = mockFeedbackFetch({
-      listings: [feedbackListing({ id: "listing_1", title: "Reviewable Script", reviewDeadline: deadlineIn(2) })],
+      listings: [feedbackListing({ id: "listing_1", title: "Reviewable Script", reviewDeadline: deadlineIn(2) as unknown as null })],
       myReviews: [feedbackReview({ id: "review_in_progress", listingId: "listing_1", status: "in_progress" })],
     });
 

--- a/apps/writer-web/app/projects/page.test.tsx
+++ b/apps/writer-web/app/projects/page.test.tsx
@@ -203,3 +203,701 @@ describe("ProjectsPage", () => {
     );
   });
 });
+
+const timestamp = "2026-02-06T00:00:00.000Z";
+
+function projectFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "project_alpha",
+    ownerUserId: "writer_01",
+    title: "Project Alpha",
+    logline: "A great script",
+    synopsis: "",
+    format: "feature",
+    genre: "drama",
+    pageCount: 100,
+    isDiscoverable: false,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    ...overrides,
+  };
+}
+
+function draftFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "draft_alpha",
+    projectId: "project_alpha",
+    scriptId: "script_alpha",
+    versionLabel: "v1",
+    changeSummary: "First pass",
+    pageCount: 101,
+    lifecycleState: "active",
+    isPrimary: true,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    ...overrides,
+  };
+}
+
+function accessRequestFixture(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "request_alpha",
+    scriptId: "script_alpha",
+    requesterUserId: "reader_01",
+    status: "pending",
+    reason: "Please review this draft.",
+    decisionReason: null,
+    requestedAt: timestamp,
+    decidedAt: null,
+    ...overrides,
+  };
+}
+
+function mockProjectsFetch({
+  projects = [],
+  coWriters = [],
+  drafts = [],
+  accessRequests = [],
+  recommendations = [],
+}: {
+  projects?: Array<Record<string, unknown>>;
+  coWriters?: Array<Record<string, unknown>>;
+  drafts?: Array<Record<string, unknown>>;
+  accessRequests?: Array<Record<string, unknown>>;
+  recommendations?: Array<Record<string, unknown>>;
+} = {}) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+
+    if (url.includes("/api/v1/projects?") && url.includes("ownerUserId")) {
+      return jsonResponse({ projects });
+    }
+    if (url.includes("/recommended-competitions")) {
+      return jsonResponse({ recommendations });
+    }
+    if (url.includes("/co-writers")) {
+      return jsonResponse({ coWriters });
+    }
+    if (url.includes("/drafts")) {
+      return jsonResponse({ drafts });
+    }
+    if (url.includes("/access-requests")) {
+      return jsonResponse({ accessRequests });
+    }
+
+    return jsonResponse({});
+  });
+}
+
+describe("ProjectsPage branch coverage", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    mockUseAuth.mockReturnValue({ user: baseUser, loading: false });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the signed-in empty state and closes an opened create-project modal", async () => {
+    mockProjectsFetch();
+    const user = userEvent.setup();
+
+    renderWithProviders(<ProjectsPage />);
+
+    expect(await screen.findByText("No projects yet")).toBeInTheDocument();
+    expect(screen.getByText("Select a project")).toBeInTheDocument();
+    expect(screen.getByText("0 total")).toBeInTheDocument();
+    expect(screen.getByText("ID: writer_01")).toBeInTheDocument();
+
+    await user.click(screen.getAllByRole("button", { name: "Create project" })[0] as HTMLElement);
+    expect(await screen.findByRole("dialog", { name: "Create project" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Close" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Create project" })).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders selected project details, draft states, and access request branches", async () => {
+    const projects = [
+      projectFixture({ id: "project_alpha", title: "Project Alpha", logline: "A great script", isDiscoverable: true }),
+      projectFixture({ id: "project_beta", title: "Project Beta", logline: "", format: "pilot", genre: "comedy", pageCount: 42 }),
+    ];
+    const drafts = [
+      draftFixture({ id: "draft_primary", scriptId: "script_primary", versionLabel: "v2", isPrimary: true }),
+      draftFixture({
+        id: "draft_archived",
+        scriptId: "script_archived",
+        versionLabel: "v1",
+        changeSummary: "",
+        lifecycleState: "archived",
+        isPrimary: false,
+        pageCount: 98,
+      }),
+    ];
+    const accessRequests = [
+      accessRequestFixture({ id: "request_pending", scriptId: "script_primary", status: "pending" }),
+      accessRequestFixture({
+        id: "request_approved",
+        scriptId: "script_primary",
+        requesterUserId: "reader_02",
+        status: "approved",
+        reason: "",
+        decidedAt: timestamp,
+        decisionReason: "",
+      }),
+    ];
+
+    mockProjectsFetch({
+      projects,
+      coWriters: [{ projectId: "project_alpha", coWriterUserId: "writer_02", creditOrder: 3 }],
+      drafts,
+      accessRequests,
+    });
+
+    renderWithProviders(<ProjectsPage />);
+
+    expect((await screen.findAllByText("Project Alpha")).length).toBeGreaterThan(0);
+    expect(screen.getByText("2 total")).toBeInTheDocument();
+    expect(screen.getByText("No logline provided.")).toBeInTheDocument();
+    expect(screen.getByText("drama | 100 pages | Discoverable")).toBeInTheDocument();
+    expect(screen.getByText("comedy | 42 pages | Private")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Selected" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Select" })).toBeInTheDocument();
+
+    expect(await screen.findByText("writer_02")).toBeInTheDocument();
+    expect(screen.getByText("Credit order: 3")).toBeInTheDocument();
+    expect(screen.queryByText("No co-writers added yet.")).not.toBeInTheDocument();
+
+    expect(screen.getByText("v2 (script_primary)")).toBeInTheDocument();
+    expect(screen.getByText("active | primary")).toBeInTheDocument();
+    expect(screen.getByText("v1 (script_archived)")).toBeInTheDocument();
+    expect(screen.getByText("archived")).toBeInTheDocument();
+    expect(screen.getByText("First pass")).toBeInTheDocument();
+    expect(screen.queryByText("No drafts added yet.")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Tracking access" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Track access" })).toBeInTheDocument();
+
+    expect(await screen.findByText("reader_01")).toBeInTheDocument();
+    expect(screen.getByText("Please review this draft.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Approve" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reject" })).toBeInTheDocument();
+    expect(screen.getByText("reader_02")).toBeInTheDocument();
+    expect(screen.getByText(/Decision: No reason provided/)).toBeInTheDocument();
+  });
+
+  it("blocks project creation when the authenticated owner id is blank", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    mockUseAuth.mockReturnValue({ user: { ...baseUser, id: "   " }, loading: false });
+    const fetchMock = mockProjectsFetch();
+    const user = userEvent.setup();
+
+    renderWithProviders(<ProjectsPage />);
+
+    await user.click((await screen.findAllByRole("button", { name: "Create project" }))[0] as HTMLElement);
+    await user.type(await screen.findByRole("textbox", { name: "Title" }), "Blank Owner Project");
+    const submit = screen.getAllByRole("button", { name: "Create project" }).find((button) =>
+      (button as HTMLButtonElement).type === "submit"
+    ) as HTMLElement;
+    await user.click(submit);
+
+    expect(toastError).toHaveBeenCalledWith("Owner ID is required.");
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/api/v1/projects",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("deletes the selected project and clears project context", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url.includes("/api/v1/projects?") && method === "GET") {
+        return jsonResponse({ projects: [projectFixture()] });
+      }
+      if (url.includes("/recommended-competitions")) return jsonResponse({ recommendations: [] });
+      if (url.includes("/co-writers")) return jsonResponse({ coWriters: [] });
+      if (url.includes("/drafts")) return jsonResponse({ drafts: [] });
+      if (url === "/api/v1/projects/project_alpha" && method === "DELETE") {
+        return jsonResponse({ deleted: true });
+      }
+      return jsonResponse({});
+    });
+    const user = userEvent.setup();
+
+    renderWithProviders(<ProjectsPage />);
+    expect((await screen.findAllByText("Project Alpha")).length).toBeGreaterThan(0);
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith("Project deleted.");
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/projects/project_alpha",
+      expect.objectContaining({ method: "DELETE" })
+    );
+    expect(screen.getByText("0 total")).toBeInTheDocument();
+    expect(screen.getByText("Select a project")).toBeInTheDocument();
+  });
+
+  it("surfaces a project delete API error without removing the project", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url.includes("/api/v1/projects?") && method === "GET") {
+        return jsonResponse({ projects: [projectFixture()] });
+      }
+      if (url.includes("/recommended-competitions")) return jsonResponse({ recommendations: [] });
+      if (url.includes("/co-writers")) return jsonResponse({ coWriters: [] });
+      if (url.includes("/drafts")) return jsonResponse({ drafts: [] });
+      if (url === "/api/v1/projects/project_alpha" && method === "DELETE") {
+        return jsonResponse({ error: "Project is locked" }, 409);
+      }
+      return jsonResponse({});
+    });
+    const user = userEvent.setup();
+
+    renderWithProviders(<ProjectsPage />);
+    expect((await screen.findAllByText("Project Alpha")).length).toBeGreaterThan(0);
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Project is locked");
+    });
+    expect(screen.getByText("1 total")).toBeInTheDocument();
+  });
+
+  it("adds and removes co-writers with the selected project id", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url.includes("/api/v1/projects?") && method === "GET") return jsonResponse({ projects: [projectFixture()] });
+      if (url.includes("/recommended-competitions")) return jsonResponse({ recommendations: [] });
+      if (url.endsWith("/co-writers") && method === "GET") {
+        return jsonResponse({ coWriters: [{ projectId: "project_alpha", coWriterUserId: "writer_02", creditOrder: 2 }] });
+      }
+      if (url.endsWith("/co-writers") && method === "POST") return jsonResponse({ coWriter: {} }, 201);
+      if (url.includes("/co-writers/writer_02") && method === "DELETE") return jsonResponse({ removed: true });
+      if (url.includes("/drafts")) return jsonResponse({ drafts: [] });
+      return jsonResponse({});
+    });
+    const user = userEvent.setup();
+
+    renderWithProviders(<ProjectsPage />);
+    expect(await screen.findByText("writer_02")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Add co-writer" }));
+    await user.type(await screen.findByRole("textbox", { name: "Co-writer user ID" }), "writer_03");
+    const creditOrderInput = screen.getByRole("spinbutton", { name: "Credit order" });
+    await user.clear(creditOrderInput);
+    await user.type(creditOrderInput, "4");
+    await user.click(screen.getAllByRole("button", { name: "Add co-writer" }).find((button) =>
+      (button as HTMLButtonElement).type === "submit"
+    ) as HTMLElement);
+
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith("Co-writer added.");
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/projects/project_alpha/co-writers",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ coWriterUserId: "writer_03", creditOrder: 4 }),
+      })
+    );
+
+    await user.click(screen.getByRole("button", { name: "Remove co-writer" }));
+
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith("Co-writer removed.");
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/projects/project_alpha/co-writers/writer_02",
+      expect.objectContaining({ method: "DELETE" })
+    );
+  });
+
+  it("uploads a script file, registers it, and creates a draft", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url.includes("/api/v1/projects?") && method === "GET") return jsonResponse({ projects: [projectFixture()] });
+      if (url.includes("/recommended-competitions")) return jsonResponse({ recommendations: [] });
+      if (url.includes("/co-writers")) return jsonResponse({ coWriters: [] });
+      if (url.endsWith("/drafts") && method === "GET") return jsonResponse({ drafts: [] });
+      if (url === "/api/v1/scripts/upload" && method === "POST") {
+        return jsonResponse({ uploaded: true, objectKey: "scripts/uploaded-draft" });
+      }
+      if (url === "/api/v1/scripts/register" && method === "POST") {
+        return jsonResponse({ script: { scriptId: "script_registered" } }, 201);
+      }
+      if (url.endsWith("/drafts") && method === "POST") return jsonResponse({ draft: draftFixture() }, 201);
+      return jsonResponse({});
+    });
+    const user = userEvent.setup();
+
+    renderWithProviders(<ProjectsPage />);
+    expect((await screen.findAllByText("Project Alpha")).length).toBeGreaterThan(0);
+
+    await user.click(screen.getByRole("button", { name: "Create draft" }));
+    await user.upload(
+      screen.getByLabelText("Script file"),
+      new File(["FADE IN"], "draft.txt", { type: "" })
+    );
+    await user.click(screen.getByRole("button", { name: "Upload + register script" }));
+
+    expect(await screen.findByText("Uploaded: script_registered")).toBeInTheDocument();
+    expect(toastSuccess).toHaveBeenCalledWith("Script uploaded and registered.");
+    const registerCall = fetchMock.mock.calls.find(([input]) => input === "/api/v1/scripts/register");
+    expect(JSON.parse(String(registerCall?.[1]?.body))).toEqual(expect.objectContaining({
+      scriptId: expect.stringMatching(/^script_/),
+      ownerUserId: "writer_01",
+      objectKey: "scripts/uploaded-draft",
+      filename: "draft.txt",
+      contentType: "application/octet-stream",
+      size: 7,
+    }));
+
+    await user.type(screen.getByRole("textbox", { name: "Version label" }), "v3");
+    await user.type(screen.getByRole("textbox", { name: "Change summary" }), "Polish pass");
+    const draftPageCount = screen.getByRole("spinbutton", { name: "Page count" });
+    await user.clear(draftPageCount);
+    await user.type(draftPageCount, "110");
+    await user.click(screen.getByRole("checkbox", { name: "Set as primary draft" }));
+    await user.click(screen.getAllByRole("button", { name: "Create draft" }).find((button) =>
+      (button as HTMLButtonElement).type === "submit"
+    ) as HTMLElement);
+
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith("Draft created.");
+    });
+    const draftCall = fetchMock.mock.calls.find(([input, init]) =>
+      String(input).endsWith("/drafts") && (init?.method ?? "GET") === "POST"
+    );
+    expect(JSON.parse(String(draftCall?.[1]?.body))).toEqual(expect.objectContaining({
+      scriptId: "script_registered",
+      versionLabel: "v3",
+      changeSummary: "Polish pass",
+      pageCount: 110,
+      setPrimary: false,
+    }));
+  });
+
+  it("surfaces file upload text fallback errors", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url.includes("/api/v1/projects?") && method === "GET") return jsonResponse({ projects: [projectFixture()] });
+      if (url.includes("/recommended-competitions")) return jsonResponse({ recommendations: [] });
+      if (url.includes("/co-writers")) return jsonResponse({ coWriters: [] });
+      if (url.includes("/drafts")) return jsonResponse({ drafts: [] });
+      if (url === "/api/v1/scripts/upload" && method === "POST") {
+        return {
+          ok: false,
+          json: async () => {
+            throw new Error("not json");
+          },
+          text: async () => "Upload proxy unavailable",
+        } as unknown as Response;
+      }
+      return jsonResponse({});
+    });
+    const user = userEvent.setup();
+
+    renderWithProviders(<ProjectsPage />);
+    expect((await screen.findAllByText("Project Alpha")).length).toBeGreaterThan(0);
+
+    await user.click(screen.getByRole("button", { name: "Create draft" }));
+    await user.upload(
+      screen.getByLabelText("Script file"),
+      new File(["FADE IN"], "draft.pdf", { type: "application/pdf" })
+    );
+    await user.click(screen.getByRole("button", { name: "Upload + register script" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Upload proxy unavailable");
+    });
+  });
+
+  it("sets primary drafts, archives drafts, and decides access requests", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    const drafts = [
+      draftFixture({ id: "draft_primary", scriptId: "script_primary", isPrimary: true, versionLabel: "v1" }),
+      draftFixture({ id: "draft_secondary", scriptId: "script_secondary", isPrimary: false, versionLabel: "v2" }),
+    ];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url.includes("/api/v1/projects?") && method === "GET") return jsonResponse({ projects: [projectFixture()] });
+      if (url.includes("/recommended-competitions")) return jsonResponse({ recommendations: [] });
+      if (url.includes("/co-writers")) return jsonResponse({ coWriters: [] });
+      if (url.endsWith("/drafts") && method === "GET") return jsonResponse({ drafts });
+      if (url.endsWith("/draft_secondary/primary") && method === "POST") return jsonResponse({ updated: true });
+      if (url.endsWith("/draft_secondary") && method === "PATCH") return jsonResponse({ archived: true });
+      if (url.includes("/access-requests?") && method === "GET") {
+        return jsonResponse({ accessRequests: [accessRequestFixture({ id: "request_pending" })] });
+      }
+      if (url.endsWith("/request_pending/approve") && method === "POST") return jsonResponse({ approved: true });
+      if (url.endsWith("/request_pending/reject") && method === "POST") return jsonResponse({ rejected: true });
+      return jsonResponse({});
+    });
+    const user = userEvent.setup();
+
+    renderWithProviders(<ProjectsPage />);
+    expect(await screen.findByText("v2 (script_secondary)")).toBeInTheDocument();
+
+    await user.click(screen.getAllByRole("button", { name: "Set primary" })[1] as HTMLElement);
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith("Primary draft updated.");
+    });
+
+    await user.click(screen.getAllByRole("button", { name: "Archive" })[1] as HTMLElement);
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith("Draft archived.");
+    });
+
+    await user.type(await screen.findByPlaceholderText("Decision reason (optional)"), "Approved for coverage");
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith("Access request approved.");
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/scripts/script_primary/access-requests/request_pending/approve",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ decisionReason: "Approved for coverage" }),
+      })
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reject" }));
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith("Access request rejectd.");
+    });
+  });
+
+  it("creates an access request and omits a blank reason", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url.includes("/api/v1/projects?") && method === "GET") return jsonResponse({ projects: [projectFixture()] });
+      if (url.includes("/recommended-competitions")) return jsonResponse({ recommendations: [] });
+      if (url.includes("/co-writers")) return jsonResponse({ coWriters: [] });
+      if (url.endsWith("/drafts") && method === "GET") return jsonResponse({ drafts: [draftFixture()] });
+      if (url.includes("/access-requests?") && method === "GET") return jsonResponse({ accessRequests: [] });
+      if (url.endsWith("/access-requests") && method === "POST") return jsonResponse({ accessRequest: {} }, 201);
+      return jsonResponse({});
+    });
+    const user = userEvent.setup();
+
+    renderWithProviders(<ProjectsPage />);
+    await screen.findByText("No access requests");
+
+    await user.click(screen.getByRole("button", { name: "New access request" }));
+    await user.type(await screen.findByRole("textbox", { name: "Requester user ID" }), "reader_99");
+    await user.click(screen.getByRole("button", { name: "Record request" }));
+
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith("Access request recorded.");
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/scripts/script_alpha/access-requests",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ requesterUserId: "reader_99" }),
+      })
+    );
+  });
+
+  it("creates an access request with a trimmed reason", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url.includes("/api/v1/projects?") && method === "GET") return jsonResponse({ projects: [projectFixture()] });
+      if (url.includes("/recommended-competitions")) return jsonResponse({ recommendations: [] });
+      if (url.includes("/co-writers")) return jsonResponse({ coWriters: [] });
+      if (url.endsWith("/drafts") && method === "GET") return jsonResponse({ drafts: [draftFixture()] });
+      if (url.includes("/access-requests?") && method === "GET") return jsonResponse({ accessRequests: [] });
+      if (url.endsWith("/access-requests") && method === "POST") return jsonResponse({ accessRequest: {} }, 201);
+      return jsonResponse({});
+    });
+    const user = userEvent.setup();
+
+    renderWithProviders(<ProjectsPage />);
+    await screen.findByText("No access requests");
+
+    await user.click(screen.getByRole("button", { name: "New access request" }));
+    await user.type(await screen.findByRole("textbox", { name: "Requester user ID" }), "reader_77");
+    await user.type(screen.getByRole("textbox", { name: "Reason (optional)" }), "  Coverage review  ");
+    await user.click(screen.getByRole("button", { name: "Record request" }));
+
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith("Access request recorded.");
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/scripts/script_alpha/access-requests",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ requesterUserId: "reader_77", reason: "Coverage review" }),
+      })
+    );
+  });
+
+  it("surfaces failed co-writer, draft, and access mutations", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+    const drafts = [
+      draftFixture({ id: "draft_primary", scriptId: "script_primary", isPrimary: true, versionLabel: "v1" }),
+      draftFixture({ id: "draft_secondary", scriptId: "script_secondary", isPrimary: false, versionLabel: "v2" }),
+    ];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const method = (init?.method ?? "GET").toUpperCase();
+
+      if (url.includes("/api/v1/projects?") && method === "GET") return jsonResponse({ projects: [projectFixture()] });
+      if (url.includes("/recommended-competitions")) return jsonResponse({ recommendations: [] });
+      if (url.endsWith("/co-writers") && method === "GET") {
+        return jsonResponse({ coWriters: [{ projectId: "project_alpha", coWriterUserId: "writer_02", creditOrder: 2 }] });
+      }
+      if (url.endsWith("/co-writers") && method === "POST") return jsonResponse({}, 400);
+      if (url.includes("/co-writers/writer_02") && method === "DELETE") {
+        return jsonResponse({ error: "Cannot remove co-writer" }, 409);
+      }
+      if (url.endsWith("/drafts") && method === "GET") return jsonResponse({ drafts });
+      if (url.endsWith("/drafts") && method === "POST") return jsonResponse({}, 400);
+      if (url.endsWith("/draft_secondary/primary") && method === "POST") {
+        return jsonResponse({ error: "Cannot promote draft" }, 409);
+      }
+      if (url.endsWith("/draft_secondary") && method === "PATCH") return jsonResponse({}, 409);
+      if (url.includes("/access-requests?") && method === "GET") {
+        return jsonResponse({ accessRequests: [accessRequestFixture({ id: "request_pending" })] });
+      }
+      if (url.endsWith("/access-requests") && method === "POST") {
+        return jsonResponse({ error: "Duplicate request" }, 409);
+      }
+      if (url.endsWith("/request_pending/reject") && method === "POST") return jsonResponse({}, 409);
+      return jsonResponse({});
+    });
+    const user = userEvent.setup();
+
+    renderWithProviders(<ProjectsPage />);
+    expect(await screen.findByText("writer_02")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Add co-writer" }));
+    await user.type(await screen.findByRole("textbox", { name: "Co-writer user ID" }), "writer_03");
+    await user.click(screen.getAllByRole("button", { name: "Add co-writer" }).find((button) =>
+      (button as HTMLButtonElement).type === "submit"
+    ) as HTMLElement);
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Unable to add co-writer.");
+    });
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    await user.click(screen.getByRole("button", { name: "Remove co-writer" }));
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Cannot remove co-writer");
+    });
+
+    await user.click(screen.getByRole("button", { name: "Create draft" }));
+    await user.type(await screen.findByRole("textbox", { name: "Script ID" }), "script_manual");
+    await user.click(screen.getAllByRole("button", { name: "Create draft" }).find((button) =>
+      (button as HTMLButtonElement).type === "submit"
+    ) as HTMLElement);
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Unable to create draft.");
+    });
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    await user.click(screen.getAllByRole("button", { name: "Set primary" })[1] as HTMLElement);
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Cannot promote draft");
+    });
+
+    await user.click(screen.getAllByRole("button", { name: "Archive" })[1] as HTMLElement);
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Unable to archive draft.");
+    });
+
+    await user.click(screen.getByRole("button", { name: "New access request" }));
+    await user.type(await screen.findByRole("textbox", { name: "Requester user ID" }), "reader_42");
+    await user.click(screen.getByRole("button", { name: "Record request" }));
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Duplicate request");
+    });
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    await user.click(screen.getByRole("button", { name: "Reject" }));
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Unable to reject access request.");
+    });
+  });
+});

--- a/apps/writer-web/app/settings/account/page.test.tsx
+++ b/apps/writer-web/app/settings/account/page.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { mockUseAuth } from "../../../vitest.setup";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mockRefreshAuth, mockUseAuth } from "../../../vitest.setup";
 import AccountSettingsPage from "./page";
 
 describe("AccountSettingsPage", () => {
@@ -30,5 +30,172 @@ describe("AccountSettingsPage", () => {
     expect(screen.getByRole("link", { name: "Export your data" })).toHaveAttribute("href", "/profile#data-export");
     expect(screen.getByRole("link", { name: "Import recovered history" })).toHaveAttribute("href", "/profile/import");
     expect(screen.getByRole("button", { name: "Delete Account" })).toBeInTheDocument();
+  });
+});
+
+const signedInUser = {
+  user: {
+    id: "writer_01",
+    email: "writer@example.com",
+    displayName: "Writer One",
+    role: "writer",
+  },
+  loading: false,
+};
+
+function mockFetchWith(impl: () => Partial<Response>) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async () => impl() as Response);
+}
+
+describe("AccountSettingsPage — interactive account deletion flow", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    mockUseAuth.mockReset();
+    mockRefreshAuth.mockReset();
+    mockUseAuth.mockReturnValue(signedInUser);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the signed-in user's email and display name", () => {
+    render(<AccountSettingsPage />);
+    expect(screen.getByText("writer@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Writer One")).toBeInTheDocument();
+  });
+
+  it("reveals the confirmation form when 'Delete Account' is clicked", () => {
+    render(<AccountSettingsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete Account" }));
+
+    expect(screen.getByRole("button", { name: "Delete my account" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Confirm your password")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Delete Account" })).not.toBeInTheDocument();
+  });
+
+  it("keeps the destructive submit disabled until a password is entered", () => {
+    render(<AccountSettingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete Account" }));
+
+    const submit = screen.getByRole("button", { name: "Delete my account" });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Confirm your password"), { target: { value: "supersecret" } });
+    expect(submit).not.toBeDisabled();
+  });
+
+  it("cancels back to the danger-zone summary and clears the password field", () => {
+    render(<AccountSettingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete Account" }));
+    fireEvent.change(screen.getByLabelText("Confirm your password"), { target: { value: "supersecret" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.getByRole("button", { name: "Delete Account" })).toBeInTheDocument();
+
+    // Re-opening should present an empty password input again.
+    fireEvent.click(screen.getByRole("button", { name: "Delete Account" }));
+    const pw = screen.getByLabelText("Confirm your password") as HTMLInputElement;
+    expect(pw.value).toBe("");
+  });
+
+  it("renders the deletion-success view after a successful delete and triggers refreshAuth", async () => {
+    const fetchSpy = mockFetchWith(() => ({ ok: true, json: async () => ({}) }));
+
+    render(<AccountSettingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete Account" }));
+    fireEvent.change(screen.getByLabelText("Confirm your password"), { target: { value: "correct" } });
+    fireEvent.click(screen.getByRole("button", { name: "Delete my account" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Account Deleted")).toBeInTheDocument();
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/v1/auth/account",
+      expect.objectContaining({
+        method: "DELETE",
+        credentials: "include",
+        body: JSON.stringify({ password: "correct" }),
+      }),
+    );
+    expect(mockRefreshAuth).toHaveBeenCalled();
+    expect(screen.getByRole("link", { name: "Go to homepage" })).toHaveAttribute("href", "/");
+  });
+
+  it("surfaces the friendly invalid_password message", async () => {
+    mockFetchWith(() => ({ ok: false, json: async () => ({ error: "invalid_password" }) }));
+
+    render(<AccountSettingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete Account" }));
+    fireEvent.change(screen.getByLabelText("Confirm your password"), { target: { value: "wrong" } });
+    fireEvent.click(screen.getByRole("button", { name: "Delete my account" }));
+
+    expect(await screen.findByText("Incorrect password. Please try again.")).toBeInTheDocument();
+    expect(mockRefreshAuth).not.toHaveBeenCalled();
+    // Still on the confirmation form (not deleted view).
+    expect(screen.getByRole("button", { name: "Delete my account" })).toBeInTheDocument();
+  });
+
+  it("renders the raw API error code when one is provided", async () => {
+    mockFetchWith(() => ({ ok: false, json: async () => ({ error: "rate_limited" }) }));
+
+    render(<AccountSettingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete Account" }));
+    fireEvent.change(screen.getByLabelText("Confirm your password"), { target: { value: "any" } });
+    fireEvent.click(screen.getByRole("button", { name: "Delete my account" }));
+
+    expect(await screen.findByText("rate_limited")).toBeInTheDocument();
+  });
+
+  it("falls back to a generic message when the error body has no error field", async () => {
+    mockFetchWith(() => ({ ok: false, json: async () => ({}) }));
+
+    render(<AccountSettingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete Account" }));
+    fireEvent.change(screen.getByLabelText("Confirm your password"), { target: { value: "any" } });
+    fireEvent.click(screen.getByRole("button", { name: "Delete my account" }));
+
+    expect(await screen.findByText("Something went wrong.")).toBeInTheDocument();
+  });
+
+  it("renders a network-error message when fetch rejects", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("offline"));
+
+    render(<AccountSettingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete Account" }));
+    fireEvent.change(screen.getByLabelText("Confirm your password"), { target: { value: "any" } });
+    fireEvent.click(screen.getByRole("button", { name: "Delete my account" }));
+
+    expect(await screen.findByText("Network error. Please try again.")).toBeInTheDocument();
+  });
+
+  it("shows the in-flight 'Deleting...' state while the request is pending", async () => {
+    let resolveFetch: (value: Response) => void = () => {};
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    render(<AccountSettingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete Account" }));
+    fireEvent.change(screen.getByLabelText("Confirm your password"), { target: { value: "any" } });
+    fireEvent.click(screen.getByRole("button", { name: "Delete my account" }));
+
+    const deleting = await screen.findByRole("button", { name: "Deleting..." });
+    expect(deleting).toBeDisabled();
+
+    await act(async () => {
+      resolveFetch({ ok: true, json: async () => ({}) } as Response);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Account Deleted")).toBeInTheDocument();
+    });
   });
 });

--- a/apps/writer-web/app/settings/security/page.test.tsx
+++ b/apps/writer-web/app/settings/security/page.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { SWRConfig } from "swr";
 import type { ReactElement } from "react";
 import { mockUseAuth } from "../../../vitest.setup";
@@ -39,5 +39,598 @@ describe("SecuritySettingsPage", () => {
 
     expect(screen.getByText("Security")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "sign in" })).toHaveAttribute("href", "/signin");
+  });
+});
+
+const signedInUser = {
+  user: {
+    id: "writer_01",
+    email: "writer@example.com",
+    displayName: "Writer One",
+    role: "writer",
+  },
+  loading: false,
+};
+
+type FetchHandler = {
+  url: string;
+  method?: string;
+  ok: boolean;
+  status?: number;
+  json: unknown;
+};
+
+function mockSecurityFetch(handlers: FetchHandler[]) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    const method = (init?.method ?? "GET").toUpperCase();
+    const handler = handlers.find(
+      (h) => url.includes(h.url) && (!h.method || h.method.toUpperCase() === method),
+    );
+    if (!handler) {
+      return {
+        ok: false,
+        status: 404,
+        text: async () => "{}",
+        json: async () => ({}),
+      } as Response;
+    }
+    const text = JSON.stringify(handler.json);
+    return {
+      ok: handler.ok,
+      status: handler.status ?? (handler.ok ? 200 : 400),
+      text: async () => text,
+      json: async () => handler.json,
+    } as Response;
+  });
+}
+
+describe("SecuritySettingsPage — MFA flows", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    mockUseAuth.mockReset();
+    mockUseAuth.mockReturnValue(signedInUser);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows 'Loading...' while auth context is still resolving", () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: true });
+    renderWithSWR(<SecuritySettingsPage />);
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("transitions to disabled state after a successful mfaEnabled=false fetch", async () => {
+    mockSecurityFetch([{ url: "/mfa/status", ok: true, json: { mfaEnabled: false } }]);
+    renderWithSWR(<SecuritySettingsPage />);
+
+    expect(
+      await screen.findByRole("button", { name: "Enable Two-Factor Authentication" }),
+    ).toBeInTheDocument();
+  });
+
+  it("transitions to enabled state after a successful mfaEnabled=true fetch", async () => {
+    mockSecurityFetch([{ url: "/mfa/status", ok: true, json: { mfaEnabled: true } }]);
+    renderWithSWR(<SecuritySettingsPage />);
+
+    expect(await screen.findByText("Two-factor authentication is enabled")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Disable 2FA" })).toBeInTheDocument();
+  });
+
+  it("falls back to disabled state with an error banner when status fetch fails", async () => {
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: false, status: 500, json: { message: "boom" } },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+
+    expect(await screen.findByText("Failed to load MFA status.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Enable Two-Factor Authentication" }),
+    ).toBeInTheDocument();
+  });
+
+  it("starts setup and renders the otpauth URL + secret on success", async () => {
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: false } },
+      {
+        url: "/mfa/setup",
+        method: "POST",
+        ok: true,
+        json: { secret: "BASE32SECRET", otpauthUrl: "otpauth://totp/SM:writer" },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enable Two-Factor Authentication" }),
+    );
+
+    expect(await screen.findByText("otpauth://totp/SM:writer")).toBeInTheDocument();
+    expect(screen.getByText("BASE32SECRET")).toBeInTheDocument();
+    expect(screen.getByText("Step 1: Scan QR Code")).toBeInTheDocument();
+  });
+
+  it("maps mfa_already_enabled to a friendly setup error", async () => {
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: false } },
+      {
+        url: "/mfa/setup",
+        method: "POST",
+        ok: false,
+        status: 409,
+        json: { error: "mfa_already_enabled" },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enable Two-Factor Authentication" }),
+    );
+
+    expect(await screen.findByText("MFA is already enabled.")).toBeInTheDocument();
+  });
+
+  it("passes through a non-special setup error code", async () => {
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: false } },
+      {
+        url: "/mfa/setup",
+        method: "POST",
+        ok: false,
+        status: 400,
+        json: { error: "rate_limited" },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enable Two-Factor Authentication" }),
+    );
+
+    expect(await screen.findByText("rate_limited")).toBeInTheDocument();
+  });
+
+  it("falls back to 'Setup failed.' when the setup error body has no error code", async () => {
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: false } },
+      {
+        url: "/mfa/setup",
+        method: "POST",
+        ok: false,
+        status: 500,
+        json: { message: "boom" },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enable Two-Factor Authentication" }),
+    );
+
+    expect(await screen.findByText("Setup failed.")).toBeInTheDocument();
+  });
+
+  it("strips non-digit input and caps the totp field at 6 characters", async () => {
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: false } },
+      {
+        url: "/mfa/setup",
+        method: "POST",
+        ok: true,
+        json: { secret: "S", otpauthUrl: "otpauth://x" },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enable Two-Factor Authentication" }),
+    );
+
+    const input = (await screen.findByPlaceholderText("000000")) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "ab12cd34ef56gh78" } });
+    expect(input.value).toBe("123456");
+    expect(screen.getByRole("button", { name: "Verify and Enable" })).not.toBeDisabled();
+  });
+
+  it("keeps the verify button disabled until 6 digits are entered", async () => {
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: false } },
+      {
+        url: "/mfa/setup",
+        method: "POST",
+        ok: true,
+        json: { secret: "S", otpauthUrl: "otpauth://x" },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enable Two-Factor Authentication" }),
+    );
+
+    const input = await screen.findByPlaceholderText("000000");
+    fireEvent.change(input, { target: { value: "123" } });
+    expect(screen.getByRole("button", { name: "Verify and Enable" })).toBeDisabled();
+  });
+
+  it("cancel during setup resets to the disabled state", async () => {
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: false } },
+      {
+        url: "/mfa/setup",
+        method: "POST",
+        ok: true,
+        json: { secret: "S", otpauthUrl: "otpauth://x" },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enable Two-Factor Authentication" }),
+    );
+    await screen.findByText("Step 1: Scan QR Code");
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(
+      screen.getByRole("button", { name: "Enable Two-Factor Authentication" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Step 1: Scan QR Code")).not.toBeInTheDocument();
+  });
+
+  it("verifies setup and renders the returned backup codes", async () => {
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: false } },
+      {
+        url: "/mfa/setup",
+        method: "POST",
+        ok: true,
+        json: { secret: "S", otpauthUrl: "otpauth://x" },
+      },
+      {
+        url: "/mfa/verify-setup",
+        method: "POST",
+        ok: true,
+        json: { backupCodes: ["AAA-111", "BBB-222"] },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enable Two-Factor Authentication" }),
+    );
+    fireEvent.change(await screen.findByPlaceholderText("000000"), { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: "Verify and Enable" }));
+
+    expect(await screen.findByText("AAA-111")).toBeInTheDocument();
+    expect(screen.getByText("BBB-222")).toBeInTheDocument();
+    expect(screen.getByText("Save your backup codes!")).toBeInTheDocument();
+  });
+
+  it("maps invalid_totp_code on verify to a friendly error", async () => {
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: false } },
+      {
+        url: "/mfa/setup",
+        method: "POST",
+        ok: true,
+        json: { secret: "S", otpauthUrl: "otpauth://x" },
+      },
+      {
+        url: "/mfa/verify-setup",
+        method: "POST",
+        ok: false,
+        status: 400,
+        json: { error: "invalid_totp_code" },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enable Two-Factor Authentication" }),
+    );
+    fireEvent.change(await screen.findByPlaceholderText("000000"), { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: "Verify and Enable" }));
+
+    expect(await screen.findByText("Invalid code. Please try again.")).toBeInTheDocument();
+  });
+
+  it("passes through non-special verify error codes", async () => {
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: false } },
+      {
+        url: "/mfa/setup",
+        method: "POST",
+        ok: true,
+        json: { secret: "S", otpauthUrl: "otpauth://x" },
+      },
+      {
+        url: "/mfa/verify-setup",
+        method: "POST",
+        ok: false,
+        status: 400,
+        json: { error: "expired" },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enable Two-Factor Authentication" }),
+    );
+    fireEvent.change(await screen.findByPlaceholderText("000000"), { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: "Verify and Enable" }));
+
+    expect(await screen.findByText("expired")).toBeInTheDocument();
+  });
+
+  it("falls back to 'Verification failed.' for unrecognized verify errors", async () => {
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: false } },
+      {
+        url: "/mfa/setup",
+        method: "POST",
+        ok: true,
+        json: { secret: "S", otpauthUrl: "otpauth://x" },
+      },
+      {
+        url: "/mfa/verify-setup",
+        method: "POST",
+        ok: false,
+        status: 500,
+        json: { message: "boom" },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enable Two-Factor Authentication" }),
+    );
+    fireEvent.change(await screen.findByPlaceholderText("000000"), { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: "Verify and Enable" }));
+
+    expect(await screen.findByText("Verification failed.")).toBeInTheDocument();
+  });
+
+  it("copies backup codes to the clipboard", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: false } },
+      { url: "/mfa/setup", method: "POST", ok: true, json: { secret: "S", otpauthUrl: "o" } },
+      {
+        url: "/mfa/verify-setup",
+        method: "POST",
+        ok: true,
+        json: { backupCodes: ["AAA", "BBB"] },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enable Two-Factor Authentication" }),
+    );
+    fireEvent.change(await screen.findByPlaceholderText("000000"), { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: "Verify and Enable" }));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Copy codes" }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("AAA\nBBB");
+    });
+  });
+
+  it("swallows a rejected clipboard write without throwing", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: false } },
+      { url: "/mfa/setup", method: "POST", ok: true, json: { secret: "S", otpauthUrl: "o" } },
+      {
+        url: "/mfa/verify-setup",
+        method: "POST",
+        ok: true,
+        json: { backupCodes: ["XYZ"] },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enable Two-Factor Authentication" }),
+    );
+    fireEvent.change(await screen.findByPlaceholderText("000000"), { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: "Verify and Enable" }));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Copy codes" }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalled();
+    });
+    // UI continues to show the codes; no crash.
+    expect(screen.getByText("XYZ")).toBeInTheDocument();
+  });
+
+  it("downloads backup codes by triggering an anchor click", async () => {
+    const createObjectURL = vi.fn().mockReturnValue("blob:url");
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, "createObjectURL", {
+      value: createObjectURL,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      value: revokeObjectURL,
+      configurable: true,
+      writable: true,
+    });
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: false } },
+      { url: "/mfa/setup", method: "POST", ok: true, json: { secret: "S", otpauthUrl: "o" } },
+      {
+        url: "/mfa/verify-setup",
+        method: "POST",
+        ok: true,
+        json: { backupCodes: ["AAA", "BBB"] },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enable Two-Factor Authentication" }),
+    );
+    fireEvent.change(await screen.findByPlaceholderText("000000"), { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: "Verify and Enable" }));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Download" }));
+
+    expect(createObjectURL).toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalled();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:url");
+  });
+
+  it("confirms saved backup codes and moves to the enabled state", async () => {
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: false } },
+      { url: "/mfa/setup", method: "POST", ok: true, json: { secret: "S", otpauthUrl: "o" } },
+      {
+        url: "/mfa/verify-setup",
+        method: "POST",
+        ok: true,
+        json: { backupCodes: ["AAA"] },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Enable Two-Factor Authentication" }),
+    );
+    fireEvent.change(await screen.findByPlaceholderText("000000"), { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: "Verify and Enable" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "I have saved my backup codes" }),
+    );
+
+    expect(await screen.findByText("Two-factor authentication is enabled")).toBeInTheDocument();
+  });
+
+  it("opens and cancels the disable confirmation form", async () => {
+    mockSecurityFetch([{ url: "/mfa/status", ok: true, json: { mfaEnabled: true } }]);
+    renderWithSWR(<SecuritySettingsPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Disable 2FA" }));
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(screen.getByLabelText("Authenticator code")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(await screen.findByText("Two-factor authentication is enabled")).toBeInTheDocument();
+  });
+
+  it("keeps the destructive disable submit gated on password + 6 digits", async () => {
+    mockSecurityFetch([{ url: "/mfa/status", ok: true, json: { mfaEnabled: true } }]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(await screen.findByRole("button", { name: "Disable 2FA" }));
+
+    const submit = screen.getByRole("button", { name: "Disable 2FA" });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "pw" } });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Authenticator code"), {
+      target: { value: "abc12def34gh56" },
+    });
+    expect(submit).not.toBeDisabled();
+  });
+
+  it("successfully disables MFA and returns to the disabled state", async () => {
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: true } },
+      { url: "/mfa/disable", method: "POST", ok: true, status: 204, json: {} },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(await screen.findByRole("button", { name: "Disable 2FA" }));
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "pw" } });
+    fireEvent.change(screen.getByLabelText("Authenticator code"), { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: "Disable 2FA" }));
+
+    expect(
+      await screen.findByRole("button", { name: "Enable Two-Factor Authentication" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the friendly invalid_password message when disable rejects with that code", async () => {
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: true } },
+      {
+        url: "/mfa/disable",
+        method: "POST",
+        ok: false,
+        status: 400,
+        json: { error: "invalid_password" },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(await screen.findByRole("button", { name: "Disable 2FA" }));
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "pw" } });
+    fireEvent.change(screen.getByLabelText("Authenticator code"), { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: "Disable 2FA" }));
+
+    expect(await screen.findByText("Incorrect password.")).toBeInTheDocument();
+  });
+
+  it("shows the friendly invalid_totp_code message when disable rejects with that code", async () => {
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: true } },
+      {
+        url: "/mfa/disable",
+        method: "POST",
+        ok: false,
+        status: 400,
+        json: { error: "invalid_totp_code" },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(await screen.findByRole("button", { name: "Disable 2FA" }));
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "pw" } });
+    fireEvent.change(screen.getByLabelText("Authenticator code"), { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: "Disable 2FA" }));
+
+    expect(await screen.findByText("Invalid authentication code.")).toBeInTheDocument();
+  });
+
+  it("passes through other disable error codes verbatim", async () => {
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: true } },
+      {
+        url: "/mfa/disable",
+        method: "POST",
+        ok: false,
+        status: 400,
+        json: { error: "session_locked" },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(await screen.findByRole("button", { name: "Disable 2FA" }));
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "pw" } });
+    fireEvent.change(screen.getByLabelText("Authenticator code"), { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: "Disable 2FA" }));
+
+    expect(await screen.findByText("session_locked")).toBeInTheDocument();
+  });
+
+  it("falls back to 'Failed to disable MFA.' when the disable error body has no code", async () => {
+    mockSecurityFetch([
+      { url: "/mfa/status", ok: true, json: { mfaEnabled: true } },
+      {
+        url: "/mfa/disable",
+        method: "POST",
+        ok: false,
+        status: 500,
+        json: { message: "boom" },
+      },
+    ]);
+    renderWithSWR(<SecuritySettingsPage />);
+    fireEvent.click(await screen.findByRole("button", { name: "Disable 2FA" }));
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "pw" } });
+    fireEvent.change(screen.getByLabelText("Authenticator code"), { target: { value: "123456" } });
+    fireEvent.click(screen.getByRole("button", { name: "Disable 2FA" }));
+
+    expect(await screen.findByText("Failed to disable MFA.")).toBeInTheDocument();
   });
 });

--- a/apps/writer-web/app/submissions/page.test.tsx
+++ b/apps/writer-web/app/submissions/page.test.tsx
@@ -277,3 +277,807 @@ describe("SubmissionsPage", () => {
     });
   });
 });
+
+describe("SubmissionsPage — branch coverage", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({ user: baseUser, loading: false });
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  function stubBasicFetch(opts: {
+    projects?: unknown[];
+    competitions?: unknown[];
+    submissions?: unknown[];
+    placements?: unknown[];
+    overrides?: (url: string, init?: RequestInit) => Response | null | undefined;
+  } = {}) {
+    const projects = opts.projects ?? [project1];
+    const competitions = opts.competitions ?? [competition1];
+    const submissions = opts.submissions ?? [];
+    const placements = opts.placements ?? [];
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const ov = opts.overrides?.(url, init ?? undefined);
+      if (ov) return ov;
+      if (url.includes("/api/v1/projects?")) return jsonResponse({ projects });
+      if (url.includes("/api/v1/competitions")) return jsonResponse({ competitions });
+      if (url.includes("/api/v1/submissions?")) return jsonResponse({ submissions });
+      if (url.includes("/api/v1/placements?")) return jsonResponse({ placements });
+      if (url === "/api/v1/onboarding-progress") return jsonResponse({ ok: true });
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  it("pauses fetches while auth is still loading", () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: true });
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+    renderWithProviders(<SubmissionsPage />);
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/submissions?"),
+      expect.anything()
+    );
+  });
+
+  it("disables hero action buttons when no projects/competitions/submissions", async () => {
+    stubBasicFetch({ projects: [], competitions: [], submissions: [], placements: [] });
+    renderWithProviders(<SubmissionsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("0 total")).toBeInTheDocument();
+    });
+
+    const createBtn = screen.getAllByRole("button", { name: "Create submission" })[0] as HTMLButtonElement;
+    const placementBtn = screen.getByRole("button", { name: "Record placement" }) as HTMLButtonElement;
+    const historicalBtn = screen.getByRole("button", { name: "Record historical placement" }) as HTMLButtonElement;
+    expect(createBtn).toBeDisabled();
+    expect(placementBtn).toBeDisabled();
+    expect(historicalBtn).toBeDisabled();
+
+    expect(screen.getByText("No submissions yet")).toBeInTheDocument();
+  });
+
+  it("falls back to raw ids when project/competition lookup misses", async () => {
+    stubBasicFetch({
+      projects: [],
+      competitions: [],
+      submissions: [
+        {
+          id: "sub_unknown",
+          writerId: "writer_01",
+          projectId: "project_missing",
+          competitionId: "comp_missing",
+          status: "pending",
+          createdAt: "2026-02-06T00:00:00.000Z",
+          updatedAt: "2026-02-06T00:00:00.000Z",
+        },
+      ],
+      placements: [],
+    });
+
+    renderWithProviders(<SubmissionsPage />);
+
+    await screen.findByText("sub_unknown");
+    expect(screen.getByText(/Project: project_missing/)).toBeInTheDocument();
+    expect(screen.getByText(/Competition: comp_missing/)).toBeInTheDocument();
+  });
+
+  it("renders historical and recovered placement badges plus disabled verify buttons when already verified/rejected", async () => {
+    stubBasicFetch({
+      submissions: [
+        {
+          id: "sub_1",
+          writerId: "writer_01",
+          projectId: "project_1",
+          competitionId: "comp_1",
+          status: "winner",
+          createdAt: "2026-02-06T00:00:00.000Z",
+          updatedAt: "2026-02-06T00:00:00.000Z",
+        },
+      ],
+      placements: [
+        {
+          id: "pl_verified",
+          submissionId: "sub_1",
+          status: "winner",
+          badgeLabel: "Winner",
+          verificationState: "verified",
+          isHistorical: true,
+          importSource: "recovered_csv",
+        },
+        {
+          id: "pl_rejected",
+          submissionId: "sub_1",
+          status: "finalist",
+          badgeLabel: "Finalist",
+          verificationState: "rejected",
+          isHistorical: false,
+          importSource: "manual",
+        },
+      ],
+    });
+
+    renderWithProviders(<SubmissionsPage />);
+
+    await screen.findByText("pl_verified");
+    expect(screen.getByText("Recovered")).toBeInTheDocument();
+    expect(screen.getByText("Historical")).toBeInTheDocument();
+
+    const markVerifiedBtns = screen.getAllByRole("button", { name: "Mark verified" });
+    const markRejectedBtns = screen.getAllByRole("button", { name: "Mark rejected" });
+    expect(markVerifiedBtns[0] as HTMLButtonElement).toBeDisabled();
+    expect(markRejectedBtns[1] as HTMLButtonElement).toBeDisabled();
+  });
+
+  it("shows 'No placements recorded.' when submission has no placements", async () => {
+    stubBasicFetch({
+      submissions: [
+        {
+          id: "sub_no_pl",
+          writerId: "writer_01",
+          projectId: "project_1",
+          competitionId: "comp_1",
+          status: "pending",
+          createdAt: "2026-02-06T00:00:00.000Z",
+          updatedAt: "2026-02-06T00:00:00.000Z",
+        },
+      ],
+      placements: [],
+    });
+
+    renderWithProviders(<SubmissionsPage />);
+    await screen.findByText("sub_no_pl");
+    expect(screen.getByText("No placements recorded.")).toBeInTheDocument();
+  });
+
+  it("blocks createSubmission when no project selected and toasts error", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    stubBasicFetch({ projects: [project1], competitions: [competition1] });
+    renderWithProviders(<SubmissionsPage />);
+
+    const user = userEvent.setup();
+    await waitFor(() => {
+      expect((screen.getAllByRole("button", { name: "Create submission" })[0] as HTMLButtonElement)).not.toBeDisabled();
+    });
+    await user.click(screen.getAllByRole("button", { name: "Create submission" })[0] as HTMLElement);
+
+    // Clear project to trigger validation guard
+    const projectSelect = await screen.findByLabelText("Project");
+    await user.selectOptions(projectSelect, "");
+    // Now click submit
+    const submitBtn = screen.getAllByRole("button", { name: "Create submission" }).find(
+      (b) => (b as HTMLButtonElement).type === "submit"
+    ) as HTMLElement;
+    // HTML form validation will block, but our async function checks guard. Use fireEvent.submit to bypass.
+    const form = submitBtn.closest("form")!;
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Writer, project, and competition are required.");
+    });
+  });
+
+  it("surfaces non-ApiError as default toast message on submission create failure", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    const submissions: Array<Record<string, unknown>> = [];
+    stubBasicFetch({
+      submissions,
+      overrides: (url, init) => {
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (url === "/api/v1/submissions" && method === "POST") {
+          // Return a network-like error -> fetcher will throw a non-ApiError
+          return new Response("oops", { status: 502, headers: { "content-type": "text/plain" } });
+        }
+        return null;
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<SubmissionsPage />);
+
+    await waitFor(() => {
+      expect((screen.getAllByRole("button", { name: "Create submission" })[0] as HTMLButtonElement)).not.toBeDisabled();
+    });
+    await user.click(screen.getAllByRole("button", { name: "Create submission" })[0] as HTMLElement);
+    const submitBtn = screen.getAllByRole("button", { name: "Create submission" }).find(
+      (b) => (b as HTMLButtonElement).type === "submit"
+    ) as HTMLElement;
+    await user.click(submitBtn);
+
+    await waitFor(() => {
+      // Either ApiError message (if fetcher parses it) or default fallback
+      expect(toastError).toHaveBeenCalled();
+    });
+  });
+
+  it("moveSubmission with no target id toasts validation error", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    stubBasicFetch({
+      submissions: [
+        {
+          id: "sub_blank",
+          writerId: "writer_01",
+          projectId: "",
+          competitionId: "comp_1",
+          status: "pending",
+          createdAt: "2026-02-06T00:00:00.000Z",
+          updatedAt: "2026-02-06T00:00:00.000Z",
+        },
+      ],
+      placements: [],
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<SubmissionsPage />);
+
+    await screen.findByText("sub_blank");
+    await user.click(screen.getByRole("button", { name: "Move submission" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Select a target project before moving.");
+    });
+  });
+
+  it("moveSubmission success updates cache and toasts", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    const project2 = { ...project1, id: "project_2", title: "Project Two" };
+    let movedTo = "project_1";
+
+    stubBasicFetch({
+      projects: [project1, project2],
+      submissions: [
+        {
+          id: "sub_move",
+          writerId: "writer_01",
+          projectId: "project_1",
+          competitionId: "comp_1",
+          status: "pending",
+          createdAt: "2026-02-06T00:00:00.000Z",
+          updatedAt: "2026-02-06T00:00:00.000Z",
+        },
+      ],
+      placements: [],
+      overrides: (url, init) => {
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (method === "PATCH" && url.includes("/api/v1/submissions/sub_move/project")) {
+          const body = JSON.parse(String(init?.body ?? "{}")) as { projectId: string };
+          movedTo = body.projectId;
+          return jsonResponse({
+            submission: {
+              id: "sub_move",
+              writerId: "writer_01",
+              projectId: movedTo,
+              competitionId: "comp_1",
+              status: "pending",
+              createdAt: "2026-02-06T00:00:00.000Z",
+              updatedAt: "2026-02-06T00:00:00.000Z",
+            },
+          });
+        }
+        return null;
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<SubmissionsPage />);
+
+    await screen.findByText("sub_move");
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    await user.selectOptions(select, "project_2");
+    await user.click(screen.getByRole("button", { name: "Move submission" }));
+
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith("Submission moved.");
+    });
+    expect(movedTo).toBe("project_2");
+  });
+
+  it("moveSubmission toasts ApiError message on failure", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    stubBasicFetch({
+      submissions: [
+        {
+          id: "sub_err",
+          writerId: "writer_01",
+          projectId: "project_1",
+          competitionId: "comp_1",
+          status: "pending",
+          createdAt: "2026-02-06T00:00:00.000Z",
+          updatedAt: "2026-02-06T00:00:00.000Z",
+        },
+      ],
+      placements: [],
+      overrides: (url, init) => {
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (method === "PATCH" && url.includes("/api/v1/submissions/sub_err/project")) {
+          return new Response(JSON.stringify({ message: "Cannot move" }), {
+            status: 400,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return null;
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<SubmissionsPage />);
+    await screen.findByText("sub_err");
+    await user.click(screen.getByRole("button", { name: "Move submission" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Cannot move");
+    });
+  });
+
+  it("verifyPlacement triggers success toast for verified state", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    stubBasicFetch({
+      submissions: [
+        {
+          id: "sub_v",
+          writerId: "writer_01",
+          projectId: "project_1",
+          competitionId: "comp_1",
+          status: "finalist",
+          createdAt: "2026-02-06T00:00:00.000Z",
+          updatedAt: "2026-02-06T00:00:00.000Z",
+        },
+      ],
+      placements: [
+        {
+          id: "pl_unverified",
+          submissionId: "sub_v",
+          status: "finalist",
+          badgeLabel: "Finalist",
+          verificationState: "unverified",
+          isHistorical: false,
+          importSource: "manual",
+        },
+      ],
+      overrides: (url, init) => {
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (method === "POST" && url.includes("/api/v1/placements/pl_unverified/verify")) {
+          return jsonResponse({ ok: true });
+        }
+        return null;
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<SubmissionsPage />);
+    await screen.findByText("pl_unverified");
+    await user.click(screen.getByRole("button", { name: "Mark verified" }));
+
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith("Placement marked verified.");
+    });
+  });
+
+  it("verifyPlacement toasts ApiError on rejection failure", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    stubBasicFetch({
+      submissions: [
+        {
+          id: "sub_vr",
+          writerId: "writer_01",
+          projectId: "project_1",
+          competitionId: "comp_1",
+          status: "finalist",
+          createdAt: "2026-02-06T00:00:00.000Z",
+          updatedAt: "2026-02-06T00:00:00.000Z",
+        },
+      ],
+      placements: [
+        {
+          id: "pl_vr",
+          submissionId: "sub_vr",
+          status: "finalist",
+          badgeLabel: "Finalist",
+          verificationState: "unverified",
+          isHistorical: false,
+          importSource: "manual",
+        },
+      ],
+      overrides: (url, init) => {
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (method === "POST" && url.includes("/api/v1/placements/pl_vr/verify")) {
+          return new Response(JSON.stringify({ message: "Verify failed" }), {
+            status: 400,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return null;
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<SubmissionsPage />);
+    await screen.findByText("pl_vr");
+    await user.click(screen.getByRole("button", { name: "Mark rejected" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Verify failed");
+    });
+  });
+
+  it("createPlacement blocks when no submission chosen", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    stubBasicFetch({
+      submissions: [
+        {
+          id: "sub_p",
+          writerId: "writer_01",
+          projectId: "project_1",
+          competitionId: "comp_1",
+          status: "pending",
+          createdAt: "2026-02-06T00:00:00.000Z",
+          updatedAt: "2026-02-06T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<SubmissionsPage />);
+
+    await waitFor(() => {
+      expect((screen.getByRole("button", { name: "Record placement" }) as HTMLButtonElement)).not.toBeDisabled();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Record placement" }));
+    const submitBtn = screen.getByRole("button", { name: "Create placement" });
+    const form = submitBtn.closest("form")!;
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Choose a submission first.");
+    });
+  });
+
+  it("createPlacement skips submission mutate when response omits submission", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    stubBasicFetch({
+      submissions: [
+        {
+          id: "sub_no_resp",
+          writerId: "writer_01",
+          projectId: "project_1",
+          competitionId: "comp_1",
+          status: "pending",
+          createdAt: "2026-02-06T00:00:00.000Z",
+          updatedAt: "2026-02-06T00:00:00.000Z",
+        },
+      ],
+      overrides: (url, init) => {
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (method === "POST" && url === "/api/v1/submissions/sub_no_resp/placements") {
+          return jsonResponse({}, 201); // no submission field
+        }
+        return null;
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<SubmissionsPage />);
+
+    await screen.findByText("sub_no_resp");
+    await user.click(screen.getByRole("button", { name: "Record placement" }));
+    await user.selectOptions(await screen.findByLabelText("Submission"), "sub_no_resp");
+    await user.click(screen.getByRole("button", { name: "Create placement" }));
+
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith("Placement recorded.");
+    });
+  });
+
+  it("createPlacement toasts ApiError on failure", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    stubBasicFetch({
+      submissions: [
+        {
+          id: "sub_pf",
+          writerId: "writer_01",
+          projectId: "project_1",
+          competitionId: "comp_1",
+          status: "pending",
+          createdAt: "2026-02-06T00:00:00.000Z",
+          updatedAt: "2026-02-06T00:00:00.000Z",
+        },
+      ],
+      overrides: (url, init) => {
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (method === "POST" && url === "/api/v1/submissions/sub_pf/placements") {
+          return new Response(JSON.stringify({ message: "Placement failed" }), {
+            status: 400,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return null;
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<SubmissionsPage />);
+    await screen.findByText("sub_pf");
+    await user.click(screen.getByRole("button", { name: "Record placement" }));
+    await user.selectOptions(await screen.findByLabelText("Submission"), "sub_pf");
+    await user.click(screen.getByRole("button", { name: "Create placement" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Placement failed");
+    });
+  });
+
+  it("createHistoricalPlacement blocks when required fields missing", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    stubBasicFetch({});
+    const user = userEvent.setup();
+    renderWithProviders(<SubmissionsPage />);
+
+    await waitFor(() => {
+      expect((screen.getByRole("button", { name: "Record historical placement" }) as HTMLButtonElement)).not.toBeDisabled();
+    });
+    await user.click(screen.getByRole("button", { name: "Record historical placement" }));
+
+    // Submit without filling required fields → guard triggers
+    const submitBtn = screen.getByRole("button", { name: "Submit historical placement" });
+    const form = submitBtn.closest("form")!;
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Project, competition, date, and source note are required.");
+    });
+  });
+
+  it("createHistoricalPlacement blocks when no evidence file or url provided", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    stubBasicFetch({});
+    const user = userEvent.setup();
+    renderWithProviders(<SubmissionsPage />);
+
+    await waitFor(() => {
+      expect((screen.getByRole("button", { name: "Record historical placement" }) as HTMLButtonElement)).not.toBeDisabled();
+    });
+    await user.click(screen.getByRole("button", { name: "Record historical placement" }));
+
+    // Fill date and source note but no evidence
+    const dateInput = screen.getByLabelText("Placement date") as HTMLInputElement;
+    await user.type(dateInput, "2024-01-15");
+    const sourceNote = screen.getByLabelText("Source note");
+    await user.type(sourceNote, "Found in archive");
+
+    const submitBtn = screen.getByRole("button", { name: "Submit historical placement" });
+    const form = submitBtn.closest("form")!;
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Attach an evidence file or URL.");
+    });
+  });
+
+  it("createHistoricalPlacement submits with evidence URL only and toasts success", async () => {
+    const toastSuccess = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: vi.fn(),
+      success: toastSuccess,
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    let historicalBody: unknown = null;
+    stubBasicFetch({
+      overrides: (url, init) => {
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (method === "POST" && url === "/api/v1/placements/historical") {
+          historicalBody = JSON.parse(String(init?.body ?? "{}"));
+          return jsonResponse({ ok: true }, 201);
+        }
+        return null;
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<SubmissionsPage />);
+
+    await waitFor(() => {
+      expect((screen.getByRole("button", { name: "Record historical placement" }) as HTMLButtonElement)).not.toBeDisabled();
+    });
+    await user.click(screen.getByRole("button", { name: "Record historical placement" }));
+
+    await user.type(screen.getByLabelText("Placement date"), "2024-01-15");
+    await user.type(screen.getByLabelText("Source note"), "Found in archive");
+    await user.type(screen.getByLabelText("Evidence URL"), "https://example.com/winner");
+
+    await user.click(screen.getByRole("button", { name: "Submit historical placement" }));
+
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith("Historical placement recorded for review.");
+    });
+    expect(historicalBody).toMatchObject({
+      projectId: "project_1",
+      competitionId: "comp_1",
+      sourceNote: "Found in archive",
+      evidenceItems: [
+        expect.objectContaining({ evidenceUrl: "https://example.com/winner" }),
+      ],
+    });
+  });
+
+  it("createHistoricalPlacement toasts ApiError on failure", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    stubBasicFetch({
+      overrides: (url, init) => {
+        const method = (init?.method ?? "GET").toUpperCase();
+        if (method === "POST" && url === "/api/v1/placements/historical") {
+          return new Response(JSON.stringify({ message: "Historical rejected" }), {
+            status: 400,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return null;
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<SubmissionsPage />);
+
+    await waitFor(() => {
+      expect((screen.getByRole("button", { name: "Record historical placement" }) as HTMLButtonElement)).not.toBeDisabled();
+    });
+    await user.click(screen.getByRole("button", { name: "Record historical placement" }));
+
+    await user.type(screen.getByLabelText("Placement date"), "2024-01-15");
+    await user.type(screen.getByLabelText("Source note"), "Source");
+    await user.type(screen.getByLabelText("Evidence URL"), "https://example.com");
+    await user.click(screen.getByRole("button", { name: "Submit historical placement" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Historical rejected");
+    });
+  });
+
+  it("toasts default messages when projects/competitions/placements endpoints return non-ApiError shapes", async () => {
+    const toastError = vi.fn();
+    vi.spyOn(toastModule, "useToast").mockReturnValue({
+      error: toastError,
+      success: vi.fn(),
+      info: vi.fn(),
+    } as ReturnType<typeof toastModule.useToast>);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input) => {
+        const url = typeof input === "string" ? input : input.toString();
+        // Return malformed JSON so fetcher throws non-ApiError
+        if (url.includes("/api/v1/projects?")) {
+          return new Response("not json", { status: 200, headers: { "content-type": "application/json" } });
+        }
+        if (url.includes("/api/v1/competitions")) {
+          return new Response("not json", { status: 200, headers: { "content-type": "application/json" } });
+        }
+        if (url.includes("/api/v1/placements?")) {
+          return new Response("not json", { status: 200, headers: { "content-type": "application/json" } });
+        }
+        return jsonResponse({});
+      })
+    );
+
+    renderWithProviders(<SubmissionsPage />);
+
+    await waitFor(() => {
+      // At least one default-fallback error toast occurred
+      expect(
+        toastError.mock.calls.some(
+          (call) =>
+            call[0] === "Failed to load projects." ||
+            call[0] === "Failed to load competitions." ||
+            call[0] === "Failed to load placements."
+        )
+      ).toBe(true);
+    });
+  });
+
+  it("refresh submissions button is rendered with default label when not mutating", async () => {
+    stubBasicFetch({
+      submissions: [
+        {
+          id: "sub_r",
+          writerId: "writer_01",
+          projectId: "project_1",
+          competitionId: "comp_1",
+          status: "pending",
+          createdAt: "2026-02-06T00:00:00.000Z",
+          updatedAt: "2026-02-06T00:00:00.000Z",
+        },
+      ],
+    });
+
+    renderWithProviders(<SubmissionsPage />);
+    await screen.findByText("sub_r");
+
+    expect(screen.getByRole("button", { name: "Refresh submissions" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Full recovery of writer-web `branches` coverage after the post-RSC drop. Re-ratchets the floor from **46 → 68** (target met) and incidentally lifts the other three web metric floors that moved with it. Supersedes the partial-recovery scope this PR opened with.

## Investigation (carried over)

The ticket asked whether the drop was real (server components genuinely less tested) or measurement (RSC instrumentation gap).

**Verdict: real.** Every top branch-coverage offender is still `"use client"`. The RSC migration shipped server-component shells around these pages but did not migrate the client components themselves, so v8 still instruments them the same way. Fix is **additive tests**, not instrumentation changes.

## Approach

After confirming the verdict, dispatched 6 parallel agents (2 × ultrabrain for the largest files, 4 × unspecified-high for the rest), each scoped to one or two of the top-offender test files. Each agent was constrained to:

- Append-only to its target `*.test.tsx` (no source edits, no other-file edits, no threshold edits)
- Run vitest after every batch to catch regressions
- Match the existing test-file pattern (Vitest + RTL, `SWRConfig` wrapper, `vi.spyOn(globalThis, "fetch")`)
- Use Node 24 via PATH override (local Node 26 has a c8/yargs incompatibility in the workspace-level coverage runner; CI is on Node 25 and unaffected)

## Per-file recovery

| File | Before | After | New tests |
|---|---|---|---|
| `app/projects/page.tsx` | 36.64% | **76.33%** | +11 |
| `app/feedback/page.tsx` | 30.62% | **87.08%** | +26 |
| `app/admin/security/page.tsx` | 32.55% | **90.69%** | +26 |
| `app/admin/rankings/page.tsx` | 42.55% | **94.68%** | +29 |
| `app/settings/security/page.tsx` | 22.95% | **98.36%** | +27 |
| `app/settings/account/page.tsx` | 27.77% | **100%** | +9 |
| `app/submissions/page.tsx` | 62.23% | **86.01%** | +19 |
| `app/competitions/page.tsx` | 55.65% | **93.91%** | +28 |
| `app/components/ResumeMetricsWidget.tsx` (first commit) | 0% | **~100%** | +7 |

Total: **+182 new tests across 9 files**.

## Overall coverage delta

```
pnpm run test:coverage:web

Test Files  171 passed (171)
Tests       699 passed (699)      (was 522)

                  before    after    Δ
Statements      63.56% → 80.09%    +16.53
Branches        55.92% → 72.34%    +16.42
Functions       56.85% → 75.65%    +18.80
Lines           64.90% → 80.87%    +15.97
```

## Threshold changes

All four web metrics ratcheted to harvest the recovery, with healthy margins to absorb ordinary jitter:

| metric | old floor | new floor | observed | margin |
|---|---|---|---|---|
| web.lines | 48 | **75** | 80.87 | +5.87 |
| web.functions | 50 | **70** | 75.65 | +5.65 |
| web.statements | 48 | **75** | 80.09 | +5.09 |
| web.branches | 46 | **68** | 72.34 | +4.34 |

Threshold runner confirms zero failures:

```
node scripts/ci/coverage-thresholds.mjs \
  --baseline .github/coverage-thresholds.json \
  --services-summary .coverage/services/coverage-summary.json \
  --web-summary apps/writer-web/coverage/coverage-summary.json

# failures: []
```

The ticket only required `web.branches` ≥ 68; since all four metrics moved together (more tests = more lines + functions + statements covered), the others are ratcheted in the same PR rather than left on the floor.

## Follow-up cleanup

CHAOS-1865 was spawned during the earlier partial-recovery iteration to track the remaining push from 55 → 68. With this PR delivering full recovery to **72.34**, CHAOS-1865 is now redundant and will be closed as work-merged-into-1815.

## Refs

- CHAOS-1364 (original ratchet-down)
- RSC migration PRs #477/#478/#479 (CHAOS-1518/1519/1520)
- Supersedes: CHAOS-1865 (originally spawned as follow-up; now obsolete)

Closes CHAOS-1815.
Closes CHAOS-1865.