### PR TITLE
fix(CHAOS-1867): publish metrics-service image and wire it into swarm

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,6 +35,7 @@ jobs:
           - feedback-exchange-service
           - industry-portal-service
           - identity-service
+          - metrics-service
           - notification-service
           - programs-service
           - partner-dashboard-service
@@ -119,6 +120,7 @@ jobs:
           - name: feedback-exchange-service
           - name: industry-portal-service
           - name: identity-service
+          - name: metrics-service
           - name: notification-service
           - name: programs-service
           - name: partner-dashboard-service

--- a/compose.harness.yml
+++ b/compose.harness.yml
@@ -99,6 +99,12 @@ services:
     environment:
       <<: *no-telemetry
 
+  metrics-service:
+    ports:
+      - "127.0.0.1:4014:4014"
+    environment:
+      <<: *no-telemetry
+
   search-sync-worker:
     ports:
       - "127.0.0.1:4020:4020"

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -512,6 +512,30 @@ services:
           cpus: '0.5'
           memory: 512M
 
+  metrics-service:
+    <<: *service-defaults
+    image: ghcr.io/full-chaos/script-manifest/metrics-service:${IMAGE_TAG:?IMAGE_TAG is required}
+    environment:
+      PORT: "4014"
+      NODE_ENV: production
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
+    depends_on:
+      db-migrator:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      # metrics-service exposes /healthz instead of the project-standard
+      # /health/live; tracked as out-of-scope cleanup in CHAOS-1866.
+      test: ["CMD-SHELL", "curl -sf http://localhost:4014/healthz || exit 1"]
+      <<: *healthcheck
+    networks: [internal]
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+
   api-gateway:
     <<: *service-defaults
     image: ghcr.io/full-chaos/script-manifest/api-gateway:${IMAGE_TAG:?IMAGE_TAG is required}
@@ -538,6 +562,7 @@ services:
       PARTNER_DASHBOARD_SERVICE_URL: "http://partner-dashboard-service:4013"
       COVERAGE_MARKETPLACE_SERVICE_URL: "http://coverage-marketplace-service:4008"
       INDUSTRY_PORTAL_SERVICE_URL: "http://industry-portal-service:4009"
+      METRICS_SERVICE_URL: "http://metrics-service:4014"
       COVERAGE_ADMIN_ALLOWLIST: ${COVERAGE_ADMIN_ALLOWLIST:-}
       INDUSTRY_ADMIN_ALLOWLIST: ${INDUSTRY_ADMIN_ALLOWLIST:-}
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"
@@ -568,6 +593,8 @@ services:
       script-storage-service:
         condition: service_healthy
       notification-service:
+        condition: service_healthy
+      metrics-service:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:4000/health/live || exit 1"]

--- a/compose.stage.yml
+++ b/compose.stage.yml
@@ -432,6 +432,30 @@ services:
           cpus: '0.5'
           memory: 512M
 
+  metrics-service:
+    <<: *service-defaults
+    image: ghcr.io/full-chaos/script-manifest/metrics-service:latest
+    environment:
+      PORT: "4014"
+      NODE_ENV: production
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
+    depends_on:
+      db-migrator:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      # metrics-service exposes /healthz instead of the project-standard
+      # /health/live; tracked as out-of-scope cleanup in CHAOS-1866.
+      test: [ "CMD-SHELL", "curl -sf http://localhost:4014/healthz || exit 1" ]
+      <<: *healthcheck
+    networks: [ internal ]
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+
   api-gateway:
     <<: *service-defaults
     image: ghcr.io/full-chaos/script-manifest/api-gateway:${IMAGE_TAG:-latest}
@@ -455,6 +479,7 @@ services:
       PARTNER_DASHBOARD_SERVICE_URL: "http://partner-dashboard-service:4013"
       COVERAGE_MARKETPLACE_SERVICE_URL: "http://coverage-marketplace-service:4008"
       INDUSTRY_PORTAL_SERVICE_URL: "http://industry-portal-service:4009"
+      METRICS_SERVICE_URL: "http://metrics-service:4014"
       COVERAGE_ADMIN_ALLOWLIST: ${COVERAGE_ADMIN_ALLOWLIST:-}
       INDUSTRY_ADMIN_ALLOWLIST: ${INDUSTRY_ADMIN_ALLOWLIST:-}
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"
@@ -485,6 +510,8 @@ services:
       script-storage-service:
         condition: service_healthy
       notification-service:
+        condition: service_healthy
+      metrics-service:
         condition: service_healthy
     healthcheck:
       test: [ "CMD-SHELL", "curl -sf http://localhost:4000/health/live || exit 1" ]

--- a/deploy/swarm/stack.staging.yml
+++ b/deploy/swarm/stack.staging.yml
@@ -100,6 +100,14 @@ services:
           cpus: '0.25'
           memory: 256M
 
+  metrics-service:
+    image: ghcr.io/full-chaos/script-manifest/metrics-service:latest
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 256M
+
   db-migrator:
     image: ghcr.io/full-chaos/script-manifest/db-migrator:latest
 

--- a/deploy/swarm/stack.yml
+++ b/deploy/swarm/stack.yml
@@ -493,6 +493,26 @@ services:
           cpus: '0.5'
           memory: 512M
 
+  metrics-service:
+    image: ghcr.io/full-chaos/script-manifest/metrics-service:${IMAGE_TAG:?IMAGE_TAG is required}
+    env_file: ./.env
+    environment:
+      PORT: "4014"
+      NODE_ENV: production
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-manifest}:${POSTGRES_PASSWORD:?}@postgres:5432/${POSTGRES_DB:-manifest}"
+    healthcheck:
+      # metrics-service exposes /healthz instead of the project-standard
+      # /health/live; tracked as out-of-scope cleanup in CHAOS-1866.
+      test: ["CMD-SHELL", "curl -sf http://localhost:4014/healthz || exit 1"]
+      <<: *healthcheck
+    networks: [internal]
+    deploy:
+      <<: *deploy-service
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+
   search-sync-worker:
     image: ghcr.io/full-chaos/script-manifest/search-sync-worker:${IMAGE_TAG:?IMAGE_TAG is required}
     env_file: ./.env
@@ -541,6 +561,7 @@ services:
       PARTNER_DASHBOARD_SERVICE_URL: "http://partner-dashboard-service:4013"
       COVERAGE_MARKETPLACE_SERVICE_URL: "http://coverage-marketplace-service:4008"
       INDUSTRY_PORTAL_SERVICE_URL: "http://industry-portal-service:4009"
+      METRICS_SERVICE_URL: "http://metrics-service:4014"
       COVERAGE_ADMIN_ALLOWLIST: ${COVERAGE_ADMIN_ALLOWLIST:-}
       INDUSTRY_ADMIN_ALLOWLIST: ${INDUSTRY_ADMIN_ALLOWLIST:-}
       NOTIFICATION_SERVICE_URL: "http://notification-service:4010"


### PR DESCRIPTION
## Summary

`metrics-service` was added in CHAOS-1811 (PR #501) and wired into local
`compose.yml` by CHAOS-1866 (PR #507), but it was **never added to the
production deployment surfaces**. This PR closes that gap.

### Before this PR
- `.github/workflows/docker.yml` had no matrix entry for `metrics-service` → `ghcr.io/full-chaos/script-manifest/metrics-service` has never been published.
- `deploy/swarm/stack.yml` had no service definition.
- `deploy/swarm/stack.staging.yml` had no staging override.
- `api-gateway` in `stack.yml` was missing `METRICS_SERVICE_URL`, which [`services/api-gateway/src/index.ts:186`](https://github.com/full-chaos/script-manifest/blob/main/services/api-gateway/src/index.ts#L186) lists in `validateRequiredEnv` → **api-gateway would crash on the next prod deploy.**

### Changes
- **`.github/workflows/docker.yml`** — add `metrics-service` to both the `build` and `merge` matrices so amd64/arm64 images get built, Trivy-scanned, and tagged on `main`.
- **`deploy/swarm/stack.yml`** — add `metrics-service` service block (port 4014, `/healthz` healthcheck, postgres dependency via `env_file`, internal network only). Mirrors the `compose.yml` definition added by CHAOS-1866.
- **`deploy/swarm/stack.yml`** — add `METRICS_SERVICE_URL: "http://metrics-service:4014"` to the api-gateway environment so `validateRequiredEnv` passes.
- **`deploy/swarm/stack.staging.yml`** — add the matching staging override block with the standard `0.25 cpu / 256 MiB` resource limits.

## Verification

```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docker.yml')); ..."
# OK: workflow + staging parse

docker compose -f compose.yml config -q
# OK: compose.yml still parses

python3 (structural checks):
# OK build matrix: 17 services, includes metrics-service
# OK merge matrix: 17 services, includes metrics-service
# OK build/merge matrices in sync
# OK stack.yml metrics-service: PORT=4014, image template correct
# OK api-gateway METRICS_SERVICE_URL: http://metrics-service:4014
# OK staging metrics-service: ghcr.io/full-chaos/script-manifest/metrics-service:latest
```

Swarm-stack interpolation requires the usual prod secrets (`FRONTEND_URL`, `EMAIL_API_KEY`, etc.) that are pre-existing requirements unrelated to this change.

## Out of scope

- The `/healthz` vs `/health/live` inconsistency for `metrics-service` is already tracked in the CHAOS-1866 description (cleanup item).
- `services/search-indexer-service/dist/` contains stale artifacts from the service that was removed in `9c05553`. Not a deploy gap, but worth a follow-up cleanup.

Closes CHAOS-1867