### PR TITLE
fix(CHAOS-1866): wire metrics-service into compose so /trust works

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -732,6 +732,39 @@ services:
     networks:
       - internal
 
+  metrics-service:
+    <<: *node-dev
+    container_name: manifest-metrics-service
+    working_dir: /workspace
+    volumes:
+      - .:/workspace
+    environment:
+      <<: [*telemetry-env, *external-schema-init]
+      OTEL_SERVICE_NAME: "metrics-service"
+      SENTRY_DSN: "${SENTRY_DSN:-}"
+      PORT: "4014"
+      DATABASE_URL: "postgresql://manifest:manifest@postgres:5432/manifest"
+      SERVICE_TOKEN_SECRET: "local-dev-token-secret"
+    command: >
+      sh -lc "/workspace/scripts/pnpm-install-once.sh /workspace && pnpm --filter @script-manifest/metrics-service dev"
+    depends_on:
+      db-migrator:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      # NOTE: metrics-service exposes /healthz instead of the project-standard
+      # /health/live (via registerHealthRoutes). Tracked as out-of-scope cleanup
+      # in CHAOS-1866 description.
+      test:
+        ["CMD-SHELL", "curl -sf http://localhost:4014/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 180s
+    networks:
+      - internal
+
   search-sync-worker:
     <<: *node-dev
     container_name: manifest-search-sync-worker
@@ -792,6 +825,7 @@ services:
       INDUSTRY_PORTAL_SERVICE_URL: "http://industry-portal-service:4009"
       PROGRAMS_SERVICE_URL: "http://programs-service:4012"
       PARTNER_DASHBOARD_SERVICE_URL: "http://partner-dashboard-service:4013"
+      METRICS_SERVICE_URL: "http://metrics-service:4014"
       REDIS_URL: "redis://:${REDIS_PASSWORD:-manifest}@redis:6379"
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"
       RATE_LIMIT_MAX: "1000"
@@ -825,6 +859,8 @@ services:
       programs-service:
         condition: service_healthy
       partner-dashboard-service:
+        condition: service_healthy
+      metrics-service:
         condition: service_healthy
       notification-service:
         condition: service_healthy


### PR DESCRIPTION
## Summary

PR #501 (feat(CHAOS-1811)) shipped `@script-manifest/metrics-service` and the public `/trust` page, but never wired the new service into `compose.yml`. The api-gateway proxies trust-proof requests to `${METRICS_SERVICE_URL ?? 'http://localhost:4014'}/internal/trust-proof-metrics/public` — inside the gateway container that resolves to the gateway itself, so the call returned HTTP 502 and `TrustPage` SSR threw, giving HTTP 500 on `http://localhost:9100/trust`.

PR #501's verification block proved the gap: the only end-to-end check was against a mock gateway at `127.0.0.1:40140`. The compose stack was never exercised.

## Changes

- Add `metrics-service` block to `compose.yml` (port 4014, postgres + db-migrator deps, internal network).
- Add `METRICS_SERVICE_URL=http://metrics-service:4014` env to `api-gateway`.
- Add `metrics-service` to `api-gateway` `depends_on` (`service_healthy`).

Healthcheck uses `/healthz` because `metrics-service` registers its own health endpoints instead of using the project-standard `registerHealthRoutes` (`/health/live`). Tracked as out-of-scope cleanup in CHAOS-1866 description.

## Linear

- Fix: https://linear.app/fullchaos/issue/CHAOS-1866
- Parent feature: https://linear.app/fullchaos/issue/CHAOS-1811
- Subtask that shipped the page (legitimately complete in isolation): https://linear.app/fullchaos/issue/CHAOS-1846

## Verification

```
$ docker compose -f compose.yml config --quiet
exit=0

$ docker exec manifest-metrics-service curl -sf http://localhost:4014/healthz
{"ok":true}

$ docker exec manifest-api-gateway sh -c 'echo $METRICS_SERVICE_URL'
http://metrics-service:4014

$ docker exec manifest-api-gateway curl -sS -w "\nHTTP %{http_code}\n" \
    http://localhost:4000/api/v1/trust-proof-metrics
{"metrics":{"snapshotAt":"2026-05-24T23:27:00.140Z","scriptsHostedTotal":0,...}}
HTTP 200

$ curl -sS -o /tmp/trust.html -w "HTTP %{http_code}\n" http://localhost:9100/trust
HTTP 200

$ grep -oE 'tabular-nums[^>]*>[^<]+</dd>' /tmp/trust.html | head
tabular-nums text-foreground">0</dd>
tabular-nums text-foreground">0</dd>
tabular-nums text-foreground">0</dd>
tabular-nums text-foreground">0</dd>
tabular-nums text-foreground">0</dd>
tabular-nums text-foreground">0</dd>
tabular-nums text-foreground">100%</dd>
```

All 7 counters render. Values are 0/0/0/0/0/0/100% on a fresh DB, which matches the metrics-service repository's documented behavior (`writersExportablePct` returns 100 when there are no writers).

## Follow-up (separate issues, not blocking this PR)

1. **`metrics-service` health endpoint inconsistency** — should switch from custom `/healthz`+`/readyz` to project-standard `registerHealthRoutes`. Healthcheck in this PR has a `NOTE:` comment pointing to it.
2. **Deploy manifests audit** — `grep -rn 'metrics-service' deploy/ .github/` returned 0 hits. If staging/prod use deploy manifests in those paths, `/trust` is broken there too.
3. **CI/process** — PR #501 used a mock gateway for verification. Full-stack features should hit the compose stack at least once before merge.