### PR TITLE
chore(CHAOS): batch Dependabot security-update PRs per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       day: "monday"
     open-pull-requests-limit: 10
     groups:
+      # Scheduled version-update groups (applies-to: version-updates by default).
       production-deps:
         dependency-type: "production"
         update-types:
@@ -20,6 +21,15 @@ updates:
       types:
         patterns:
           - "@types/*"
+      # Security-update PRs are a separate track and ignore the groups above
+      # unless a group opts in with applies-to: security-updates. Batch them
+      # into a single PR instead of one-per-advisory. (Note: Dependabot cannot
+      # fix transitive-only pnpm vulns it has no manifest line to bump — those
+      # still require manual pnpm.overrides.)
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -34,6 +44,10 @@ updates:
           - "major"
           - "minor"
           - "patch"
+      actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "/infra/docker"
@@ -41,5 +55,9 @@ updates:
       interval: "monthly"
     groups:
       docker:
+        patterns:
+          - "*"
+      docker-security:
+        applies-to: security-updates
         patterns:
           - "*"


### PR DESCRIPTION
## Why

The repo already had `dependabot.yml` with `groups:` — but those only apply to the **version-update** track. **Security-update** PRs are a separate track and open **one PR per advisory** unless a group explicitly opts in with `applies-to: security-updates`. That's why the recent 10 security alerts appeared individually rather than batched.

(Repo settings are already correct: vulnerability alerts on, automated security fixes `enabled: true, paused: false`.)

## Change

Add an `applies-to: security-updates` group to each ecosystem so security fixes batch into a single PR per ecosystem:
- `npm` → `npm-security` (`*`)
- `github-actions` → `actions-security` (`*`)
- `docker` → `docker-security` (`*`)

Existing version-update groups are unchanged (they implicitly target `version-updates`).

## Honest limitation

This batches the alerts Dependabot **can** fix (direct deps). **Transitive-only pnpm vulns** — like all 10 in #521 — have no manifest line for Dependabot to bump and it won't author `pnpm.overrides`, so those still require the manual-override approach. Grouping improves batching, not transitive coverage.

## Validation
- `dependabot.yml` parses as valid YAML; confirmed each ecosystem has a `security-updates`-scoped group.