### PR TITLE
fix(CHAOS): make bundled manage-admin CLI work in production images

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -192,16 +192,20 @@ pnpm manage-admin list
 **Inside a running container** (bundled as `scripts/manage-admin.cjs` in all service images):
 
 ```bash
+# The bundle lives at /app/scripts/manage-admin.cjs. Use the absolute path —
+# the container WORKDIR is /app/services/<service>, so a relative
+# `scripts/manage-admin.cjs` will not resolve.
+
 # Docker Compose
-docker exec -it <identity-service-container> node scripts/manage-admin.cjs promote user@example.com
+docker exec -it <identity-service-container> node /app/scripts/manage-admin.cjs promote user@example.com
 
 # Docker Swarm
 docker exec -it $(docker ps -q -f name=script-manifest_identity-service) \
-  node scripts/manage-admin.cjs promote user@example.com
+  node /app/scripts/manage-admin.cjs promote user@example.com
 
 # Kubernetes
 kubectl exec -it deploy/identity-service -n script-manifest -- \
-  node scripts/manage-admin.cjs promote user@example.com
+  node /app/scripts/manage-admin.cjs promote user@example.com
 ```
 
 The script reads `DATABASE_URL` from the environment. Inside containers, this is already set. From a local checkout targeting a remote database:

--- a/infra/docker/service.Dockerfile
+++ b/infra/docker/service.Dockerfile
@@ -57,12 +57,17 @@ COPY --from=pruner /app/tsconfig.base.json ./tsconfig.base.json
 ARG SERVICE_NAME
 RUN pnpm build --filter=@script-manifest/${SERVICE_NAME}...
 
-# Bundle manage-admin CLI (self-contained, needs only pg at runtime)
-# esbuild may fail for services whose turbo-prune tree lacks packages/db;
-# create a stub so the COPY in the runner stage always succeeds.
+# Bundle manage-admin CLI fully self-contained (pg inlined; only the optional
+# pg-native C addon stays external since it can't be bundled). The import.meta
+# shim lets bundled ESM deps (migrate.ts, generated prisma client) load under
+# the cjs format — those paths are never invoked by the CLI but evaluate at
+# module load. esbuild may fail for services whose turbo-prune tree lacks
+# packages/db; create a stub so the COPY in the runner stage always succeeds.
 COPY --from=pruner /app/scripts/manage-admin.ts ./scripts/manage-admin.ts
 RUN npx esbuild scripts/manage-admin.ts --bundle --platform=node --format=cjs \
-    --outfile=scripts/manage-admin.cjs --external:pg --external:pg-native \
+    --outfile=scripts/manage-admin.cjs --external:pg-native \
+    --define:import.meta.url=__IMPORT_META_URL__ \
+    --banner:js="const __IMPORT_META_URL__=require('url').pathToFileURL(__filename).href;" \
     2>/dev/null || echo '#!/usr/bin/env node\nconsole.error("manage-admin not available in this image");process.exit(1);' > scripts/manage-admin.cjs
 
 # ── Stage 3: Production runtime ──────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:services": "pnpm -r --filter './services/*' test",
     "test:web": "pnpm -r --filter './apps/writer-web' test",
     "manage-admin": "node --import tsx scripts/manage-admin.ts",
-    "bundle:manage-admin": "esbuild scripts/manage-admin.ts --bundle --platform=node --format=cjs --outfile=scripts/manage-admin.cjs --external:pg --external:pg-native",
+    "bundle:manage-admin": "esbuild scripts/manage-admin.ts --bundle --platform=node --format=cjs --outfile=scripts/manage-admin.cjs --external:pg-native --define:import.meta.url=__IMPORT_META_URL__ --banner:js=\"const __IMPORT_META_URL__=require('url').pathToFileURL(__filename).href;\"",
     "test:ops": "node --test scripts/ci/**/*.test.mjs",
     "test:unit": "turbo run test && pnpm run test:ops",
     "test:coverage": "bash ./scripts/run-coverage.sh",

--- a/scripts/manage-admin.ts
+++ b/scripts/manage-admin.ts
@@ -96,11 +96,10 @@ export async function runManageAdmin(args: string[], deps: ManageAdminDeps = def
   await deps.closePool();
 }
 
-const isMain =
-  typeof process.argv[1] === "string" &&
-  (process.argv[1].endsWith("/scripts/manage-admin.ts") ||
-    process.argv[1].endsWith("\\scripts\\manage-admin.ts") ||
-    process.argv[1].endsWith("manage-admin.ts"));
+// Match the entrypoint whether run as source (`manage-admin.ts` via tsx) or as
+// the bundled CLI (`manage-admin.cjs` in production images). Anchored on a path
+// separator + exact basename so it never matches `manage-admin.test.ts`.
+const isMain = /(^|[\\/])manage-admin\.(ts|cjs|mjs|js)$/.test(process.argv[1] ?? "");
 
 if (isMain) {
   runManageAdmin(process.argv.slice(2)).catch((err) => {


### PR DESCRIPTION
## Problem

Running the admin CLI in a production container failed:

\`\`\`
$ docker compose exec identity-service node /app/scripts/manage-admin.cjs promote
Error: Cannot find module 'pg'
\`\`\`

That error masked **two further latent bugs** — the bundled CLI had effectively never worked in any image.

## Root causes (three, in load order)

1. **`pg` not resolvable.** esbuild emitted a bare `require("pg")` (`--external:pg`), but pnpm's isolated `node_modules` only places `pg` under `packages/db/node_modules` — never anywhere reachable from `/app/scripts/`. `require` resolves by file location, not cwd, so it could never be found.
2. **`import.meta.url` crash.** Once `pg` is inlined, module init reaches `migrate.ts` and a generated Prisma client whose top-level `fileURLToPath(import.meta.url)` evaluates to `undefined` under esbuild's `cjs` format — throwing at load. The old bundle never reached this because `require("pg")` threw first.
3. **Dead entrypoint guard.** `isMain` only matched a `.ts` suffix, so `manage-admin.cjs` exited 0 silently without ever running its logic.

## Fix

- **Inline `pg`** into the bundle; keep only the optional native addon external (`--external:pg-native`). The CLI is now truly self-contained — no runtime `node_modules` needed.
- **Shim `import.meta.url`** to `pathToFileURL(__filename)` via an esbuild banner + define, so ESM-authored deps load cleanly under `cjs`.
- **Make `isMain` extension-agnostic** (`/(^|[\\/])manage-admin\.(ts|cjs|mjs|js)$/`) — matches both tsx-run source and the bundled `.cjs`, still excludes `manage-admin.test.ts`.
- **Docs:** correct `docs/deployment.md` to use the absolute `/app/scripts/...` path (container WORKDIR is `/app/services/<service>`, so the relative path never resolved).

Changes applied in both `package.json` (`bundle:manage-admin`) and `infra/docker/service.Dockerfile`, kept in sync.

## Verification

- \`pnpm bundle:manage-admin\` → `pg` fully inlined, only `pg-native` external.
- No-args / unknown-cmd → usage + exit 1 (guard fires).
- \`list\` against real Postgres → full TCP + wire-protocol handshake, returns a Postgres protocol error for bad creds (not a module/load failure) — driver is genuinely functional.
- 7/7 unit tests pass; typecheck clean.

The generated `scripts/manage-admin.cjs` is gitignored (built inside the image), so the diff is source + Dockerfile + docs only.